### PR TITLE
ME17 FTHR board.mk and .c  update

### DIFF
--- a/Libraries/Boards/MAX32655/FTHR_Apps_P1/Include/board.h
+++ b/Libraries/Boards/MAX32655/FTHR_Apps_P1/Include/board.h
@@ -75,6 +75,10 @@ extern "C" {
 #define USER_UART 3
 #endif
 
+#ifndef EXT_FLASH_BAUD
+#define EXT_FLASH_BAUD 5000000
+#endif
+
 #define LED_OFF 1 /// Inactive state of LEDs
 #define LED_ON  0 /// Active state of LEDs
 

--- a/Libraries/Boards/MAX32655/FTHR_Apps_P1/Source/board.c
+++ b/Libraries/Boards/MAX32655/FTHR_Apps_P1/Source/board.c
@@ -35,6 +35,7 @@
  ******************************************************************************/
 
 #include <stdio.h>
+#include <string.h>
 #include "mxc_device.h"
 #include "mxc_sys.h"
 #include "mxc_assert.h"
@@ -47,7 +48,8 @@
 #include "max20303.h"
 #include "pb.h"
 #include "mxc_sys.h"
-
+#include "spi.h"
+#include "Ext_Flash.h"
 /***** Global Variables *****/
 mxc_uart_regs_t* ConsoleUart = MXC_UART_GET_UART(CONSOLE_UART);
 extern uint32_t SystemCoreClock;
@@ -68,7 +70,211 @@ const mxc_gpio_cfg_t led_pin[] = {
     {MXC_GPIO0, MXC_GPIO_PIN_26, MXC_GPIO_FUNC_OUT, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO},
 };
 const unsigned int num_leds = (sizeof(led_pin) / sizeof(mxc_gpio_cfg_t));
+#ifndef __riscv /* RISCV does not have access to MXC_SPI0 */
 
+/******************************************************************************/
+static void ext_flash_board_init_quad(bool quadEnabled)
+{
+    mxc_gpio_cfg_t sdio23;
+
+    sdio23.port  = MXC_GPIO0;
+    sdio23.mask  = (MXC_GPIO_PIN_8 | MXC_GPIO_PIN_9);
+    sdio23.pad   = MXC_GPIO_PAD_NONE;
+    sdio23.vssel = MXC_GPIO_VSSEL_VDDIOH;
+
+    if (quadEnabled) {
+        /* Enable these pins as SPI SDIO2/3*/
+        sdio23.func = MXC_GPIO_FUNC_ALT1;
+        MXC_GPIO_Config(&sdio23);
+
+    } else {
+        /* Control these pins as GPIO and set high when not using quad mode.
+         * The W25 used on this board multiplexes the HOLD and WP functions on these
+         * pins when not using quad mode
+         */
+        sdio23.func = MXC_GPIO_FUNC_OUT;
+        MXC_GPIO_Config(&sdio23);
+        MXC_GPIO_OutSet(sdio23.port, sdio23.mask);
+    }
+}
+
+/******************************************************************************/
+static int ext_flash_board_init(void)
+{
+    mxc_spi_pins_t qspi_flash_pins;
+    int err = E_NO_ERROR;
+
+    qspi_flash_pins.clock  = true;
+    qspi_flash_pins.ss0    = true;
+    qspi_flash_pins.ss1    = true;
+    qspi_flash_pins.ss2    = false;
+    qspi_flash_pins.miso   = true;
+    qspi_flash_pins.mosi   = true;
+    qspi_flash_pins.vddioh = true;
+
+    err = MXC_SPI_Init(MXC_SPI0, 1, 1, 1, 0, EXT_FLASH_BAUD, qspi_flash_pins);
+    if (err != E_NO_ERROR) {
+        return err;
+    }
+
+    MXC_SPI_SetDataSize(MXC_SPI0, 8);
+    MXC_SPI_SetMode(MXC_SPI0, SPI_MODE_0);
+
+    /* Leave the quad pins disabled, enable for quad transactions. */
+    ext_flash_board_init_quad(false);
+
+    return err;
+}
+
+/******************************************************************************/
+static int ext_flash_board_read(uint8_t* read, unsigned len, unsigned deassert,
+                                Ext_Flash_DataLine_t width)
+{
+    mxc_spi_req_t qspi_read_req;
+    mxc_spi_width_t spi_width;
+    int err = E_NO_ERROR;
+
+    switch (width) {
+        case Ext_Flash_DataLine_Single:
+            spi_width = SPI_WIDTH_STANDARD;
+            break;
+        case Ext_Flash_DataLine_Dual:
+            spi_width = SPI_WIDTH_DUAL;
+            break;
+        case Ext_Flash_DataLine_Quad:
+            spi_width = SPI_WIDTH_QUAD;
+            ext_flash_board_init_quad(true);
+            break;
+        default:
+            return E_BAD_PARAM;
+    }
+
+    MXC_SPI_SetWidth(MXC_SPI0, spi_width);
+
+    qspi_read_req.spi        = MXC_SPI0;
+    qspi_read_req.ssIdx      = 1;
+    qspi_read_req.ssDeassert = deassert;
+    qspi_read_req.txData     = NULL;
+    qspi_read_req.rxData     = read;
+    qspi_read_req.txLen      = 0;
+    qspi_read_req.rxLen      = len;
+    qspi_read_req.txCnt      = 0;
+    qspi_read_req.rxCnt      = 0;
+    qspi_read_req.completeCB = NULL;
+
+    err = MXC_SPI_MasterTransaction(&qspi_read_req);
+    if (err != E_NO_ERROR) {
+        if (width == Ext_Flash_DataLine_Quad) {
+            /* Restore the SPI config to disable quad pins */
+            ext_flash_board_init_quad(false);
+        }
+        return err;
+    }
+
+    if (width == Ext_Flash_DataLine_Quad) {
+        /* Restore the SPI config to disable quad pins */
+        ext_flash_board_init_quad(false);
+    }
+
+    return err;
+}
+
+/******************************************************************************/
+static int ext_flash_board_write(const uint8_t* write, unsigned len, unsigned deassert,
+                                 Ext_Flash_DataLine_t width)
+{
+    mxc_spi_req_t qspi_write_req;
+    mxc_spi_width_t spi_width;
+    int err = E_NO_ERROR;
+
+    switch (width) {
+        case Ext_Flash_DataLine_Single:
+            spi_width = SPI_WIDTH_STANDARD;
+            break;
+        case Ext_Flash_DataLine_Dual:
+            spi_width = SPI_WIDTH_DUAL;
+            break;
+        case Ext_Flash_DataLine_Quad:
+            spi_width = SPI_WIDTH_QUAD;
+            ext_flash_board_init_quad(true);
+            break;
+        default:
+            return E_BAD_PARAM;
+    }
+
+    MXC_SPI_SetWidth(MXC_SPI0, spi_width);
+
+    qspi_write_req.spi        = MXC_SPI0;
+    qspi_write_req.ssIdx      = 1;
+    qspi_write_req.ssDeassert = deassert;
+    qspi_write_req.txData     = (uint8_t*)write;
+    qspi_write_req.rxData     = NULL;
+    qspi_write_req.txLen      = len;
+    qspi_write_req.rxLen      = 0;
+    qspi_write_req.txCnt      = 0;
+    qspi_write_req.rxCnt      = 0;
+    qspi_write_req.completeCB = NULL;
+
+    err = MXC_SPI_MasterTransaction(&qspi_write_req);
+    if (err != E_NO_ERROR) {
+        if (width == Ext_Flash_DataLine_Quad) {
+            /* Restore the SPI config to disable quad pins */
+            ext_flash_board_init_quad(false);
+        }
+        return err;
+    }
+
+    if (width == Ext_Flash_DataLine_Quad) {
+        /* Restore the SPI config to disable quad pins */
+        ext_flash_board_init_quad(false);
+    }
+
+    return err;
+}
+
+/******************************************************************************/
+static int ext_flash_clock(unsigned len, unsigned deassert)
+{
+    mxc_spi_req_t qspi_dummy_req;
+    mxc_spi_width_t width;
+
+    if (MXC_SPI_GetDataSize(MXC_SPI0) != 8) {
+        return E_BAD_STATE;
+    }
+
+    width = MXC_SPI_GetWidth(MXC_SPI0);
+
+    switch (width) {
+        case SPI_WIDTH_STANDARD:
+            len /= 8;
+            break;
+        case SPI_WIDTH_DUAL:
+            len /= 4;
+            break;
+        case SPI_WIDTH_QUAD:
+            len /= 2;
+            break;
+        default:
+            return E_BAD_STATE;
+    }
+
+    uint8_t write[len];
+    memset(write, 0, sizeof(write));
+
+    qspi_dummy_req.spi        = MXC_SPI0;
+    qspi_dummy_req.ssIdx      = 1;
+    qspi_dummy_req.ssDeassert = deassert;
+    qspi_dummy_req.txData     = write;
+    qspi_dummy_req.rxData     = NULL;
+    qspi_dummy_req.txLen      = len;
+    qspi_dummy_req.rxLen      = 0;
+    qspi_dummy_req.txCnt      = 0;
+    qspi_dummy_req.rxCnt      = 0;
+    qspi_dummy_req.completeCB = NULL;
+
+    return MXC_SPI_MasterTransaction(&qspi_dummy_req);
+}
+#endif /* __riscv */
 /******************************************************************************/
 void mxc_assert(const char* expr, const char* file, int line)
 {
@@ -89,8 +295,17 @@ void SystemCoreClockUpdate(void)
 /******************************************************************************/
 int Board_Init(void)
 {
-#ifndef __riscv
     int err;
+
+#ifndef __riscv /* RISCV does not have access to MXC_SPI0 */
+    Ext_Flash_Config_t exf_cfg = {.init  = ext_flash_board_init,
+                                  .read  = ext_flash_board_read,
+                                  .write = ext_flash_board_write,
+                                  .clock = ext_flash_clock};
+
+    if ((err = Ext_Flash_Configure(&exf_cfg)) != E_NO_ERROR) {
+        return err;
+    }
 
     // Enable GPIO
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);

--- a/Libraries/Boards/MAX32655/FTHR_Apps_P1/board.mk
+++ b/Libraries/Boards/MAX32655/FTHR_Apps_P1/board.mk
@@ -44,11 +44,18 @@ SRCS += stdio.c
 SRCS += led.c
 SRCS += pb.c
 SRCS += max20303.c
+SRCS += w25.c
+
+PROJ_CFLAGS+=-DEXT_FLASH_W25
+
+MISC_DRIVERS_DIR=$(LIBS_DIR)/MiscDrivers
 
 # Where to find BSP source files
 VPATH += $(BOARD_DIR)/Source
 VPATH += $(BOARD_DIR)/../Source
+VPATH += $(MISC_DRIVERS_DIR)/ExtMemory
 
 # Where to find BSP header files
 IPATH += $(BOARD_DIR)/Include
 IPATH += $(BOARD_DIR)/../Include
+IPATH += $(MISC_DRIVERS_DIR)/ExtMemory


### PR DESCRIPTION
Makes necessary changes to allow FTHR board to discover and use EXT_Flash driver. As a result BLE_otac/otas  Examples work. Tested with  2 FTHR boards as client/server. 