### PR TITLE
[MSDK-772] Disable OpenCV output for ImgCapture-Serial

### DIFF
--- a/Examples/MAX78000/ImgCapture-Serial/pc_utility/console.py
+++ b/Examples/MAX78000/ImgCapture-Serial/pc_utility/console.py
@@ -174,9 +174,13 @@ class CameraIFConsole():
                                     filename = "Image.png"
                                     convert(img_raw, filename, w, h, pixel_format)
                                     _print(f"Saved image to '{filename}'")
-                                    image = cv2.imread(filename)
-                                    cv2.imshow(" ", image)
-                                    cv2.waitKey(1)
+
+                                    # The code below will display the image in an OpenCV
+                                    # window.  It's disabled by default because it won't
+                                    # work on headless systems.  Uncomment to enable.
+                                    # image = cv2.imread(filename)
+                                    # cv2.imshow(" ", image)
+                                    # cv2.waitKey(1)
 
         except Exception as e:
             print(f"[red]{traceback.format_exc()}[/red]")


### PR DESCRIPTION
Linux testing found that the image preview window from OpenCV would throw an error on headless systems for the ImgCapture-Serial `console.py` utility.

This PR disables the OpenCV window by default.