### PR TITLE
Set MAXIM_SBT_DIR environment variable for Build_Examples action

### DIFF
--- a/.github/workflows/Build_Examples.yml
+++ b/.github/workflows/Build_Examples.yml
@@ -36,6 +36,10 @@ jobs:
           git submodule sync
           git submodule update --init --recursive
           
+          # This environment variable is required for the SBTs.
+          # It must be set to the absolute path inside the Github repo.
+          export MAXIM_SBT_DIR=$(pwd)/Tools/SBT
+
           cd Examples
           # Rebuild all of the peripheral drivers and build all of the Hello_World examples
           SUBDIRS=$(find . -type d -name "Hello_World")


### PR DESCRIPTION
The Secure Boot Tools depend on the MAXIM_SBT_DIR environment variable being set.  This PR sets the environment variable in the `Build_Examples` action so that auto-tests for the secure micros work properly.  

Needed for #30 