### PR TITLE
Make sure file exists before formatting

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -33,5 +33,8 @@ jobs:
           CHANGE_FILES=$(git diff --ignore-submodules --name-only remotes/origin/main '*.c' '*.h')
           for change_file in ${CHANGE_FILES}
           do
+            if [ -f ${change_file} ];
+            then
             clang-format --verbose -style=file -n --ferror-limit=1 -Werror ${change_file}
+            fi
           done


### PR DESCRIPTION
If a commit deletes a file, then clang-format will attempt to run on a file that doesn't exist.  This PR adds an existence check for the file