### PR TITLE
Update clang-format-check Workflow.

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -31,7 +31,7 @@ jobs:
       #   Exclude register header files. Those don't follow clang formatting or it becomes unreadable
       - name: clang-format-check
         run: |
-          CHANGE_FILES=$(git diff --ignore-submodules --name-only remotes/origin/main '*.c' '*.h' ':!*/Include/*_regs.h')
+          CHANGE_FILES=$(git diff --ignore-submodules --name-only remotes/origin/main '*.c' '*.h' ':!*_regs.h')
           for change_file in ${CHANGE_FILES}
           do
             if [ -f ${change_file} ];


### PR DESCRIPTION
Exclude peripheral register header files from clang-format-check workflow to keep the formatting of the autogenerated register files without the checker complaining.