### PR TITLE
fix(BLE): Always stop atts service discovery idle timers to make sure not leaking TimerStruct buffers

### DIFF
--- a/Libraries/Cordio/ble-host/sources/stack/att/atts_main.c
+++ b/Libraries/Cordio/ble-host/sources/stack/att/atts_main.c
@@ -266,9 +266,7 @@ static void attsConnCback(attCcb_t *pCcb, dmEvt_t *pDmEvt)
 	  /* if idle timer timed has already timed out then DM_IDLE_ATTS_DISC won't be set.
 	   * extra calls to WsfTimerStop() ok because it will just skip inactive timers */
       //if (DmConnCheckIdle(pAttsCb->connId) & DM_IDLE_ATTS_DISC)
-      {
-        WsfTimerStop(&pAttsCb->idleTimer);
-      }
+      WsfTimerStop(&pAttsCb->idleTimer);
     }
   }
 


### PR DESCRIPTION
### Description

Running 20s repeats of my BLE streaming app on a MAX32666FTHR I found that WsBuf allocation fails after about 35 trials.  I instrumented the code to show pool stats and found that after every connection 1 16-byte buffer is left allocated.  After several repeats the 16-byte pool overflows, then the 32-byte pool overflows, etc until the 512-byte pool overflows and WsfBufAlloc asserts.

My app is based on the BLE_FreeRTOS example - here is a summary of the instrumentation that shows buffers left allocated:

In dats_main.c:
```
    case DM_CONN_CLOSE_IND:
        datsCb.connected = FALSE;
        WsfTimerStop(&trimTimer);
#if 0
        APP_TRACE_INFO2("Connection closed status 0x%x, reason 0x%x", pMsg->connClose.status,
                        pMsg->connClose.reason);
#else
        static WsfBufPoolStat_t stat0, stat1, stat2, stat3, stat4;
        WsfBufGetPoolStats(&stat0, 0);
        WsfBufGetPoolStats(&stat1, 1);
        WsfBufGetPoolStats(&stat2, 2);
        WsfBufGetPoolStats(&stat3, 3);
        WsfBufGetPoolStats(&stat4, 4);
        APP_TRACE_INFO6("Connection closed, reason 0x%x, numAlloc = %d, %d, %d, %d, %d", pMsg->connClose.reason,
                    stat0.numAlloc, stat1.numAlloc, stat2.numAlloc, stat3.numAlloc, stat4.numAlloc);
#endif
```
which results in the following in the console log:
```
khp@Kevins-MacBook-Pro-M1 BLE_FreeRTOS_v2023_06_wsbuf_leak % grep ^Connection wsbuf_leak.log
Connection closed, reason 0x13, numAlloc = 1, 4, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 2, 4, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 3, 4, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 4, 4, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 5, 4, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 6, 4, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 4, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 5, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 6, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 7, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 8, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 9, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 10, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 11, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 12, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 13, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 14, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 15, 0, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 15, 1, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 15, 2, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 15, 3, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 15, 4, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 16, 4, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 16, 5, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 16, 6, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 16, 7, 0, 0
Connection closed, reason 0x13, numAlloc = 7, 16, 7, 1, 0
Connection closed, reason 0x13, numAlloc = 7, 16, 7, 2, 0
Connection closed, reason 0x13, numAlloc = 7, 16, 7, 3, 0
Connection closed, reason 0x13, numAlloc = 7, 16, 7, 4, 0
Connection closed, reason 0x13, numAlloc = 7, 16, 7, 5, 0
Connection closed, reason 0x13, numAlloc = 7, 16, 7, 6, 0
Connection closed, reason 0x13, numAlloc = 7, 16, 7, 7, 0
Connection closed, reason 0x13, numAlloc = 7, 16, 7, 8, 0
Connection closed, reason 0x13, numAlloc = 7, 16, 7, 8, 1
```
I added some debugging code and eventually traced this back to the idleTimer in atts_main.c not being stopped:
```
static void attsConnCback(attCcb_t *pCcb, dmEvt_t *pDmEvt)
{
  uint8_t i;

  /* if connection closed */
  if (pDmEvt->hdr.event == DM_CONN_CLOSE_IND)
  {
    for (i = 0; i < ATT_BEARER_MAX; i++)
    {
      attsCcb_t *pAttsCb = &attsCb.ccb[pCcb->connId - 1][i];

      /* clear prepare write queue */
      attsClearPrepWrites(pAttsCb);

     /* stop service discovery idle timer, if running */
     if (DmConnCheckIdle(pCcb->connId) & DM_IDLE_ATTS_DISC)
      {
        WsfTimerStop(&pAttsCb->idleTimer);
      }
    }
  }

  /* pass event to indication interface */
  (*attsCb.pInd->connCback)(pCcb, pDmEvt);
}
```
This may be a timing dependent bug but in my case it's clear that DM_IDLE_ATTS_DISC flag is not set when the connection is closed and the timer is never stopped.

My change simply calls WsfTimerStop() every time, relying on the fact that WsfStopTimer() will ignore timers that were not previously started/allocated.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.