### PR TITLE
new workflow to verify BLE TIFS

### DIFF
--- a/.github/workflows/BLE_Ver_TIFS.yml
+++ b/.github/workflows/BLE_Ver_TIFS.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Lock Resources
         if: ${{ always() }}
         run: |
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 600 /home/$USER/Workspace/Resource_Share/max32655_0.txt
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 600 /home/$USER/Workspace/Resource_Share/max32655_1.txt
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 780 /home/$USER/Workspace/Resource_Share/max32655_0.txt
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 780 /home/$USER/Workspace/Resource_Share/max32655_1.txt
           
   verify:
     # The type of runner that the job will run on


### PR DESCRIPTION
The verification should be done on the machine wall-e.