### PR TITLE
Refactor SPIXF code to pass cpplint checks

### DIFF
--- a/Examples/MAX32570/SPIXF/main.c
+++ b/Examples/MAX32570/SPIXF/main.c
@@ -175,7 +175,7 @@ int main(void)
     }
 
     printf("Verifying external flash\n");
-    while(remain) {
+    while (remain) {
         int chunk = ((remain > BUFF_SIZE) ? BUFF_SIZE : remain);
         if ((err = Ext_Flash_Read(EXT_FLASH_ADDR + rx_len - remain, rx_buf, chunk,
                                   EXT_FLASH_SPIXFC_WIDTH)) !=

--- a/Examples/MAX32572/SPIXF/main.c
+++ b/Examples/MAX32572/SPIXF/main.c
@@ -173,7 +173,7 @@ int main(void)
     }
 
     printf("Verifying external flash\n");
-    while(remain) {
+    while (remain) {
         int chunk = ((remain > BUFF_SIZE) ? BUFF_SIZE : remain);
         if ((err = Ext_Flash_Read(EXT_FLASH_ADDR + rx_len - remain, rx_buf, chunk,
                                   EXT_FLASH_SPIXFC_WIDTH)) !=

--- a/Examples/MAX32650/SPIXF/main.c
+++ b/Examples/MAX32650/SPIXF/main.c
@@ -177,7 +177,7 @@ int main(void)
     }
 
     printf("Verifying external flash\n");
-    while(remain) {
+    while (remain) {
         int chunk = ((remain > BUFF_SIZE) ? BUFF_SIZE : remain);
         if ((err = Ext_Flash_Read(EXT_FLASH_ADDR + rx_len - remain, rx_buf, chunk,
                                   EXT_FLASH_SPIXFC_WIDTH)) !=

--- a/Examples/MAX32665/SPIXF/main.c
+++ b/Examples/MAX32665/SPIXF/main.c
@@ -177,7 +177,7 @@ int main(void)
     }
 
     printf("Verifying external flash\n");
-    while(remain) {
+    while (remain) {
         int chunk = ((remain > BUFF_SIZE) ? BUFF_SIZE : remain);
         if ((err = Ext_Flash_Read(EXT_FLASH_ADDR + rx_len - remain, rx_buf, chunk,
                                   EXT_FLASH_SPIXFC_WIDTH)) !=

--- a/Examples/MAX32690/SPIXF/main.c
+++ b/Examples/MAX32690/SPIXF/main.c
@@ -177,7 +177,7 @@ int main(void)
     }
 
     printf("Verifying external flash\n");
-    while(remain) {
+    while (remain) {
         int chunk = ((remain > BUFF_SIZE) ? BUFF_SIZE : remain);
         if ((err = Ext_Flash_Read(EXT_FLASH_ADDR + rx_len - remain, rx_buf, chunk,
                                   EXT_FLASH_SPIXFC_WIDTH)) !=


### PR DESCRIPTION
The code changes were tested on a MAX32650 EV kit and then ported over to the other devices.