### PR TITLE
adds missing macros to FTHR_Apps_P1

### DIFF
--- a/Libraries/Boards/MAX32655/FTHR_Apps_P1/Include/board.h
+++ b/Libraries/Boards/MAX32655/FTHR_Apps_P1/Include/board.h
@@ -57,6 +57,18 @@ extern "C" {
 #define CONSOLE_BAUD    115200  /// Console baud rate
 #endif
 
+#ifndef HCI_UART
+#define HCI_UART            3   /// LP UART
+#endif
+
+#ifndef TERMINAL_UART
+#define TERMINAL_UART       CONSOLE_UART
+#endif
+
+#ifndef USER_UART
+#define USER_UART           3
+#endif
+
 #define LED_OFF         1       /// Inactive state of LEDs
 #define LED_ON          0       /// Active state of LEDs
 


### PR DESCRIPTION
MAX32655  BLE examples are not building when you build for FTHR_Apps_P1 because of missing UART  macros. 
I believe HCI UART and USER UART are shared on the FTHR since its the only user exposed UART. Can you verify @kevin-gillespie   