### PR TITLE
fix(BLE): Add declaration for refresh keys function

### DIFF
--- a/Libraries/Cordio/platform/include/pal_bb_ble.h
+++ b/Libraries/Cordio/platform/include/pal_bb_ble.h
@@ -341,6 +341,14 @@ void PalBbBleInlineEncryptSetPacketCount(uint64_t count);
 /*************************************************************************************************/
 void PalBbBleLowPower(void);
 
+/*************************************************************************************************/
+/*!
+ *  \brief      Refresh encryption keys.
+ *
+ *  \note       Needed after deep sleep.
+ */
+/*************************************************************************************************/
+void PalBbBleRefreshKeyAfterSleep(void);
 /*! \} */    /* PAL_BB_BLE */
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Description
This function reloads the encryption keys stored in ram back into registers after MCU wakes up from deep sleep.
The function definition lives  in RF-PHY-close.
Tested and working on ME14
### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

