### PR TITLE
docs(Other): Update All Links to New User Guide Address

### DIFF
--- a/Examples/MAX32520/AES/.vscode/README.md
+++ b/Examples/MAX32520/AES/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/AES/Makefile
+++ b/Examples/MAX32520/AES/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/AES/README.md
+++ b/Examples/MAX32520/AES/README.md
@@ -7,7 +7,7 @@ This application demonstrates both encryption and decryption using AES.  A block
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/AES/project.mk
+++ b/Examples/MAX32520/AES/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/ARM-DSP/README.md
+++ b/Examples/MAX32520/ARM-DSP/README.md
@@ -14,7 +14,7 @@ Development with Visual Studio Code is also supported.  See [VSCode-Maxim](https
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_bayes_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/ARM-DSP/arm_bayes_example/project.mk
+++ b/Examples/MAX32520/ARM-DSP/arm_bayes_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_class_marks_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/ARM-DSP/arm_class_marks_example/project.mk
+++ b/Examples/MAX32520/ARM-DSP/arm_class_marks_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_convolution_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/ARM-DSP/arm_convolution_example/project.mk
+++ b/Examples/MAX32520/ARM-DSP/arm_convolution_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/ARM-DSP/arm_dotproduct_example_f32/project.mk
+++ b/Examples/MAX32520/ARM-DSP/arm_dotproduct_example_f32/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_fft_bin_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/ARM-DSP/arm_fft_bin_example/project.mk
+++ b/Examples/MAX32520/ARM-DSP/arm_fft_bin_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_fir_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/ARM-DSP/arm_fir_example/project.mk
+++ b/Examples/MAX32520/ARM-DSP/arm_fir_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/ARM-DSP/arm_graphic_equalizer_example/project.mk
+++ b/Examples/MAX32520/ARM-DSP/arm_graphic_equalizer_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_linear_interp_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/ARM-DSP/arm_linear_interp_example/project.mk
+++ b/Examples/MAX32520/ARM-DSP/arm_linear_interp_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_matrix_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/ARM-DSP/arm_matrix_example/project.mk
+++ b/Examples/MAX32520/ARM-DSP/arm_matrix_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_signal_converge_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/ARM-DSP/arm_signal_converge_example/project.mk
+++ b/Examples/MAX32520/ARM-DSP/arm_signal_converge_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_sin_cos_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/ARM-DSP/arm_sin_cos_example/project.mk
+++ b/Examples/MAX32520/ARM-DSP/arm_sin_cos_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_svm_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/ARM-DSP/arm_svm_example/project.mk
+++ b/Examples/MAX32520/ARM-DSP/arm_svm_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_variance_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/ARM-DSP/arm_variance_example/project.mk
+++ b/Examples/MAX32520/ARM-DSP/arm_variance_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/CRC/.vscode/README.md
+++ b/Examples/MAX32520/CRC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/CRC/Makefile
+++ b/Examples/MAX32520/CRC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/CRC/README.md
+++ b/Examples/MAX32520/CRC/README.md
@@ -7,7 +7,7 @@ This example demonstrates the use of the HW CRC calculator.  The example first g
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/CRC/project.mk
+++ b/Examples/MAX32520/CRC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/Coremark/.vscode/README.md
+++ b/Examples/MAX32520/Coremark/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/Coremark/Makefile
+++ b/Examples/MAX32520/Coremark/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/Coremark/README.md
+++ b/Examples/MAX32520/Coremark/README.md
@@ -10,7 +10,7 @@ For more information, visit the [CoreMark webpage](https://www.eembc.org/coremar
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/Coremark/project.mk
+++ b/Examples/MAX32520/Coremark/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32520/DMA/.vscode/README.md
+++ b/Examples/MAX32520/DMA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/DMA/Makefile
+++ b/Examples/MAX32520/DMA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/DMA/README.md
+++ b/Examples/MAX32520/DMA/README.md
@@ -9,7 +9,7 @@ A second more complex memory-to-memory DMA transaction is then shown that chains
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/DMA/project.mk
+++ b/Examples/MAX32520/DMA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/ECDSA/.vscode/README.md
+++ b/Examples/MAX32520/ECDSA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/ECDSA/Makefile
+++ b/Examples/MAX32520/ECDSA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/ECDSA/README.md
+++ b/Examples/MAX32520/ECDSA/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/ECDSA/project.mk
+++ b/Examples/MAX32520/ECDSA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32520/EEPROM_Emulator/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32520/EEPROM_Emulator/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/EEPROM_Emulator/README.md
+++ b/Examples/MAX32520/EEPROM_Emulator/README.md
@@ -48,7 +48,7 @@ To help with syncronization, a "Ready Signal" is set up as an output from a GPIO
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/EEPROM_Emulator/project.mk
+++ b/Examples/MAX32520/EEPROM_Emulator/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32520/Flash/.vscode/README.md
+++ b/Examples/MAX32520/Flash/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/Flash/Makefile
+++ b/Examples/MAX32520/Flash/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/Flash/README.md
+++ b/Examples/MAX32520/Flash/README.md
@@ -21,7 +21,7 @@ The _second_ time the example is run the application will see the "magic" 32-bit
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
@@ -42,9 +42,9 @@ If using the MAX32520FTHR:
 
 ## Building and Running
 
-**See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
+**See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
 
-This example supports all available MAX32520 evaluation platforms but comes _pre-configured_ for the MAX32520-KIT by default.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
+This example supports all available MAX32520 evaluation platforms but comes _pre-configured_ for the MAX32520-KIT by default.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
 
 ## Expected Output
 

--- a/Examples/MAX32520/Flash/project.mk
+++ b/Examples/MAX32520/Flash/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32520/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32520/Flash_CLI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/Flash_CLI/Makefile
+++ b/Examples/MAX32520/Flash_CLI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/Flash_CLI/README.md
+++ b/Examples/MAX32520/Flash_CLI/README.md
@@ -9,7 +9,7 @@ This example demonstates the CLI commands feature of FreeRTOS, various features 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/Flash_CLI/project.mk
+++ b/Examples/MAX32520/Flash_CLI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32520/FreeRTOSDemo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32520/FreeRTOSDemo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/FreeRTOSDemo/README.md
+++ b/Examples/MAX32520/FreeRTOSDemo/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/FreeRTOSDemo/project.mk
+++ b/Examples/MAX32520/FreeRTOSDemo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/GPIO/.vscode/README.md
+++ b/Examples/MAX32520/GPIO/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/GPIO/Makefile
+++ b/Examples/MAX32520/GPIO/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/GPIO/README.md
+++ b/Examples/MAX32520/GPIO/README.md
@@ -9,7 +9,7 @@ P1.1 is continuously scanned and whatever value is read on that pin is then outp
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/GPIO/project.mk
+++ b/Examples/MAX32520/GPIO/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/Hello_World/.vscode/README.md
+++ b/Examples/MAX32520/Hello_World/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/Hello_World/Makefile
+++ b/Examples/MAX32520/Hello_World/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/Hello_World/README.md
+++ b/Examples/MAX32520/Hello_World/README.md
@@ -9,7 +9,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/Hello_World/project.mk
+++ b/Examples/MAX32520/Hello_World/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32520/Hello_World_Cpp/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/Hello_World_Cpp/Makefile
+++ b/Examples/MAX32520/Hello_World_Cpp/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/Hello_World_Cpp/README.md
+++ b/Examples/MAX32520/Hello_World_Cpp/README.md
@@ -8,7 +8,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/Hello_World_Cpp/project.mk
+++ b/Examples/MAX32520/Hello_World_Cpp/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32520/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32520/I2C_MNGR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/I2C_MNGR/Makefile
+++ b/Examples/MAX32520/I2C_MNGR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/I2C_MNGR/README.md
+++ b/Examples/MAX32520/I2C_MNGR/README.md
@@ -11,7 +11,7 @@ You may change the configuration of each EEPROM's I2C transaction parameters (sl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/I2C_MNGR/project.mk
+++ b/Examples/MAX32520/I2C_MNGR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32520/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32520/I2C_SCAN/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/I2C_SCAN/Makefile
+++ b/Examples/MAX32520/I2C_SCAN/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/I2C_SCAN/README.md
+++ b/Examples/MAX32520/I2C_SCAN/README.md
@@ -6,7 +6,7 @@ This example uses the I2C Master to find the addresses of any I2C Slave devices 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/I2C_SCAN/project.mk
+++ b/Examples/MAX32520/I2C_SCAN/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32520/I2C_Sensor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/I2C_Sensor/Makefile
+++ b/Examples/MAX32520/I2C_Sensor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/I2C_Sensor/README.md
+++ b/Examples/MAX32520/I2C_Sensor/README.md
@@ -9,7 +9,7 @@ After initialization, a new reading is printed to the terminal every second.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/I2C_Sensor/project.mk
+++ b/Examples/MAX32520/I2C_Sensor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32520/ICC/.vscode/README.md
+++ b/Examples/MAX32520/ICC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/ICC/Makefile
+++ b/Examples/MAX32520/ICC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/ICC/README.md
+++ b/Examples/MAX32520/ICC/README.md
@@ -12,7 +12,7 @@ This example demonstrates the time differences when running code with the instru
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/ICC/project.mk
+++ b/Examples/MAX32520/ICC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/LP/.vscode/README.md
+++ b/Examples/MAX32520/LP/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/LP/Makefile
+++ b/Examples/MAX32520/LP/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/LP/README.md
+++ b/Examples/MAX32520/LP/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/LP/project.mk
+++ b/Examples/MAX32520/LP/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/Library_Generate/.vscode/README.md
+++ b/Examples/MAX32520/Library_Generate/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
   * If it's not in the README, check the UG.
   * If it's not in the UG, open a ticket!
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
@@ -31,7 +31,7 @@ The following features are supported:
 
 The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.analog.com/en/education/education-library/videos/6313212752112.html).
 
-1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
     * [Windows](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0010820A)
     * [Linux (Ubuntu)](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018720A)
     * [MacOS](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018610A)

--- a/Examples/MAX32520/Library_Generate/Makefile
+++ b/Examples/MAX32520/Library_Generate/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/Library_Generate/README.md
+++ b/Examples/MAX32520/Library_Generate/README.md
@@ -9,7 +9,7 @@ Check the Library_Use demo to see how to link static libraries to an application
 
 ### Project Usage
 
-Universal instructions on building this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/Library_Generate/project.mk
+++ b/Examples/MAX32520/Library_Generate/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
  
 # **********************************************************
 

--- a/Examples/MAX32520/Library_Use/.vscode/README.md
+++ b/Examples/MAX32520/Library_Use/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/Library_Use/Makefile
+++ b/Examples/MAX32520/Library_Use/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/Library_Use/README.md
+++ b/Examples/MAX32520/Library_Use/README.md
@@ -9,11 +9,11 @@ to project.mk to see how to include ".a" static library files into your project.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-This example supports all available MAX32520 evaluation platforms but comes _pre-configured_ for the MAX32520-KIT by default. See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
+This example supports all available MAX32520 evaluation platforms but comes _pre-configured_ for the MAX32520-KIT by default. See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
 
 ## Hardware Connections
 

--- a/Examples/MAX32520/Library_Use/project.mk
+++ b/Examples/MAX32520/Library_Use/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32520/LockDebug/.vscode/README.md
+++ b/Examples/MAX32520/LockDebug/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/LockDebug/Makefile
+++ b/Examples/MAX32520/LockDebug/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/LockDebug/README.md
+++ b/Examples/MAX32520/LockDebug/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/LockDebug/project.mk
+++ b/Examples/MAX32520/LockDebug/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32520/OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32520/OTP_Dump/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/OTP_Dump/Makefile
+++ b/Examples/MAX32520/OTP_Dump/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/SCPA_OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32520/SCPA_OTP_Dump/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/SCPA_OTP_Dump/Makefile
+++ b/Examples/MAX32520/SCPA_OTP_Dump/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/SCPA_OTP_Dump/README.md
+++ b/Examples/MAX32520/SCPA_OTP_Dump/README.md
@@ -21,7 +21,7 @@ PROJ_CFLAGS+=-DMAX32520_A2
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/SCPA_OTP_Dump/project.mk
+++ b/Examples/MAX32520/SCPA_OTP_Dump/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/SFE/.vscode/README.md
+++ b/Examples/MAX32520/SFE/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/SFE/Makefile
+++ b/Examples/MAX32520/SFE/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/SFE/README.md
+++ b/Examples/MAX32520/SFE/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/SFE/project.mk
+++ b/Examples/MAX32520/SFE/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/SFE_Host/.vscode/README.md
+++ b/Examples/MAX32520/SFE_Host/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/SFE_Host/Makefile
+++ b/Examples/MAX32520/SFE_Host/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/SFE_Host/README.md
+++ b/Examples/MAX32520/SFE_Host/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/SFE_Host/project.mk
+++ b/Examples/MAX32520/SFE_Host/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/SMON/.vscode/README.md
+++ b/Examples/MAX32520/SMON/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/SMON/Makefile
+++ b/Examples/MAX32520/SMON/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/SMON/README.md
+++ b/Examples/MAX32520/SMON/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/SMON/project.mk
+++ b/Examples/MAX32520/SMON/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/SPI/.vscode/README.md
+++ b/Examples/MAX32520/SPI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/SPI/Makefile
+++ b/Examples/MAX32520/SPI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/SPI/README.md
+++ b/Examples/MAX32520/SPI/README.md
@@ -11,7 +11,7 @@ By default, the example performs blocking SPI transactions.  To switch to non-bl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/SPI/project.mk
+++ b/Examples/MAX32520/SPI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/SPI_MasterSlave/.vscode/README.md
+++ b/Examples/MAX32520/SPI_MasterSlave/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/SPI_MasterSlave/Makefile
+++ b/Examples/MAX32520/SPI_MasterSlave/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/SPI_MasterSlave/README.md
+++ b/Examples/MAX32520/SPI_MasterSlave/README.md
@@ -11,7 +11,7 @@ Once the master ends the transaction, the data received by the master and the sl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/SPI_MasterSlave/project.mk
+++ b/Examples/MAX32520/SPI_MasterSlave/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32520/TMR/.vscode/README.md
+++ b/Examples/MAX32520/TMR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/TMR/Makefile
+++ b/Examples/MAX32520/TMR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/TMR/README.md
+++ b/Examples/MAX32520/TMR/README.md
@@ -11,7 +11,7 @@ Two timers are used to demonstrate two different modes of the general purpose ti
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/TMR/project.mk
+++ b/Examples/MAX32520/TMR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/TRNG/.vscode/README.md
+++ b/Examples/MAX32520/TRNG/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/TRNG/Makefile
+++ b/Examples/MAX32520/TRNG/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/TRNG/README.md
+++ b/Examples/MAX32520/TRNG/README.md
@@ -7,7 +7,7 @@ The true random number generator (TRNG) hardware is exercised in this example.  
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/TRNG/project.mk
+++ b/Examples/MAX32520/TRNG/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/UCL/README.md
+++ b/Examples/MAX32520/UCL/README.md
@@ -10,7 +10,7 @@ TODO:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/UCL/project.mk
+++ b/Examples/MAX32520/UCL/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32520/Watchdog/.vscode/README.md
+++ b/Examples/MAX32520/Watchdog/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32520/Watchdog/Makefile
+++ b/Examples/MAX32520/Watchdog/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32520/Watchdog/README.md
+++ b/Examples/MAX32520/Watchdog/README.md
@@ -11,7 +11,7 @@ When the application begins, it initializes and starts the watchdog timer.  The 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32520/Watchdog/project.mk
+++ b/Examples/MAX32520/Watchdog/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=MAX32520FTHR
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/ADC/.vscode/README.md
+++ b/Examples/MAX32650/ADC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/ADC/Makefile
+++ b/Examples/MAX32650/ADC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/ADC/README.md
+++ b/Examples/MAX32650/ADC/README.md
@@ -11,7 +11,7 @@ Any reading that exceeds the full-scale value of the ADC will have an '*' append
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/ADC/project.mk
+++ b/Examples/MAX32650/ADC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/ADC_MAX11261/.vscode/README.md
+++ b/Examples/MAX32650/ADC_MAX11261/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/ADC_MAX11261/Makefile
+++ b/Examples/MAX32650/ADC_MAX11261/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/ADC_MAX11261/README.md
+++ b/Examples/MAX32650/ADC_MAX11261/README.md
@@ -11,7 +11,7 @@ Any reading that exceeds the full-scale value of the ADC will have an '*' append
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/ADC_MAX11261/project.mk
+++ b/Examples/MAX32650/ADC_MAX11261/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/AES/.vscode/README.md
+++ b/Examples/MAX32650/AES/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/AES/Makefile
+++ b/Examples/MAX32650/AES/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/AES/README.md
+++ b/Examples/MAX32650/AES/README.md
@@ -7,7 +7,7 @@ This application demonstrates both encryption and decryption using AES.  A block
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/AES/project.mk
+++ b/Examples/MAX32650/AES/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/ARM-DSP/README.md
+++ b/Examples/MAX32650/ARM-DSP/README.md
@@ -14,7 +14,7 @@ Development with Visual Studio Code is also supported.  See [VSCode-Maxim](https
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_bayes_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/ARM-DSP/arm_bayes_example/project.mk
+++ b/Examples/MAX32650/ARM-DSP/arm_bayes_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_class_marks_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/ARM-DSP/arm_class_marks_example/project.mk
+++ b/Examples/MAX32650/ARM-DSP/arm_class_marks_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_convolution_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/ARM-DSP/arm_convolution_example/project.mk
+++ b/Examples/MAX32650/ARM-DSP/arm_convolution_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/ARM-DSP/arm_dotproduct_example_f32/project.mk
+++ b/Examples/MAX32650/ARM-DSP/arm_dotproduct_example_f32/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_fft_bin_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/ARM-DSP/arm_fft_bin_example/project.mk
+++ b/Examples/MAX32650/ARM-DSP/arm_fft_bin_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_fir_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/ARM-DSP/arm_fir_example/project.mk
+++ b/Examples/MAX32650/ARM-DSP/arm_fir_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/ARM-DSP/arm_graphic_equalizer_example/project.mk
+++ b/Examples/MAX32650/ARM-DSP/arm_graphic_equalizer_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_linear_interp_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/ARM-DSP/arm_linear_interp_example/project.mk
+++ b/Examples/MAX32650/ARM-DSP/arm_linear_interp_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_matrix_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/ARM-DSP/arm_matrix_example/project.mk
+++ b/Examples/MAX32650/ARM-DSP/arm_matrix_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_signal_converge_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/ARM-DSP/arm_signal_converge_example/project.mk
+++ b/Examples/MAX32650/ARM-DSP/arm_signal_converge_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_sin_cos_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/ARM-DSP/arm_sin_cos_example/project.mk
+++ b/Examples/MAX32650/ARM-DSP/arm_sin_cos_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_svm_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/ARM-DSP/arm_svm_example/project.mk
+++ b/Examples/MAX32650/ARM-DSP/arm_svm_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_variance_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/ARM-DSP/arm_variance_example/project.mk
+++ b/Examples/MAX32650/ARM-DSP/arm_variance_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/CLCD/.vscode/README.md
+++ b/Examples/MAX32650/CLCD/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/CLCD/Makefile
+++ b/Examples/MAX32650/CLCD/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/CLCD/README.md
+++ b/Examples/MAX32650/CLCD/README.md
@@ -7,7 +7,7 @@ This example demonstrates the use of the LCD Display on the MAX32650 EV Kit. Thi
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/CLCD/project.mk
+++ b/Examples/MAX32650/CLCD/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/CRC/.vscode/README.md
+++ b/Examples/MAX32650/CRC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/CRC/Makefile
+++ b/Examples/MAX32650/CRC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/CRC/README.md
+++ b/Examples/MAX32650/CRC/README.md
@@ -9,7 +9,7 @@ To demonstrate, CRC values are calculated in software and using the TPU. The res
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/CRC/project.mk
+++ b/Examples/MAX32650/CRC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/Coremark/.vscode/README.md
+++ b/Examples/MAX32650/Coremark/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/Coremark/Makefile
+++ b/Examples/MAX32650/Coremark/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/Coremark/README.md
+++ b/Examples/MAX32650/Coremark/README.md
@@ -10,7 +10,7 @@ For more information, visit the [CoreMark webpage](https://www.eembc.org/coremar
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/Coremark/project.mk
+++ b/Examples/MAX32650/Coremark/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32650/DES/.vscode/README.md
+++ b/Examples/MAX32650/DES/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/DES/Makefile
+++ b/Examples/MAX32650/DES/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/DES/README.md
+++ b/Examples/MAX32650/DES/README.md
@@ -9,7 +9,7 @@ To demonstrate, encryption and decryption operations are executed with the TPU a
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/DES/project.mk
+++ b/Examples/MAX32650/DES/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/DMA/.vscode/README.md
+++ b/Examples/MAX32650/DMA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/DMA/Makefile
+++ b/Examples/MAX32650/DMA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/DMA/README.md
+++ b/Examples/MAX32650/DMA/README.md
@@ -9,7 +9,7 @@ A second more complex memory-to-memory DMA transaction is then shown that chains
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/DMA/project.mk
+++ b/Examples/MAX32650/DMA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32650/EEPROM_Emulator/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32650/EEPROM_Emulator/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/EEPROM_Emulator/README.md
+++ b/Examples/MAX32650/EEPROM_Emulator/README.md
@@ -48,7 +48,7 @@ To help with syncronization, a "Ready Signal" is set up as an output from a GPIO
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/EEPROM_Emulator/project.mk
+++ b/Examples/MAX32650/EEPROM_Emulator/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32650/EMCC/.vscode/README.md
+++ b/Examples/MAX32650/EMCC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/EMCC/Makefile
+++ b/Examples/MAX32650/EMCC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/EMCC/README.md
+++ b/Examples/MAX32650/EMCC/README.md
@@ -9,7 +9,7 @@ The same external memory operations are performed with both the cache enabled an
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/EMCC/project.mk
+++ b/Examples/MAX32650/EMCC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/Flash/.vscode/README.md
+++ b/Examples/MAX32650/Flash/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/Flash/Makefile
+++ b/Examples/MAX32650/Flash/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/Flash/README.md
+++ b/Examples/MAX32650/Flash/README.md
@@ -21,7 +21,7 @@ The _second_ time the example is run the application will see the "magic" 32-bit
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
@@ -42,9 +42,9 @@ If using the MAX32650FTHR:
 
 ## Building and Running
 
-**See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
+**See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
 
-This example supports all available MAX32650 evaluation platforms but comes _pre-configured_ for the MAX32650EVKIT by default.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
+This example supports all available MAX32650 evaluation platforms but comes _pre-configured_ for the MAX32650EVKIT by default.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
 
 ## Expected Output
 

--- a/Examples/MAX32650/Flash/project.mk
+++ b/Examples/MAX32650/Flash/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32650/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32650/Flash_CLI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/Flash_CLI/Makefile
+++ b/Examples/MAX32650/Flash_CLI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/Flash_CLI/README.md
+++ b/Examples/MAX32650/Flash_CLI/README.md
@@ -9,7 +9,7 @@ This example demonstates the CLI commands feature of FreeRTOS, various features 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/Flash_CLI/project.mk
+++ b/Examples/MAX32650/Flash_CLI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32650/FreeRTOSDemo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32650/FreeRTOSDemo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/FreeRTOSDemo/README.md
+++ b/Examples/MAX32650/FreeRTOSDemo/README.md
@@ -11,7 +11,7 @@ vCmdLineTask takes command inputs from the terminal and executes the command (th
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/FreeRTOSDemo/project.mk
+++ b/Examples/MAX32650/FreeRTOSDemo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/GPIO/.vscode/README.md
+++ b/Examples/MAX32650/GPIO/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/GPIO/Makefile
+++ b/Examples/MAX32650/GPIO/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/GPIO/README.md
+++ b/Examples/MAX32650/GPIO/README.md
@@ -9,7 +9,7 @@ P2.28 (SW2) is continuously scanned and whatever value is read on that pin is th
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/GPIO/project.mk
+++ b/Examples/MAX32650/GPIO/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/HBMC/.vscode/README.md
+++ b/Examples/MAX32650/HBMC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/HBMC/Makefile
+++ b/Examples/MAX32650/HBMC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/HBMC/README.md
+++ b/Examples/MAX32650/HBMC/README.md
@@ -11,7 +11,7 @@ A function to blink an LED (found in ramfunc.c) is copied to external memory and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/HBMC/project.mk
+++ b/Examples/MAX32650/HBMC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/Hello_World/.vscode/README.md
+++ b/Examples/MAX32650/Hello_World/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/Hello_World/Makefile
+++ b/Examples/MAX32650/Hello_World/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/Hello_World/README.md
+++ b/Examples/MAX32650/Hello_World/README.md
@@ -9,7 +9,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/Hello_World/project.mk
+++ b/Examples/MAX32650/Hello_World/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32650/Hello_World_Cpp/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/Hello_World_Cpp/Makefile
+++ b/Examples/MAX32650/Hello_World_Cpp/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/Hello_World_Cpp/README.md
+++ b/Examples/MAX32650/Hello_World_Cpp/README.md
@@ -8,7 +8,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/Hello_World_Cpp/project.mk
+++ b/Examples/MAX32650/Hello_World_Cpp/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32650/I2C/.vscode/README.md
+++ b/Examples/MAX32650/I2C/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/I2C/Makefile
+++ b/Examples/MAX32650/I2C/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/I2C/README.md
+++ b/Examples/MAX32650/I2C/README.md
@@ -7,7 +7,7 @@ This example uses the I2C Master (I2C0) to read/write from/to the I2C Slave (I2C
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/I2C/project.mk
+++ b/Examples/MAX32650/I2C/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32650/I2C_MNGR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/I2C_MNGR/Makefile
+++ b/Examples/MAX32650/I2C_MNGR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/I2C_MNGR/README.md
+++ b/Examples/MAX32650/I2C_MNGR/README.md
@@ -11,7 +11,7 @@ You may change the configuration of each EEPROM's I2C transaction parameters (sl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/I2C_MNGR/project.mk
+++ b/Examples/MAX32650/I2C_MNGR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32650/I2C_SCAN/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/I2C_SCAN/Makefile
+++ b/Examples/MAX32650/I2C_SCAN/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/I2C_SCAN/README.md
+++ b/Examples/MAX32650/I2C_SCAN/README.md
@@ -6,7 +6,7 @@ This example uses the I2C Master to find the addresses of any I2C Slave devices 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/I2C_SCAN/project.mk
+++ b/Examples/MAX32650/I2C_SCAN/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32650/I2C_Sensor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/I2C_Sensor/Makefile
+++ b/Examples/MAX32650/I2C_Sensor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/I2C_Sensor/README.md
+++ b/Examples/MAX32650/I2C_Sensor/README.md
@@ -9,7 +9,7 @@ After initialization, a new reading is printed to the terminal every second.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/I2C_Sensor/project.mk
+++ b/Examples/MAX32650/I2C_Sensor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32650/I2S/.vscode/README.md
+++ b/Examples/MAX32650/I2S/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/I2S/Makefile
+++ b/Examples/MAX32650/I2S/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/I2S/README.md
+++ b/Examples/MAX32650/I2S/README.md
@@ -8,7 +8,7 @@ This example demonstrates of the SPIMSS I2S functionality. To demonstrate, an au
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/I2S/project.mk
+++ b/Examples/MAX32650/I2S/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/ICC/.vscode/README.md
+++ b/Examples/MAX32650/ICC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/ICC/Makefile
+++ b/Examples/MAX32650/ICC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/ICC/README.md
+++ b/Examples/MAX32650/ICC/README.md
@@ -12,7 +12,7 @@ This example demonstrates the time differences when running code with the instru
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/ICC/project.mk
+++ b/Examples/MAX32650/ICC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/LP/.vscode/README.md
+++ b/Examples/MAX32650/LP/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/LP/Makefile
+++ b/Examples/MAX32650/LP/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/LP/README.md
+++ b/Examples/MAX32650/LP/README.md
@@ -9,7 +9,7 @@ The wakeup source can be configured to be either the RTC clock or the push butto
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/LP/project.mk
+++ b/Examples/MAX32650/LP/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/Library_Generate/.vscode/README.md
+++ b/Examples/MAX32650/Library_Generate/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
   * If it's not in the README, check the UG.
   * If it's not in the UG, open a ticket!
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
@@ -31,7 +31,7 @@ The following features are supported:
 
 The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.analog.com/en/education/education-library/videos/6313212752112.html).
 
-1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
     * [Windows](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0010820A)
     * [Linux (Ubuntu)](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018720A)
     * [MacOS](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018610A)

--- a/Examples/MAX32650/Library_Generate/Makefile
+++ b/Examples/MAX32650/Library_Generate/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/Library_Generate/README.md
+++ b/Examples/MAX32650/Library_Generate/README.md
@@ -9,7 +9,7 @@ Check the Library_Use demo to see how to link static libraries to an application
 
 ### Project Usage
 
-Universal instructions on building this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/Library_Generate/project.mk
+++ b/Examples/MAX32650/Library_Generate/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
  
 # **********************************************************
 

--- a/Examples/MAX32650/Library_Use/.vscode/README.md
+++ b/Examples/MAX32650/Library_Use/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/Library_Use/Makefile
+++ b/Examples/MAX32650/Library_Use/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/Library_Use/README.md
+++ b/Examples/MAX32650/Library_Use/README.md
@@ -9,11 +9,11 @@ to project.mk to see how to include ".a" static library files into your project.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-This example supports all available MAX32650 evaluation platforms but comes _pre-configured_ for the MAX32650EVKIT by default. See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
+This example supports all available MAX32650 evaluation platforms but comes _pre-configured_ for the MAX32650EVKIT by default. See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
 
 ## Required Connections
 

--- a/Examples/MAX32650/Library_Use/project.mk
+++ b/Examples/MAX32650/Library_Use/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32650/MAA/.vscode/README.md
+++ b/Examples/MAX32650/MAA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/MAA/Makefile
+++ b/Examples/MAX32650/MAA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/MAA/README.md
+++ b/Examples/MAX32650/MAA/README.md
@@ -11,7 +11,7 @@ In this particular example the MAA is configured to compute an exponentiation. T
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/MAA/project.mk
+++ b/Examples/MAX32650/MAA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32650/OTP_Dump/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/OTP_Dump/Makefile
+++ b/Examples/MAX32650/OTP_Dump/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/OWM/.vscode/README.md
+++ b/Examples/MAX32650/OWM/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/OWM/Makefile
+++ b/Examples/MAX32650/OWM/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/OWM/README.md
+++ b/Examples/MAX32650/OWM/README.md
@@ -7,7 +7,7 @@ This example demonstrate how 1-Wire master can be configured and read slave ROM 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/OWM/project.mk
+++ b/Examples/MAX32650/OWM/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/Pulse_Train/.vscode/README.md
+++ b/Examples/MAX32650/Pulse_Train/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/Pulse_Train/Makefile
+++ b/Examples/MAX32650/Pulse_Train/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/Pulse_Train/README.md
+++ b/Examples/MAX32650/Pulse_Train/README.md
@@ -11,7 +11,7 @@ The second, PT15, is set to generate a 10Hz square wave.  If you make the connec
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/Pulse_Train/project.mk
+++ b/Examples/MAX32650/Pulse_Train/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/RTC/.vscode/README.md
+++ b/Examples/MAX32650/RTC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/RTC/Makefile
+++ b/Examples/MAX32650/RTC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/RTC/README.md
+++ b/Examples/MAX32650/RTC/README.md
@@ -13,7 +13,7 @@ Pressing SW2 will output the current value of the RTC to the console UART.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/RTC/project.mk
+++ b/Examples/MAX32650/RTC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX32650/RTC_Backup/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/RTC_Backup/Makefile
+++ b/Examples/MAX32650/RTC_Backup/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/RTC_Backup/README.md
+++ b/Examples/MAX32650/RTC_Backup/README.md
@@ -10,7 +10,7 @@ The RTC time-of-day alarm is used to wake the device from backup mode every TIME
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/RTC_Backup/project.mk
+++ b/Examples/MAX32650/RTC_Backup/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/SCPA_OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32650/SCPA_OTP_Dump/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/SCPA_OTP_Dump/Makefile
+++ b/Examples/MAX32650/SCPA_OTP_Dump/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/SCPA_OTP_Dump/README.md
+++ b/Examples/MAX32650/SCPA_OTP_Dump/README.md
@@ -20,7 +20,7 @@ PROJ_CFLAGS+=-DMAX32651_A1
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/SCPA_OTP_Dump/project.mk
+++ b/Examples/MAX32650/SCPA_OTP_Dump/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/SDHC_FAT/.vscode/README.md
+++ b/Examples/MAX32650/SDHC_FAT/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/SDHC_FAT/Makefile
+++ b/Examples/MAX32650/SDHC_FAT/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/SDHC_FAT/README.md
+++ b/Examples/MAX32650/SDHC_FAT/README.md
@@ -6,7 +6,7 @@ This example demonstrates the SDHC FAT Filesystem. The terminal prompts with a l
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/SDHC_FAT/project.mk
+++ b/Examples/MAX32650/SDHC_FAT/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/SDHC_Raw/.vscode/README.md
+++ b/Examples/MAX32650/SDHC_Raw/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/SDHC_Raw/Makefile
+++ b/Examples/MAX32650/SDHC_Raw/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/SDHC_Raw/README.md
+++ b/Examples/MAX32650/SDHC_Raw/README.md
@@ -7,7 +7,7 @@ This example demonstrates reading and writing to an SD card using both 1-bit and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/SDHC_Raw/project.mk
+++ b/Examples/MAX32650/SDHC_Raw/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/SPI/.vscode/README.md
+++ b/Examples/MAX32650/SPI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/SPI/Makefile
+++ b/Examples/MAX32650/SPI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/SPI/README.md
+++ b/Examples/MAX32650/SPI/README.md
@@ -11,7 +11,7 @@ By default, the example performs blocking SPI transactions.  To switch to non-bl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/SPI/project.mk
+++ b/Examples/MAX32650/SPI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/SPIMSS/.vscode/README.md
+++ b/Examples/MAX32650/SPIMSS/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/SPIMSS/Makefile
+++ b/Examples/MAX32650/SPIMSS/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/SPIMSS/README.md
+++ b/Examples/MAX32650/SPIMSS/README.md
@@ -10,7 +10,7 @@ Multiple word sizes (2 through 16 bits) are demonstrated.  To select between blo
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/SPIMSS/project.mk
+++ b/Examples/MAX32650/SPIMSS/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/SPIXF/.vscode/README.md
+++ b/Examples/MAX32650/SPIXF/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/SPIXF/Makefile
+++ b/Examples/MAX32650/SPIXF/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/SPIXF/README.md
+++ b/Examples/MAX32650/SPIXF/README.md
@@ -7,7 +7,7 @@ This example communicates with the MX25 flash on the EvKit. It loads code onto i
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/SPIXF/project.mk
+++ b/Examples/MAX32650/SPIXF/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/SPIXF_ICC/.vscode/README.md
+++ b/Examples/MAX32650/SPIXF_ICC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/SPIXF_ICC/Makefile
+++ b/Examples/MAX32650/SPIXF_ICC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/SPIXF_ICC/README.md
+++ b/Examples/MAX32650/SPIXF_ICC/README.md
@@ -9,7 +9,7 @@ A sample function which performs a multiplication operation repeatedly is loaded
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/SPIXF_ICC/project.mk
+++ b/Examples/MAX32650/SPIXF_ICC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/SPIXR/.vscode/README.md
+++ b/Examples/MAX32650/SPIXR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/SPIXR/Makefile
+++ b/Examples/MAX32650/SPIXR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/SPIXR/README.md
+++ b/Examples/MAX32650/SPIXR/README.md
@@ -9,7 +9,7 @@ It writes random data to the SPI RAM and reads it back.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/SPIXR/project.mk
+++ b/Examples/MAX32650/SPIXR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/SPI_MasterSlave/.vscode/README.md
+++ b/Examples/MAX32650/SPI_MasterSlave/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/SPI_MasterSlave/Makefile
+++ b/Examples/MAX32650/SPI_MasterSlave/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/SPI_MasterSlave/README.md
+++ b/Examples/MAX32650/SPI_MasterSlave/README.md
@@ -11,7 +11,7 @@ Once the master ends the transaction, the data received by the master and the sl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/SPI_MasterSlave/project.mk
+++ b/Examples/MAX32650/SPI_MasterSlave/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32650/Semaphore/.vscode/README.md
+++ b/Examples/MAX32650/Semaphore/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/Semaphore/Makefile
+++ b/Examples/MAX32650/Semaphore/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/Semaphore/README.md
+++ b/Examples/MAX32650/Semaphore/README.md
@@ -9,7 +9,7 @@ A semaphore is shared between task A and task B. The buttons are used to start a
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/Semaphore/project.mk
+++ b/Examples/MAX32650/Semaphore/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/SysTick/.vscode/README.md
+++ b/Examples/MAX32650/SysTick/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/SysTick/Makefile
+++ b/Examples/MAX32650/SysTick/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/SysTick/README.md
+++ b/Examples/MAX32650/SysTick/README.md
@@ -7,7 +7,7 @@ This example demostrates the use of the SysTick Interrupt on the MAX32650. The s
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/SysTick/project.mk
+++ b/Examples/MAX32650/SysTick/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/TMR/.vscode/README.md
+++ b/Examples/MAX32650/TMR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/TMR/Makefile
+++ b/Examples/MAX32650/TMR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/TMR/README.md
+++ b/Examples/MAX32650/TMR/README.md
@@ -13,7 +13,7 @@ Three timers are used to demonstrate three different modes of the general purpos
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/TMR/project.mk
+++ b/Examples/MAX32650/TMR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/TRNG/.vscode/README.md
+++ b/Examples/MAX32650/TRNG/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/TRNG/Makefile
+++ b/Examples/MAX32650/TRNG/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/TRNG/README.md
+++ b/Examples/MAX32650/TRNG/README.md
@@ -7,7 +7,7 @@ This example uses the various functions of the True Random Number Generator. Spe
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/TRNG/project.mk
+++ b/Examples/MAX32650/TRNG/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32650/Temp_Monitor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/Temp_Monitor/Makefile
+++ b/Examples/MAX32650/Temp_Monitor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/Temp_Monitor/README.md
+++ b/Examples/MAX32650/Temp_Monitor/README.md
@@ -15,7 +15,7 @@ The temperature limits, flash storage page, and RTC time-of-day alarm period are
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/Temp_Monitor/project.mk
+++ b/Examples/MAX32650/Temp_Monitor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/UART/.vscode/README.md
+++ b/Examples/MAX32650/UART/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/UART/Makefile
+++ b/Examples/MAX32650/UART/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/UART/README.md
+++ b/Examples/MAX32650/UART/README.md
@@ -7,7 +7,7 @@ To demonstrate the use of the UART peripheral, data is sent between two UART por
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/UART/project.mk
+++ b/Examples/MAX32650/UART/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/UCL/README.md
+++ b/Examples/MAX32650/UCL/README.md
@@ -9,7 +9,7 @@ TODO:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/UCL/project.mk
+++ b/Examples/MAX32650/UCL/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/USB/USB_CDCACM/.vscode/README.md
+++ b/Examples/MAX32650/USB/USB_CDCACM/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/USB/USB_CDCACM/Makefile
+++ b/Examples/MAX32650/USB/USB_CDCACM/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/USB/USB_CDCACM/README.md
+++ b/Examples/MAX32650/USB/USB_CDCACM/README.md
@@ -7,7 +7,7 @@ The example demonstartes the use of USB CDC-ACM driver class. After doing the re
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/USB/USB_CDCACM/project.mk
+++ b/Examples/MAX32650/USB/USB_CDCACM/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/USB/USB_CompositeDevice_MSC_CDC/.vscode/README.md
+++ b/Examples/MAX32650/USB/USB_CompositeDevice_MSC_CDC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/USB/USB_CompositeDevice_MSC_CDC/Makefile
+++ b/Examples/MAX32650/USB/USB_CompositeDevice_MSC_CDC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/USB/USB_CompositeDevice_MSC_CDC/README.md
+++ b/Examples/MAX32650/USB/USB_CompositeDevice_MSC_CDC/README.md
@@ -7,7 +7,7 @@ The example demonstartes the use of USB composite device with Mass Storage drive
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/USB/USB_CompositeDevice_MSC_CDC/project.mk
+++ b/Examples/MAX32650/USB/USB_CompositeDevice_MSC_CDC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/USB/USB_CompositeDevice_MSC_HID/.vscode/README.md
+++ b/Examples/MAX32650/USB/USB_CompositeDevice_MSC_HID/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/USB/USB_CompositeDevice_MSC_HID/Makefile
+++ b/Examples/MAX32650/USB/USB_CompositeDevice_MSC_HID/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/USB/USB_CompositeDevice_MSC_HID/README.md
+++ b/Examples/MAX32650/USB/USB_CompositeDevice_MSC_HID/README.md
@@ -7,7 +7,7 @@ The example demonstartes the use of USB composite device with Mass Storage drive
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/USB/USB_CompositeDevice_MSC_HID/project.mk
+++ b/Examples/MAX32650/USB/USB_CompositeDevice_MSC_HID/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/USB/USB_HIDKeyboard/.vscode/README.md
+++ b/Examples/MAX32650/USB/USB_HIDKeyboard/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/USB/USB_HIDKeyboard/Makefile
+++ b/Examples/MAX32650/USB/USB_HIDKeyboard/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/USB/USB_HIDKeyboard/README.md
+++ b/Examples/MAX32650/USB/USB_HIDKeyboard/README.md
@@ -7,7 +7,7 @@ The example demonstartes the use of USB HID driver class. After doing the requir
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/USB/USB_HIDKeyboard/project.mk
+++ b/Examples/MAX32650/USB/USB_HIDKeyboard/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/USB/USB_MassStorage/.vscode/README.md
+++ b/Examples/MAX32650/USB/USB_MassStorage/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/USB/USB_MassStorage/Makefile
+++ b/Examples/MAX32650/USB/USB_MassStorage/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/USB/USB_MassStorage/README.md
+++ b/Examples/MAX32650/USB/USB_MassStorage/README.md
@@ -7,7 +7,7 @@ The example demonstartes the use of USB Mass Storage driver class. After doing t
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/USB/USB_MassStorage/project.mk
+++ b/Examples/MAX32650/USB/USB_MassStorage/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/Watchdog/.vscode/README.md
+++ b/Examples/MAX32650/Watchdog/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/Watchdog/Makefile
+++ b/Examples/MAX32650/Watchdog/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/Watchdog/README.md
+++ b/Examples/MAX32650/Watchdog/README.md
@@ -12,7 +12,7 @@ When the application begins, it initializes and starts the watchdog timer.  The 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32650/Watchdog/project.mk
+++ b/Examples/MAX32650/Watchdog/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32650/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32650/WearLeveling/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32650/WearLeveling/Makefile
+++ b/Examples/MAX32650/WearLeveling/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32650/WearLeveling/README.md
+++ b/Examples/MAX32650/WearLeveling/README.md
@@ -15,11 +15,11 @@ Enter "help" in the command line to see more details on the usage of each of the
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32650EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX32650EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32650/WearLeveling/project.mk
+++ b/Examples/MAX32650/WearLeveling/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32655/ADC/.vscode/README.md
+++ b/Examples/MAX32655/ADC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/ADC/Makefile
+++ b/Examples/MAX32655/ADC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/ADC/README.md
+++ b/Examples/MAX32655/ADC/README.md
@@ -11,11 +11,11 @@ Any reading that exceeds the full-scale value of the ADC will have an '*' append
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/ADC/project.mk
+++ b/Examples/MAX32655/ADC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/AES/.vscode/README.md
+++ b/Examples/MAX32655/AES/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/AES/Makefile
+++ b/Examples/MAX32655/AES/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/AES/README.md
+++ b/Examples/MAX32655/AES/README.md
@@ -8,11 +8,11 @@ This application demonstrates both encryption and decryption using AES.  A block
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ##  Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/AES/project.mk
+++ b/Examples/MAX32655/AES/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/ARM-DSP/README.md
+++ b/Examples/MAX32655/ARM-DSP/README.md
@@ -14,7 +14,7 @@ Development with Visual Studio Code is also supported.  See [VSCode-Maxim](https
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32655/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_bayes_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/ARM-DSP/arm_bayes_example/project.mk
+++ b/Examples/MAX32655/ARM-DSP/arm_bayes_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32655/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_class_marks_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/ARM-DSP/arm_class_marks_example/project.mk
+++ b/Examples/MAX32655/ARM-DSP/arm_class_marks_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32655/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_convolution_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/ARM-DSP/arm_convolution_example/project.mk
+++ b/Examples/MAX32655/ARM-DSP/arm_convolution_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32655/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/ARM-DSP/arm_dotproduct_example_f32/project.mk
+++ b/Examples/MAX32655/ARM-DSP/arm_dotproduct_example_f32/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32655/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_fft_bin_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/ARM-DSP/arm_fft_bin_example/project.mk
+++ b/Examples/MAX32655/ARM-DSP/arm_fft_bin_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32655/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_fir_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/ARM-DSP/arm_fir_example/project.mk
+++ b/Examples/MAX32655/ARM-DSP/arm_fir_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32655/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/ARM-DSP/arm_graphic_equalizer_example/project.mk
+++ b/Examples/MAX32655/ARM-DSP/arm_graphic_equalizer_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32655/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_linear_interp_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/ARM-DSP/arm_linear_interp_example/project.mk
+++ b/Examples/MAX32655/ARM-DSP/arm_linear_interp_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32655/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_matrix_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/ARM-DSP/arm_matrix_example/project.mk
+++ b/Examples/MAX32655/ARM-DSP/arm_matrix_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32655/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_signal_converge_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/ARM-DSP/arm_signal_converge_example/project.mk
+++ b/Examples/MAX32655/ARM-DSP/arm_signal_converge_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32655/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_sin_cos_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/ARM-DSP/arm_sin_cos_example/project.mk
+++ b/Examples/MAX32655/ARM-DSP/arm_sin_cos_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32655/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_svm_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/ARM-DSP/arm_svm_example/project.mk
+++ b/Examples/MAX32655/ARM-DSP/arm_svm_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32655/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_variance_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/ARM-DSP/arm_variance_example/project.mk
+++ b/Examples/MAX32655/ARM-DSP/arm_variance_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32655/Bluetooth/BLE4_ctr/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE4_ctr/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Bluetooth/BLE4_ctr/Makefile
+++ b/Examples/MAX32655/Bluetooth/BLE4_ctr/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Bluetooth/BLE4_ctr/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE4_ctr/README.md
@@ -8,7 +8,7 @@ Refer to the [BLE4_ctr](../../../Libraries/Cordio/docs/Applications/BLE4_ctr.md)
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 

--- a/Examples/MAX32655/Bluetooth/BLE4_ctr/project.mk
+++ b/Examples/MAX32655/Bluetooth/BLE4_ctr/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Bluetooth/BLE5_ctr/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE5_ctr/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Bluetooth/BLE5_ctr/Makefile
+++ b/Examples/MAX32655/Bluetooth/BLE5_ctr/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Bluetooth/BLE5_ctr/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE5_ctr/README.md
@@ -8,7 +8,7 @@ Refer to the [BLE5_ctr](../../../Libraries/Cordio/docs/Applications/BLE5_ctr.md)
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 -   Connect a USB cable between the PC and the (USB/PWR - UART) connector.

--- a/Examples/MAX32655/Bluetooth/BLE5_ctr/project.mk
+++ b/Examples/MAX32655/Bluetooth/BLE5_ctr/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Bluetooth/BLE_FreeRTOS/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_FreeRTOS/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Bluetooth/BLE_FreeRTOS/Makefile
+++ b/Examples/MAX32655/Bluetooth/BLE_FreeRTOS/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Bluetooth/BLE_FreeRTOS/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_FreeRTOS/README.md
@@ -7,7 +7,7 @@ Refer to the [BLE_FreeRTOS](../../../Libraries/Cordio/docs/Applications/BLE_Free
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 

--- a/Examples/MAX32655/Bluetooth/BLE_FreeRTOS/project.mk
+++ b/Examples/MAX32655/Bluetooth/BLE_FreeRTOS/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Bluetooth/BLE_datc/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_datc/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Bluetooth/BLE_datc/Makefile
+++ b/Examples/MAX32655/Bluetooth/BLE_datc/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Bluetooth/BLE_datc/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_datc/README.md
@@ -6,7 +6,7 @@ Refer to the [BLE_datc_dats](../../../Libraries/Cordio/docs/Applications/BLE_dat
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 * Connect a USB cable between the PC and the (USB/PWR - UART) connector.

--- a/Examples/MAX32655/Bluetooth/BLE_datc/project.mk
+++ b/Examples/MAX32655/Bluetooth/BLE_datc/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Bluetooth/BLE_dats/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_dats/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Bluetooth/BLE_dats/Makefile
+++ b/Examples/MAX32655/Bluetooth/BLE_dats/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Bluetooth/BLE_dats/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_dats/README.md
@@ -6,7 +6,7 @@ Refer to the [BLE_datc_dats](../../../Libraries/Cordio/docs/Applications/BLE_dat
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 * Connect a USB cable between the PC and the (USB/PWR - UART) connector.

--- a/Examples/MAX32655/Bluetooth/BLE_dats/project.mk
+++ b/Examples/MAX32655/Bluetooth/BLE_dats/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Bluetooth/BLE_fcc/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_fcc/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Bluetooth/BLE_fcc/Makefile
+++ b/Examples/MAX32655/Bluetooth/BLE_fcc/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Bluetooth/BLE_fcc/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_fcc/README.md
@@ -7,7 +7,7 @@ Refer to [BLE_fcc](../../../Libraries/Cordio/docs/Applications/BLE_fcc.md) docum
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ## Required Connections
 * Connect a USB cable between the PC and the (USB/PWR - UART) connector.

--- a/Examples/MAX32655/Bluetooth/BLE_fcc/project.mk
+++ b/Examples/MAX32655/Bluetooth/BLE_fcc/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Bluetooth/BLE_fit/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_fit/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Bluetooth/BLE_fit/Makefile
+++ b/Examples/MAX32655/Bluetooth/BLE_fit/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Bluetooth/BLE_fit/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_fit/README.md
@@ -6,7 +6,7 @@ Refer to [BLE_fit](../../../Libraries/Cordio/docs/Applications/BLE_fit.md) docum
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 

--- a/Examples/MAX32655/Bluetooth/BLE_fit/project.mk
+++ b/Examples/MAX32655/Bluetooth/BLE_fit/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Bluetooth/BLE_fit_FreeRTOS/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_fit_FreeRTOS/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Bluetooth/BLE_fit_FreeRTOS/Makefile
+++ b/Examples/MAX32655/Bluetooth/BLE_fit_FreeRTOS/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Bluetooth/BLE_fit_FreeRTOS/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_fit_FreeRTOS/README.md
@@ -35,9 +35,9 @@ In the project.mk, changing USE_DUAL_CORE to 1 will enable using both ARM core a
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 

--- a/Examples/MAX32655/Bluetooth/BLE_fit_FreeRTOS/project.mk
+++ b/Examples/MAX32655/Bluetooth/BLE_fit_FreeRTOS/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Bluetooth/BLE_mcs/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_mcs/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Bluetooth/BLE_mcs/Makefile
+++ b/Examples/MAX32655/Bluetooth/BLE_mcs/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Bluetooth/BLE_mcs/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_mcs/README.md
@@ -8,7 +8,7 @@ Refer to the [BLE_mcs](../../../Libraries/Cordio/docs/Applications/BLE_mcs.md) d
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 * Connect a USB cable between the PC and the (USB/PWR - UART) connector.

--- a/Examples/MAX32655/Bluetooth/BLE_mcs/project.mk
+++ b/Examples/MAX32655/Bluetooth/BLE_mcs/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Bluetooth/BLE_otac/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_otac/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Bluetooth/BLE_otac/Makefile
+++ b/Examples/MAX32655/Bluetooth/BLE_otac/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Bluetooth/BLE_otac/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_otac/README.md
@@ -11,7 +11,7 @@ Refer to the [BLE_otac_otas](../../../Libraries/Cordio/docs/Applications/BLE_ota
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 * Connect a USB cable between the PC and the (USB/PWR - UART) connector.

--- a/Examples/MAX32655/Bluetooth/BLE_otac/project.mk
+++ b/Examples/MAX32655/Bluetooth/BLE_otac/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Bluetooth/BLE_otas/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_otas/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Bluetooth/BLE_otas/Makefile
+++ b/Examples/MAX32655/Bluetooth/BLE_otas/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Bluetooth/BLE_otas/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_otas/README.md
@@ -11,7 +11,7 @@ Refer to the [BLE_otac_otas](../../../Libraries/Cordio/docs/Applications/BLE_ota
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ## Required Connections
 * Connect a USB cable between the PC and the (USB/PWR - UART) connector.

--- a/Examples/MAX32655/Bluetooth/BLE_otas/project.mk
+++ b/Examples/MAX32655/Bluetooth/BLE_otas/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Bluetooth/BLE_periph/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_periph/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Bluetooth/BLE_periph/Makefile
+++ b/Examples/MAX32655/Bluetooth/BLE_periph/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Bluetooth/BLE_periph/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_periph/README.md
@@ -5,7 +5,7 @@ Refer to the [BLE_periph](../../../Libraries/Cordio/docs/Applications/BLE_periph
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 * Connect a USB cable between the PC and the (USB/PWR - UART) connector. An anteanna or wired connection can be used if SMA is available on the board. 

--- a/Examples/MAX32655/Bluetooth/BLE_periph/project.mk
+++ b/Examples/MAX32655/Bluetooth/BLE_periph/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Bluetooth/Bootloader/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/Bootloader/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Bluetooth/Bootloader/Makefile
+++ b/Examples/MAX32655/Bluetooth/Bootloader/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Bluetooth/Bootloader/README.md
+++ b/Examples/MAX32655/Bluetooth/Bootloader/README.md
@@ -35,9 +35,9 @@ The red LED will blink in the error case.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 

--- a/Examples/MAX32655/Bluetooth/Bootloader/project.mk
+++ b/Examples/MAX32655/Bluetooth/Bootloader/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Bluetooth/RF_Test/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/RF_Test/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Bluetooth/RF_Test/Makefile
+++ b/Examples/MAX32655/Bluetooth/RF_Test/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Bluetooth/RF_Test/README.md
+++ b/Examples/MAX32655/Bluetooth/RF_Test/README.md
@@ -7,11 +7,11 @@ Simple serial port console for FCC testing.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 # Usage
 

--- a/Examples/MAX32655/Bluetooth/RF_Test/project.mk
+++ b/Examples/MAX32655/Bluetooth/RF_Test/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/CRC/.vscode/README.md
+++ b/Examples/MAX32655/CRC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/CRC/Makefile
+++ b/Examples/MAX32655/CRC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/CRC/README.md
+++ b/Examples/MAX32655/CRC/README.md
@@ -7,11 +7,11 @@ This example demonstrates the use of the HW CRC calculator.  The example first g
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/CRC/project.mk
+++ b/Examples/MAX32655/CRC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Coremark/.vscode/README.md
+++ b/Examples/MAX32655/Coremark/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Coremark/Makefile
+++ b/Examples/MAX32655/Coremark/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Coremark/README.md
+++ b/Examples/MAX32655/Coremark/README.md
@@ -10,13 +10,13 @@ For more information, visit the [CoreMark webpage](https://www.eembc.org/coremar
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
 * To comply with the CoreMark rules, the only source files which are included in this example directory are the core_portme.c/.h files, the rest (including main) are located in the [Coremark](../../../Libraries/Coremark/) library.
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/Coremark/project.mk
+++ b/Examples/MAX32655/Coremark/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/DMA/.vscode/README.md
+++ b/Examples/MAX32655/DMA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/DMA/Makefile
+++ b/Examples/MAX32655/DMA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/DMA/README.md
+++ b/Examples/MAX32655/DMA/README.md
@@ -9,11 +9,11 @@ A second more complex DMA transaction is then shown that chains two memory-to-me
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/DMA/project.mk
+++ b/Examples/MAX32655/DMA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/.vscode/README.md
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/Makefile
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/README.md
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/README.md
@@ -13,11 +13,11 @@ Please refer to the App Note [The MAX32655: Why Two Cores Are Better Than One](h
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/project.mk
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/.vscode/README.md
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/Makefile
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/README.md
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/README.md
@@ -11,11 +11,11 @@ README file of project MAX32655/Dual_core_sync_arm will present more details on 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the Standard EV Kit (EvKit\_V1):

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/project.mk
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32655/EEPROM_Emulator/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32655/EEPROM_Emulator/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/EEPROM_Emulator/README.md
+++ b/Examples/MAX32655/EEPROM_Emulator/README.md
@@ -48,11 +48,11 @@ To help with syncronization, a "Ready Signal" is set up as an output from a GPIO
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/EEPROM_Emulator/project.mk
+++ b/Examples/MAX32655/EEPROM_Emulator/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/External_Flash/.vscode/README.md
+++ b/Examples/MAX32655/External_Flash/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/External_Flash/Makefile
+++ b/Examples/MAX32655/External_Flash/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/External_Flash/README.md
+++ b/Examples/MAX32655/External_Flash/README.md
@@ -10,7 +10,7 @@ The user may select between Quad and Single SPI interface modes by setting the v
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32655/External_Flash/project.mk
+++ b/Examples/MAX32655/External_Flash/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 
@@ -11,5 +11,5 @@
 
 # This example is only compatible with the MAX32655EVKIT
 ifneq ($(BOARD),EvKit_V1)
-$(error ERR_NOTSUPPORTED: This project is only supported on the MAX32655EVKIT.  (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages))
+$(error ERR_NOTSUPPORTED: This project is only supported on the MAX32655EVKIT.  (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages))
 endif

--- a/Examples/MAX32655/FTHR_I2C/.vscode/README.md
+++ b/Examples/MAX32655/FTHR_I2C/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/FTHR_I2C/Makefile
+++ b/Examples/MAX32655/FTHR_I2C/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/FTHR_I2C/README.md
+++ b/Examples/MAX32655/FTHR_I2C/README.md
@@ -9,7 +9,7 @@ This example uses I2C to cycle through the 8 colors of the RGB LED connected to 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32655/FTHR_I2C/project.mk
+++ b/Examples/MAX32655/FTHR_I2C/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 
@@ -12,5 +12,5 @@ override BOARD=FTHR_Apps_P1
 
 # This example is only compatible with the MAX32655FTHR
 ifneq ($(BOARD),FTHR_Apps_P1)
-$(error ERR_NOTSUPPORTED: This project is only supported on the MAX32655FTHR.  (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages))
+$(error ERR_NOTSUPPORTED: This project is only supported on the MAX32655FTHR.  (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages))
 endif

--- a/Examples/MAX32655/Flash/.vscode/README.md
+++ b/Examples/MAX32655/Flash/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Flash/Makefile
+++ b/Examples/MAX32655/Flash/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Flash/README.md
+++ b/Examples/MAX32655/Flash/README.md
@@ -21,11 +21,11 @@ The _second_ time the example is run the application will see the "magic" 32-bit
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32655/Flash/project.mk
+++ b/Examples/MAX32655/Flash/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32655/Flash_CLI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Flash_CLI/Makefile
+++ b/Examples/MAX32655/Flash_CLI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Flash_CLI/README.md
+++ b/Examples/MAX32655/Flash_CLI/README.md
@@ -9,11 +9,11 @@ This example demonstates the CLI commands feature of FreeRTOS, various features 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/Flash_CLI/project.mk
+++ b/Examples/MAX32655/Flash_CLI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32655/FreeRTOSDemo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32655/FreeRTOSDemo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/FreeRTOSDemo/README.md
+++ b/Examples/MAX32655/FreeRTOSDemo/README.md
@@ -7,11 +7,11 @@ A basic getting started application for FreeRTOS.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/FreeRTOSDemo/project.mk
+++ b/Examples/MAX32655/FreeRTOSDemo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/GPIO/.vscode/README.md
+++ b/Examples/MAX32655/GPIO/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/GPIO/Makefile
+++ b/Examples/MAX32655/GPIO/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/GPIO/README.md
+++ b/Examples/MAX32655/GPIO/README.md
@@ -21,11 +21,11 @@ On the Featherboard:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/GPIO/project.mk
+++ b/Examples/MAX32655/GPIO/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Hello_World-riscv/.vscode/README.md
+++ b/Examples/MAX32655/Hello_World-riscv/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Hello_World-riscv/README.md
+++ b/Examples/MAX32655/Hello_World-riscv/README.md
@@ -10,7 +10,7 @@ The ARM core initializes the RISC-V core before relinquishing control of executi
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32655/Hello_World/.vscode/README.md
+++ b/Examples/MAX32655/Hello_World/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Hello_World/Makefile
+++ b/Examples/MAX32655/Hello_World/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Hello_World/README.md
+++ b/Examples/MAX32655/Hello_World/README.md
@@ -9,11 +9,11 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/Hello_World/project.mk
+++ b/Examples/MAX32655/Hello_World/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32655/Hello_World_Cpp/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Hello_World_Cpp/Makefile
+++ b/Examples/MAX32655/Hello_World_Cpp/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Hello_World_Cpp/README.md
+++ b/Examples/MAX32655/Hello_World_Cpp/README.md
@@ -8,11 +8,11 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32655/Hello_World_Cpp/project.mk
+++ b/Examples/MAX32655/Hello_World_Cpp/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32655/I2C/.vscode/README.md
+++ b/Examples/MAX32655/I2C/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/I2C/Makefile
+++ b/Examples/MAX32655/I2C/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/I2C/README.md
+++ b/Examples/MAX32655/I2C/README.md
@@ -12,7 +12,7 @@ NOTE: This example is not supported by the MAX32655FTHR kit due to a lack of exp
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32655/I2C/project.mk
+++ b/Examples/MAX32655/I2C/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 
@@ -11,5 +11,5 @@
 
 # This example is only compatible with the MAX32655EVKIT
 ifneq ($(BOARD),EvKit_V1)
-$(error ERR_NOTSUPPORTED: This project is only supported on the MAX32655EVKIT.  (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages))
+$(error ERR_NOTSUPPORTED: This project is only supported on the MAX32655EVKIT.  (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages))
 endif

--- a/Examples/MAX32655/I2C_EEPROM/.vscode/README.md
+++ b/Examples/MAX32655/I2C_EEPROM/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/I2C_EEPROM/Makefile
+++ b/Examples/MAX32655/I2C_EEPROM/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/I2C_EEPROM/README.md
+++ b/Examples/MAX32655/I2C_EEPROM/README.md
@@ -8,11 +8,11 @@ One 24LC256 EEPROM is required to implement this example.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32655/I2C_EEPROM/project.mk
+++ b/Examples/MAX32655/I2C_EEPROM/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32655/I2C_MNGR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/I2C_MNGR/Makefile
+++ b/Examples/MAX32655/I2C_MNGR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/I2C_MNGR/README.md
+++ b/Examples/MAX32655/I2C_MNGR/README.md
@@ -12,7 +12,7 @@ NOTE: This example is not supported by the MAX32655FTHR.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32655/I2C_MNGR/project.mk
+++ b/Examples/MAX32655/I2C_MNGR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 
@@ -11,7 +11,7 @@
 
 # This example is only compatible with the MAX32655EVKIT
 ifneq ($(BOARD),EvKit_V1)
-$(error ERR_NOTSUPPORTED: This project is only supported on the MAX32655EVKIT.  (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages))
+$(error ERR_NOTSUPPORTED: This project is only supported on the MAX32655EVKIT.  (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages))
 endif
 
 # Build the FreeRTOS Library

--- a/Examples/MAX32655/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32655/I2C_SCAN/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/I2C_SCAN/Makefile
+++ b/Examples/MAX32655/I2C_SCAN/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/I2C_SCAN/README.md
+++ b/Examples/MAX32655/I2C_SCAN/README.md
@@ -8,11 +8,11 @@ Please check schematic diagram to get more information about the discovered devi
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/I2C_SCAN/project.mk
+++ b/Examples/MAX32655/I2C_SCAN/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32655/I2C_Sensor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/I2C_Sensor/Makefile
+++ b/Examples/MAX32655/I2C_Sensor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/I2C_Sensor/README.md
+++ b/Examples/MAX32655/I2C_Sensor/README.md
@@ -10,7 +10,7 @@ NOTE: This example is only supported on the MAX32655EVKIT.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32655/I2C_Sensor/project.mk
+++ b/Examples/MAX32655/I2C_Sensor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 
@@ -11,7 +11,7 @@
 
 # This example is only compatible with the MAX32655EVKIT
 ifneq ($(BOARD),EvKit_V1)
-$(error ERR_NOTSUPPORTED: This project is only supported on the MAX32655EVKIT.  (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages))
+$(error ERR_NOTSUPPORTED: This project is only supported on the MAX32655EVKIT.  (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages))
 endif
 
 # Include temperature sensor driver

--- a/Examples/MAX32655/I2C_Sensor_ADT7420/.vscode/README.md
+++ b/Examples/MAX32655/I2C_Sensor_ADT7420/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/I2C_Sensor_ADT7420/Makefile
+++ b/Examples/MAX32655/I2C_Sensor_ADT7420/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/I2C_Sensor_ADT7420/README.md
+++ b/Examples/MAX32655/I2C_Sensor_ADT7420/README.md
@@ -10,7 +10,7 @@ NOTE: This example is only supported on the MAX32655EVKIT.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32655/I2C_Sensor_ADT7420/project.mk
+++ b/Examples/MAX32655/I2C_Sensor_ADT7420/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 
@@ -11,7 +11,7 @@
 
 # This example is only compatible with the MAX32655EVKIT
 ifneq ($(BOARD),EvKit_V1)
-$(error ERR_NOTSUPPORTED: This project is only supported on the MAX32655EVKIT.  (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages))
+$(error ERR_NOTSUPPORTED: This project is only supported on the MAX32655EVKIT.  (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages))
 endif
 
 # Include temperature sensor driver

--- a/Examples/MAX32655/I2S/.vscode/README.md
+++ b/Examples/MAX32655/I2S/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/I2S/Makefile
+++ b/Examples/MAX32655/I2S/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/I2S/README.md
+++ b/Examples/MAX32655/I2S/README.md
@@ -7,11 +7,11 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32655/I2S/project.mk
+++ b/Examples/MAX32655/I2S/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/I2S_Playback/.vscode/README.md
+++ b/Examples/MAX32655/I2S_Playback/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/I2S_Playback/Makefile
+++ b/Examples/MAX32655/I2S_Playback/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/I2S_Playback/README.md
+++ b/Examples/MAX32655/I2S_Playback/README.md
@@ -10,11 +10,11 @@ After the recording has finished the audio will begin playing after a 3 second d
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32655/I2S_Playback/project.mk
+++ b/Examples/MAX32655/I2S_Playback/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/ICC/.vscode/README.md
+++ b/Examples/MAX32655/ICC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/ICC/Makefile
+++ b/Examples/MAX32655/ICC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/ICC/README.md
+++ b/Examples/MAX32655/ICC/README.md
@@ -12,11 +12,11 @@ This example demonstrates the time differences when running code with the instru
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX32655/ICC/project.mk
+++ b/Examples/MAX32655/ICC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/LP/.vscode/README.md
+++ b/Examples/MAX32655/LP/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/LP/Makefile
+++ b/Examples/MAX32655/LP/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/LP/README.md
+++ b/Examples/MAX32655/LP/README.md
@@ -10,11 +10,11 @@ Users may also select whether they want to use a GPIO or RTC wakeup source. To u
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/LP/project.mk
+++ b/Examples/MAX32655/LP/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/LPCMP/.vscode/README.md
+++ b/Examples/MAX32655/LPCMP/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/LPCMP/Makefile
+++ b/Examples/MAX32655/LPCMP/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/LPCMP/README.md
+++ b/Examples/MAX32655/LPCMP/README.md
@@ -9,11 +9,11 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/LPCMP/project.mk
+++ b/Examples/MAX32655/LPCMP/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Library_Generate/.vscode/README.md
+++ b/Examples/MAX32655/Library_Generate/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
   * If it's not in the README, check the UG.
   * If it's not in the UG, open a ticket!
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
@@ -31,7 +31,7 @@ The following features are supported:
 
 The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.analog.com/en/education/education-library/videos/6313212752112.html).
 
-1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
     * [Windows](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0010820A)
     * [Linux (Ubuntu)](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018720A)
     * [MacOS](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018610A)

--- a/Examples/MAX32655/Library_Generate/Makefile
+++ b/Examples/MAX32655/Library_Generate/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Library_Generate/README.md
+++ b/Examples/MAX32655/Library_Generate/README.md
@@ -9,7 +9,7 @@ Check the Library_Use demo to see how to link static libraries to an application
 
 ### Project Usage
 
-Universal instructions on building this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32655/Library_Generate/project.mk
+++ b/Examples/MAX32655/Library_Generate/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
  
 # **********************************************************
 

--- a/Examples/MAX32655/Library_Use/.vscode/README.md
+++ b/Examples/MAX32655/Library_Use/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Library_Use/Makefile
+++ b/Examples/MAX32655/Library_Use/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Library_Use/README.md
+++ b/Examples/MAX32655/Library_Use/README.md
@@ -9,11 +9,11 @@ to project.mk to see how to include ".a" static library files into your project.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-This example supports all available MAX32655 evaluation platforms but comes _pre-configured_ for the MAX32655EVKIT by default. See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
+This example supports all available MAX32655 evaluation platforms but comes _pre-configured_ for the MAX32655EVKIT by default. See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
 
 ## Required Connections
 

--- a/Examples/MAX32655/Library_Use/project.mk
+++ b/Examples/MAX32655/Library_Use/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Pulse_Train/.vscode/README.md
+++ b/Examples/MAX32655/Pulse_Train/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Pulse_Train/Makefile
+++ b/Examples/MAX32655/Pulse_Train/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Pulse_Train/README.md
+++ b/Examples/MAX32655/Pulse_Train/README.md
@@ -19,11 +19,11 @@ On the Featherboard:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/Pulse_Train/project.mk
+++ b/Examples/MAX32655/Pulse_Train/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/RTC/.vscode/README.md
+++ b/Examples/MAX32655/RTC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/RTC/Makefile
+++ b/Examples/MAX32655/RTC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/RTC/README.md
+++ b/Examples/MAX32655/RTC/README.md
@@ -25,11 +25,11 @@ On the Featherboard:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/RTC/project.mk
+++ b/Examples/MAX32655/RTC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX32655/RTC_Backup/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/RTC_Backup/Makefile
+++ b/Examples/MAX32655/RTC_Backup/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/RTC_Backup/README.md
+++ b/Examples/MAX32655/RTC_Backup/README.md
@@ -8,11 +8,11 @@ The RTC time-of-day alarm is used to wake the device from backup mode every TIME
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/RTC_Backup/project.mk
+++ b/Examples/MAX32655/RTC_Backup/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/RV_ARM_Loader/.vscode/README.md
+++ b/Examples/MAX32655/RV_ARM_Loader/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/RV_ARM_Loader/Makefile
+++ b/Examples/MAX32655/RV_ARM_Loader/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/RV_ARM_Loader/README.md
+++ b/Examples/MAX32655/RV_ARM_Loader/README.md
@@ -8,7 +8,7 @@ RV_ARM_Loader runs on the ARM core to load the RISCV code space, setup the RISCV
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32655/RV_ARM_Loader/project.mk
+++ b/Examples/MAX32655/RV_ARM_Loader/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/SPI/.vscode/README.md
+++ b/Examples/MAX32655/SPI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/SPI/Makefile
+++ b/Examples/MAX32655/SPI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/SPI/README.md
+++ b/Examples/MAX32655/SPI/README.md
@@ -12,11 +12,11 @@ By default, the example performs blocking SPI transactions.  To switch to non-bl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/SPI/project.mk
+++ b/Examples/MAX32655/SPI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/TFT_Demo/.vscode/README.md
+++ b/Examples/MAX32655/TFT_Demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/TFT_Demo/Makefile
+++ b/Examples/MAX32655/TFT_Demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/TFT_Demo/README.md
+++ b/Examples/MAX32655/TFT_Demo/README.md
@@ -6,7 +6,7 @@ This examples demonstrates the use of the TFT display and the touchscreen contro
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32655/TFT_Demo/project.mk
+++ b/Examples/MAX32655/TFT_Demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/TMR/.vscode/README.md
+++ b/Examples/MAX32655/TMR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/TMR/Makefile
+++ b/Examples/MAX32655/TMR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/TMR/README.md
+++ b/Examples/MAX32655/TMR/README.md
@@ -25,11 +25,11 @@ On the Featherboard:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/TMR/project.mk
+++ b/Examples/MAX32655/TMR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/TRNG/.vscode/README.md
+++ b/Examples/MAX32655/TRNG/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/TRNG/Makefile
+++ b/Examples/MAX32655/TRNG/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/TRNG/README.md
+++ b/Examples/MAX32655/TRNG/README.md
@@ -6,11 +6,11 @@ The true random number generator (TRNG) hardware is exercised in this example.  
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/TRNG/project.mk
+++ b/Examples/MAX32655/TRNG/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32655/Temp_Monitor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Temp_Monitor/Makefile
+++ b/Examples/MAX32655/Temp_Monitor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Temp_Monitor/README.md
+++ b/Examples/MAX32655/Temp_Monitor/README.md
@@ -16,7 +16,7 @@ NOTE: This example is only supported by the MAX32655EVKIT.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32655/Temp_Monitor/project.mk
+++ b/Examples/MAX32655/Temp_Monitor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 
@@ -11,7 +11,7 @@
 
 # This example is only compatible with the MAX32655EVKIT
 ifneq ($(BOARD),EvKit_V1)
-$(error ERR_NOTSUPPORTED: This project is only supported on the MAX32655EVKIT.  (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages))
+$(error ERR_NOTSUPPORTED: This project is only supported on the MAX32655EVKIT.  (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages))
 endif
 
 # Include MAX31889 drivers from MiscDrivers library.

--- a/Examples/MAX32655/UART/.vscode/README.md
+++ b/Examples/MAX32655/UART/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/UART/Makefile
+++ b/Examples/MAX32655/UART/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/UART/README.md
+++ b/Examples/MAX32655/UART/README.md
@@ -6,7 +6,7 @@ This application uses two serial ports to send and receive data.  One serial por
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32655/UART/project.mk
+++ b/Examples/MAX32655/UART/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 
@@ -11,5 +11,5 @@
 
 # This example is only compatible with the MAX32655EVKIT
 ifneq ($(BOARD),EvKit_V1)
-$(error ERR_NOTSUPPORTED: This project is only supported on the MAX32655EVKIT.  (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages))
+$(error ERR_NOTSUPPORTED: This project is only supported on the MAX32655EVKIT.  (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages))
 endif

--- a/Examples/MAX32655/UCL/README.md
+++ b/Examples/MAX32655/UCL/README.md
@@ -9,11 +9,11 @@ TODO:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ### Required Connections
 If using the Standard EV Kit (EvKit\_V1):

--- a/Examples/MAX32655/UCL/project.mk
+++ b/Examples/MAX32655/UCL/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/WUT/.vscode/README.md
+++ b/Examples/MAX32655/WUT/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/WUT/Makefile
+++ b/Examples/MAX32655/WUT/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/WUT/README.md
+++ b/Examples/MAX32655/WUT/README.md
@@ -11,11 +11,11 @@ On the MAX32655FTHR:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/WUT/project.mk
+++ b/Examples/MAX32655/WUT/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/Watchdog/.vscode/README.md
+++ b/Examples/MAX32655/Watchdog/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/Watchdog/Makefile
+++ b/Examples/MAX32655/Watchdog/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/Watchdog/README.md
+++ b/Examples/MAX32655/Watchdog/README.md
@@ -20,11 +20,11 @@ On the Featherboard:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 If using the MAX32655EVKIT (EvKit\_V1):

--- a/Examples/MAX32655/Watchdog/project.mk
+++ b/Examples/MAX32655/Watchdog/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32655/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32655/WearLeveling/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32655/WearLeveling/Makefile
+++ b/Examples/MAX32655/WearLeveling/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32655/WearLeveling/README.md
+++ b/Examples/MAX32655/WearLeveling/README.md
@@ -15,11 +15,11 @@ Enter "help" in the command line to see more details on the usage of each of the
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32655/WearLeveling/project.mk
+++ b/Examples/MAX32655/WearLeveling/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32660/ARM-DSP/README.md
+++ b/Examples/MAX32660/ARM-DSP/README.md
@@ -14,7 +14,7 @@ Development with Visual Studio Code is also supported.  See [VSCode-Maxim](https
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_bayes_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/ARM-DSP/arm_bayes_example/project.mk
+++ b/Examples/MAX32660/ARM-DSP/arm_bayes_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_class_marks_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/ARM-DSP/arm_class_marks_example/project.mk
+++ b/Examples/MAX32660/ARM-DSP/arm_class_marks_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_convolution_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/ARM-DSP/arm_convolution_example/project.mk
+++ b/Examples/MAX32660/ARM-DSP/arm_convolution_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/ARM-DSP/arm_dotproduct_example_f32/project.mk
+++ b/Examples/MAX32660/ARM-DSP/arm_dotproduct_example_f32/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_fft_bin_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/ARM-DSP/arm_fft_bin_example/project.mk
+++ b/Examples/MAX32660/ARM-DSP/arm_fft_bin_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_fir_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/ARM-DSP/arm_fir_example/project.mk
+++ b/Examples/MAX32660/ARM-DSP/arm_fir_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/ARM-DSP/arm_graphic_equalizer_example/project.mk
+++ b/Examples/MAX32660/ARM-DSP/arm_graphic_equalizer_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_linear_interp_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/ARM-DSP/arm_linear_interp_example/project.mk
+++ b/Examples/MAX32660/ARM-DSP/arm_linear_interp_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_matrix_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/ARM-DSP/arm_matrix_example/project.mk
+++ b/Examples/MAX32660/ARM-DSP/arm_matrix_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_signal_converge_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/ARM-DSP/arm_signal_converge_example/project.mk
+++ b/Examples/MAX32660/ARM-DSP/arm_signal_converge_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_sin_cos_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/ARM-DSP/arm_sin_cos_example/project.mk
+++ b/Examples/MAX32660/ARM-DSP/arm_sin_cos_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_svm_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/ARM-DSP/arm_svm_example/project.mk
+++ b/Examples/MAX32660/ARM-DSP/arm_svm_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_variance_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/ARM-DSP/arm_variance_example/project.mk
+++ b/Examples/MAX32660/ARM-DSP/arm_variance_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/Bootloader_Host/.vscode/README.md
+++ b/Examples/MAX32660/Bootloader_Host/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/Bootloader_Host/Makefile
+++ b/Examples/MAX32660/Bootloader_Host/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/Bootloader_Host/README.md
+++ b/Examples/MAX32660/Bootloader_Host/README.md
@@ -23,7 +23,7 @@ flash based bootloader. It is designed to easily be ported on any micro.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/Bootloader_Host/project.mk
+++ b/Examples/MAX32660/Bootloader_Host/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/Coremark/.vscode/README.md
+++ b/Examples/MAX32660/Coremark/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/Coremark/Makefile
+++ b/Examples/MAX32660/Coremark/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/Coremark/README.md
+++ b/Examples/MAX32660/Coremark/README.md
@@ -10,7 +10,7 @@ For more information, visit the [CoreMark webpage](https://www.eembc.org/coremar
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/Coremark/project.mk
+++ b/Examples/MAX32660/Coremark/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32660/DMA/.vscode/README.md
+++ b/Examples/MAX32660/DMA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/DMA/Makefile
+++ b/Examples/MAX32660/DMA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/DMA/README.md
+++ b/Examples/MAX32660/DMA/README.md
@@ -9,7 +9,7 @@ A second more complex memory-to-memory DMA transaction is then shown that chains
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/DMA/project.mk
+++ b/Examples/MAX32660/DMA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32660/EEPROM_Emulator/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32660/EEPROM_Emulator/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/EEPROM_Emulator/README.md
+++ b/Examples/MAX32660/EEPROM_Emulator/README.md
@@ -48,7 +48,7 @@ To help with syncronization, a "Ready Signal" is set up as an output from a GPIO
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/EEPROM_Emulator/project.mk
+++ b/Examples/MAX32660/EEPROM_Emulator/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32660/Flash/.vscode/README.md
+++ b/Examples/MAX32660/Flash/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/Flash/Makefile
+++ b/Examples/MAX32660/Flash/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/Flash/README.md
+++ b/Examples/MAX32660/Flash/README.md
@@ -21,7 +21,7 @@ The _second_ time the example is run the application will see the "magic" 32-bit
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
@@ -29,7 +29,7 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ## Building and Running
 
-**See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
+**See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
 
 ## Hardware Connections
 

--- a/Examples/MAX32660/Flash/project.mk
+++ b/Examples/MAX32660/Flash/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32660/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32660/Flash_CLI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/Flash_CLI/Makefile
+++ b/Examples/MAX32660/Flash_CLI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/Flash_CLI/README.md
+++ b/Examples/MAX32660/Flash_CLI/README.md
@@ -9,7 +9,7 @@ This example demonstates the CLI commands feature of FreeRTOS and various featur
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/Flash_CLI/project.mk
+++ b/Examples/MAX32660/Flash_CLI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32660/FreeRTOSDemo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32660/FreeRTOSDemo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/FreeRTOSDemo/README.md
+++ b/Examples/MAX32660/FreeRTOSDemo/README.md
@@ -7,7 +7,7 @@ A basic getting started application for FreeRTOS.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/FreeRTOSDemo/project.mk
+++ b/Examples/MAX32660/FreeRTOSDemo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/GPIO/.vscode/README.md
+++ b/Examples/MAX32660/GPIO/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/GPIO/Makefile
+++ b/Examples/MAX32660/GPIO/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/GPIO/README.md
+++ b/Examples/MAX32660/GPIO/README.md
@@ -9,7 +9,7 @@ P0.11 is continuously scanned and whatever value is read on that pin is then out
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/GPIO/project.mk
+++ b/Examples/MAX32660/GPIO/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/Hello_World/.vscode/README.md
+++ b/Examples/MAX32660/Hello_World/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/Hello_World/Makefile
+++ b/Examples/MAX32660/Hello_World/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/Hello_World/README.md
+++ b/Examples/MAX32660/Hello_World/README.md
@@ -9,7 +9,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/Hello_World/project.mk
+++ b/Examples/MAX32660/Hello_World/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32660/Hello_World_Cpp/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/Hello_World_Cpp/Makefile
+++ b/Examples/MAX32660/Hello_World_Cpp/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/Hello_World_Cpp/README.md
+++ b/Examples/MAX32660/Hello_World_Cpp/README.md
@@ -8,7 +8,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/Hello_World_Cpp/project.mk
+++ b/Examples/MAX32660/Hello_World_Cpp/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32660/I2C/.vscode/README.md
+++ b/Examples/MAX32660/I2C/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/I2C/Makefile
+++ b/Examples/MAX32660/I2C/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/I2C/README.md
+++ b/Examples/MAX32660/I2C/README.md
@@ -7,7 +7,7 @@ This example uses the I2C Master to read/write from/to the I2C Slave.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/I2C/project.mk
+++ b/Examples/MAX32660/I2C/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32660/I2C_MNGR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/I2C_MNGR/Makefile
+++ b/Examples/MAX32660/I2C_MNGR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/I2C_MNGR/README.md
+++ b/Examples/MAX32660/I2C_MNGR/README.md
@@ -11,7 +11,7 @@ You may change the configuration of each EEPROM's I2C transaction parameters (sl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/I2C_MNGR/project.mk
+++ b/Examples/MAX32660/I2C_MNGR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32660/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32660/I2C_SCAN/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/I2C_SCAN/Makefile
+++ b/Examples/MAX32660/I2C_SCAN/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/I2C_SCAN/README.md
+++ b/Examples/MAX32660/I2C_SCAN/README.md
@@ -6,7 +6,7 @@ This example uses the I2C Master to find the addresses of any I2C Slave devices 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/I2C_SCAN/project.mk
+++ b/Examples/MAX32660/I2C_SCAN/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32660/I2C_Sensor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/I2C_Sensor/Makefile
+++ b/Examples/MAX32660/I2C_Sensor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/I2C_Sensor/README.md
+++ b/Examples/MAX32660/I2C_Sensor/README.md
@@ -9,7 +9,7 @@ After initialization, a new reading is printed to the terminal every second.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/I2C_Sensor/project.mk
+++ b/Examples/MAX32660/I2C_Sensor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32660/I2S/.vscode/README.md
+++ b/Examples/MAX32660/I2S/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/I2S/Makefile
+++ b/Examples/MAX32660/I2S/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/I2S/README.md
+++ b/Examples/MAX32660/I2S/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/I2S/project.mk
+++ b/Examples/MAX32660/I2S/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/ICC/.vscode/README.md
+++ b/Examples/MAX32660/ICC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/ICC/Makefile
+++ b/Examples/MAX32660/ICC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/ICC/README.md
+++ b/Examples/MAX32660/ICC/README.md
@@ -12,7 +12,7 @@ This example demonstrates the time differences when running code with the instru
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/ICC/project.mk
+++ b/Examples/MAX32660/ICC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/Info_Block_Usecase/.vscode/README.md
+++ b/Examples/MAX32660/Info_Block_Usecase/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/Info_Block_Usecase/Makefile
+++ b/Examples/MAX32660/Info_Block_Usecase/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/Info_Block_Usecase/README.md
+++ b/Examples/MAX32660/Info_Block_Usecase/README.md
@@ -14,7 +14,7 @@ For more information please check MAX32660 User Guide
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/Info_Block_Usecase/project.mk
+++ b/Examples/MAX32660/Info_Block_Usecase/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/LP/.vscode/README.md
+++ b/Examples/MAX32660/LP/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/LP/Makefile
+++ b/Examples/MAX32660/LP/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/LP/README.md
+++ b/Examples/MAX32660/LP/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/LP/project.mk
+++ b/Examples/MAX32660/LP/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/Library_Generate/.vscode/README.md
+++ b/Examples/MAX32660/Library_Generate/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
   * If it's not in the README, check the UG.
   * If it's not in the UG, open a ticket!
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
@@ -31,7 +31,7 @@ The following features are supported:
 
 The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.analog.com/en/education/education-library/videos/6313212752112.html).
 
-1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
     * [Windows](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0010820A)
     * [Linux (Ubuntu)](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018720A)
     * [MacOS](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018610A)

--- a/Examples/MAX32660/Library_Generate/Makefile
+++ b/Examples/MAX32660/Library_Generate/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/Library_Generate/README.md
+++ b/Examples/MAX32660/Library_Generate/README.md
@@ -9,7 +9,7 @@ Check the Library_Use demo to see how to link static libraries to an application
 
 ### Project Usage
 
-Universal instructions on building this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/Library_Generate/project.mk
+++ b/Examples/MAX32660/Library_Generate/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
  
 # **********************************************************
 

--- a/Examples/MAX32660/Library_Use/.vscode/README.md
+++ b/Examples/MAX32660/Library_Use/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/Library_Use/Makefile
+++ b/Examples/MAX32660/Library_Use/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/Library_Use/README.md
+++ b/Examples/MAX32660/Library_Use/README.md
@@ -9,7 +9,7 @@ to project.mk to see how to include ".a" static library files into your project.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/Library_Use/project.mk
+++ b/Examples/MAX32660/Library_Use/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32660/RTC/.vscode/README.md
+++ b/Examples/MAX32660/RTC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/RTC/Makefile
+++ b/Examples/MAX32660/RTC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/RTC/README.md
+++ b/Examples/MAX32660/RTC/README.md
@@ -12,7 +12,7 @@ The time-of-day alarm is then rearmed for another 10 sec.  Pressing PB1 will out
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/RTC/project.mk
+++ b/Examples/MAX32660/RTC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX32660/RTC_Backup/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/RTC_Backup/Makefile
+++ b/Examples/MAX32660/RTC_Backup/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/RTC_Backup/README.md
+++ b/Examples/MAX32660/RTC_Backup/README.md
@@ -10,7 +10,7 @@ The RTC time-of-day alarm is used to wake the device from backup mode every TIME
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/RTC_Backup/project.mk
+++ b/Examples/MAX32660/RTC_Backup/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/SPI/.vscode/README.md
+++ b/Examples/MAX32660/SPI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/SPI/Makefile
+++ b/Examples/MAX32660/SPI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/SPI/README.md
+++ b/Examples/MAX32660/SPI/README.md
@@ -12,7 +12,7 @@ By default, the example performs blocking SPI transactions.  To switch to non-bl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/SPI/project.mk
+++ b/Examples/MAX32660/SPI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/SPIMSS/.vscode/README.md
+++ b/Examples/MAX32660/SPIMSS/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/SPIMSS/Makefile
+++ b/Examples/MAX32660/SPIMSS/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/SPIMSS/README.md
+++ b/Examples/MAX32660/SPIMSS/README.md
@@ -10,7 +10,7 @@ Multiple word sizes (2 through 16 bits) are demonstrated.  To switch to non-bloc
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/SPIMSS/project.mk
+++ b/Examples/MAX32660/SPIMSS/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/SPIMSS_DMA/.vscode/README.md
+++ b/Examples/MAX32660/SPIMSS_DMA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/SPIMSS_DMA/Makefile
+++ b/Examples/MAX32660/SPIMSS_DMA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/SPIMSS_DMA/README.md
+++ b/Examples/MAX32660/SPIMSS_DMA/README.md
@@ -7,7 +7,7 @@ MISO (P0.10) pins.  Connect these two pins together.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/SPIMSS_DMA/project.mk
+++ b/Examples/MAX32660/SPIMSS_DMA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the

--- a/Examples/MAX32660/SPI_MasterSlave/.vscode/README.md
+++ b/Examples/MAX32660/SPI_MasterSlave/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/SPI_MasterSlave/Makefile
+++ b/Examples/MAX32660/SPI_MasterSlave/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/SPI_MasterSlave/README.md
+++ b/Examples/MAX32660/SPI_MasterSlave/README.md
@@ -11,7 +11,7 @@ Once the master ends the transaction, the data received by the master and the sl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/SPI_MasterSlave/project.mk
+++ b/Examples/MAX32660/SPI_MasterSlave/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32660/SecureROM_BL_Host/.vscode/README.md
+++ b/Examples/MAX32660/SecureROM_BL_Host/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/SecureROM_BL_Host/Makefile
+++ b/Examples/MAX32660/SecureROM_BL_Host/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/SecureROM_BL_Host/README.md
+++ b/Examples/MAX32660/SecureROM_BL_Host/README.md
@@ -22,7 +22,7 @@ Please check:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/SecureROM_BL_Host/project.mk
+++ b/Examples/MAX32660/SecureROM_BL_Host/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 
 # **********************************************************

--- a/Examples/MAX32660/SecureROM_BL_Host/script/README.md
+++ b/Examples/MAX32660/SecureROM_BL_Host/script/README.md
@@ -9,7 +9,7 @@ then each packet array will linked with a C structure.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/TMR/.vscode/README.md
+++ b/Examples/MAX32660/TMR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/TMR/Makefile
+++ b/Examples/MAX32660/TMR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/TMR/README.md
+++ b/Examples/MAX32660/TMR/README.md
@@ -13,7 +13,7 @@ Push PB1 to start the PWM and continuous timer and PB2 to start the oneshot time
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/TMR/project.mk
+++ b/Examples/MAX32660/TMR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32660/Temp_Monitor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/Temp_Monitor/Makefile
+++ b/Examples/MAX32660/Temp_Monitor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/Temp_Monitor/README.md
+++ b/Examples/MAX32660/Temp_Monitor/README.md
@@ -15,7 +15,7 @@ The temperature limits, flash storage page, and RTC time-of-day alarm period are
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/Temp_Monitor/project.mk
+++ b/Examples/MAX32660/Temp_Monitor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32660/UART/.vscode/README.md
+++ b/Examples/MAX32660/UART/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/UART/Makefile
+++ b/Examples/MAX32660/UART/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/UART/README.md
+++ b/Examples/MAX32660/UART/README.md
@@ -7,7 +7,7 @@ This application uses two serial ports to send and receive data.  One serial por
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/UART/project.mk
+++ b/Examples/MAX32660/UART/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/UART_Wakeup/.vscode/README.md
+++ b/Examples/MAX32660/UART_Wakeup/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/UART_Wakeup/Makefile
+++ b/Examples/MAX32660/UART_Wakeup/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/UART_Wakeup/project.mk
+++ b/Examples/MAX32660/UART_Wakeup/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/Watchdog/.vscode/README.md
+++ b/Examples/MAX32660/Watchdog/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/Watchdog/Makefile
+++ b/Examples/MAX32660/Watchdog/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/Watchdog/README.md
+++ b/Examples/MAX32660/Watchdog/README.md
@@ -11,7 +11,7 @@ When the application begins, it initializes and starts the watchdog timer.  The 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32660/Watchdog/project.mk
+++ b/Examples/MAX32660/Watchdog/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32660/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32660/WearLeveling/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32660/WearLeveling/Makefile
+++ b/Examples/MAX32660/WearLeveling/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32660/WearLeveling/README.md
+++ b/Examples/MAX32660/WearLeveling/README.md
@@ -15,11 +15,11 @@ Enter "help" in the command line to see more details on the usage of each of the
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32660EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX32660EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32660/WearLeveling/project.mk
+++ b/Examples/MAX32660/WearLeveling/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32662/ADC/.vscode/README.md
+++ b/Examples/MAX32662/ADC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/ADC/Makefile
+++ b/Examples/MAX32662/ADC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/ADC/README.md
+++ b/Examples/MAX32662/ADC/README.md
@@ -11,7 +11,7 @@ Additionally the trigger source that starts the ADC conversion can be selected a
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/ADC/project.mk
+++ b/Examples/MAX32662/ADC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/ARM-DSP/README.md
+++ b/Examples/MAX32662/ARM-DSP/README.md
@@ -14,7 +14,7 @@ Development with Visual Studio Code is also supported.  See [VSCode-Maxim](https
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_bayes_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/ARM-DSP/arm_bayes_example/project.mk
+++ b/Examples/MAX32662/ARM-DSP/arm_bayes_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32662/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_class_marks_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/ARM-DSP/arm_class_marks_example/project.mk
+++ b/Examples/MAX32662/ARM-DSP/arm_class_marks_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32662/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_convolution_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/ARM-DSP/arm_convolution_example/project.mk
+++ b/Examples/MAX32662/ARM-DSP/arm_convolution_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32662/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/ARM-DSP/arm_dotproduct_example_f32/project.mk
+++ b/Examples/MAX32662/ARM-DSP/arm_dotproduct_example_f32/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32662/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_fft_bin_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/ARM-DSP/arm_fft_bin_example/project.mk
+++ b/Examples/MAX32662/ARM-DSP/arm_fft_bin_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32662/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_fir_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/ARM-DSP/arm_fir_example/project.mk
+++ b/Examples/MAX32662/ARM-DSP/arm_fir_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32662/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/ARM-DSP/arm_graphic_equalizer_example/project.mk
+++ b/Examples/MAX32662/ARM-DSP/arm_graphic_equalizer_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32662/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_linear_interp_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/ARM-DSP/arm_linear_interp_example/project.mk
+++ b/Examples/MAX32662/ARM-DSP/arm_linear_interp_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32662/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_matrix_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/ARM-DSP/arm_matrix_example/project.mk
+++ b/Examples/MAX32662/ARM-DSP/arm_matrix_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32662/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_signal_converge_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/ARM-DSP/arm_signal_converge_example/project.mk
+++ b/Examples/MAX32662/ARM-DSP/arm_signal_converge_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32662/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_sin_cos_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/ARM-DSP/arm_sin_cos_example/project.mk
+++ b/Examples/MAX32662/ARM-DSP/arm_sin_cos_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32662/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_svm_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/ARM-DSP/arm_svm_example/project.mk
+++ b/Examples/MAX32662/ARM-DSP/arm_svm_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32662/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_variance_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/ARM-DSP/arm_variance_example/project.mk
+++ b/Examples/MAX32662/ARM-DSP/arm_variance_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32662/Bootloader_Host/.vscode/README.md
+++ b/Examples/MAX32662/Bootloader_Host/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/Bootloader_Host/Makefile
+++ b/Examples/MAX32662/Bootloader_Host/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/Bootloader_Host/README.md
+++ b/Examples/MAX32662/Bootloader_Host/README.md
@@ -23,7 +23,7 @@ flash based bootloader. It is designed to easily be ported on any micro.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/Bootloader_Host/project.mk
+++ b/Examples/MAX32662/Bootloader_Host/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/CAN/.vscode/README.md
+++ b/Examples/MAX32662/CAN/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/CAN/Makefile
+++ b/Examples/MAX32662/CAN/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/CAN/README.md
+++ b/Examples/MAX32662/CAN/README.md
@@ -9,7 +9,7 @@ Connect CAN signals on header JH3 to CAN bus.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/CAN/project.mk
+++ b/Examples/MAX32662/CAN/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/Coremark/.vscode/README.md
+++ b/Examples/MAX32662/Coremark/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/Coremark/Makefile
+++ b/Examples/MAX32662/Coremark/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/Coremark/README.md
+++ b/Examples/MAX32662/Coremark/README.md
@@ -10,7 +10,7 @@ For more information, visit the [CoreMark webpage](https://www.eembc.org/coremar
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/Coremark/project.mk
+++ b/Examples/MAX32662/Coremark/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/DMA/.vscode/README.md
+++ b/Examples/MAX32662/DMA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/DMA/Makefile
+++ b/Examples/MAX32662/DMA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/DMA/README.md
+++ b/Examples/MAX32662/DMA/README.md
@@ -9,7 +9,7 @@ The first example does just as described above, a single DMA transaction that co
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/DMA/project.mk
+++ b/Examples/MAX32662/DMA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/Demo/.vscode/README.md
+++ b/Examples/MAX32662/Demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/Demo/Makefile
+++ b/Examples/MAX32662/Demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/Demo/README.md
+++ b/Examples/MAX32662/Demo/README.md
@@ -12,7 +12,7 @@ Features:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/Demo/project.mk
+++ b/Examples/MAX32662/Demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32662/EEPROM_Emulator/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32662/EEPROM_Emulator/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/EEPROM_Emulator/README.md
+++ b/Examples/MAX32662/EEPROM_Emulator/README.md
@@ -48,7 +48,7 @@ To help with syncronization, a "Ready Signal" is set up as an output from a GPIO
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/EEPROM_Emulator/project.mk
+++ b/Examples/MAX32662/EEPROM_Emulator/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/Flash/.vscode/README.md
+++ b/Examples/MAX32662/Flash/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/Flash/Makefile
+++ b/Examples/MAX32662/Flash/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/Flash/README.md
+++ b/Examples/MAX32662/Flash/README.md
@@ -21,7 +21,7 @@ The _second_ time the example is run the application will see the "magic" 32-bit
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
@@ -37,7 +37,7 @@ MAX32662EVKIT:
 
 ## Building and Running
 
-**See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
+**See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
 
 ## Expected Output
 

--- a/Examples/MAX32662/Flash/project.mk
+++ b/Examples/MAX32662/Flash/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32662/Flash_CLI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/Flash_CLI/Makefile
+++ b/Examples/MAX32662/Flash_CLI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/Flash_CLI/README.md
+++ b/Examples/MAX32662/Flash_CLI/README.md
@@ -9,7 +9,7 @@ This example demonstates the CLI commands feature of FreeRTOS and various featur
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/Flash_CLI/project.mk
+++ b/Examples/MAX32662/Flash_CLI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/GPIO/.vscode/README.md
+++ b/Examples/MAX32662/GPIO/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/GPIO/Makefile
+++ b/Examples/MAX32662/GPIO/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/GPIO/README.md
+++ b/Examples/MAX32662/GPIO/README.md
@@ -9,7 +9,7 @@ P0.04 is continuously scanned and whatever value is read on that pin is then out
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/GPIO/project.mk
+++ b/Examples/MAX32662/GPIO/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/Hello_World/.vscode/README.md
+++ b/Examples/MAX32662/Hello_World/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/Hello_World/Makefile
+++ b/Examples/MAX32662/Hello_World/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/Hello_World/README.md
+++ b/Examples/MAX32662/Hello_World/README.md
@@ -9,7 +9,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/Hello_World/project.mk
+++ b/Examples/MAX32662/Hello_World/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32662/Hello_World_Cpp/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/Hello_World_Cpp/Makefile
+++ b/Examples/MAX32662/Hello_World_Cpp/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/Hello_World_Cpp/README.md
+++ b/Examples/MAX32662/Hello_World_Cpp/README.md
@@ -8,7 +8,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/Hello_World_Cpp/project.mk
+++ b/Examples/MAX32662/Hello_World_Cpp/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32662/I2C/.vscode/README.md
+++ b/Examples/MAX32662/I2C/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/I2C/Makefile
+++ b/Examples/MAX32662/I2C/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/I2C/README.md
+++ b/Examples/MAX32662/I2C/README.md
@@ -7,7 +7,7 @@ This example uses the I2C Master to read/write from/to the I2C Slave.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/I2C/project.mk
+++ b/Examples/MAX32662/I2C/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32662/I2C_MNGR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/I2C_MNGR/Makefile
+++ b/Examples/MAX32662/I2C_MNGR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/I2C_MNGR/README.md
+++ b/Examples/MAX32662/I2C_MNGR/README.md
@@ -11,7 +11,7 @@ You may change the configuration of each EEPROM's I2C transaction parameters (sl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/I2C_MNGR/project.mk
+++ b/Examples/MAX32662/I2C_MNGR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32662/I2C_SCAN/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/I2C_SCAN/Makefile
+++ b/Examples/MAX32662/I2C_SCAN/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/I2C_SCAN/README.md
+++ b/Examples/MAX32662/I2C_SCAN/README.md
@@ -6,7 +6,7 @@ This example uses the I2C Master to find the addresses of any I2C Slave devices 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/I2C_SCAN/project.mk
+++ b/Examples/MAX32662/I2C_SCAN/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32662/I2C_Sensor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/I2C_Sensor/Makefile
+++ b/Examples/MAX32662/I2C_Sensor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/I2C_Sensor/README.md
+++ b/Examples/MAX32662/I2C_Sensor/README.md
@@ -9,7 +9,7 @@ After initialization, a new reading is printed to the terminal every second.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/I2C_Sensor/project.mk
+++ b/Examples/MAX32662/I2C_Sensor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/I2S/.vscode/README.md
+++ b/Examples/MAX32662/I2S/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/I2S/Makefile
+++ b/Examples/MAX32662/I2S/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/I2S/README.md
+++ b/Examples/MAX32662/I2S/README.md
@@ -7,7 +7,7 @@ This example demonstrates how to transmit a set of audio samples over the I2S bu
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/I2S/project.mk
+++ b/Examples/MAX32662/I2S/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/ICC/.vscode/README.md
+++ b/Examples/MAX32662/ICC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/ICC/Makefile
+++ b/Examples/MAX32662/ICC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/ICC/README.md
+++ b/Examples/MAX32662/ICC/README.md
@@ -12,7 +12,7 @@ This example demonstrates the time differences when running code with the instru
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/ICC/project.mk
+++ b/Examples/MAX32662/ICC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/Info_Block_Usecase/.vscode/README.md
+++ b/Examples/MAX32662/Info_Block_Usecase/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/Info_Block_Usecase/Makefile
+++ b/Examples/MAX32662/Info_Block_Usecase/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/Info_Block_Usecase/README.md
+++ b/Examples/MAX32662/Info_Block_Usecase/README.md
@@ -13,7 +13,7 @@ For more information please check the MAX32662 User Guide.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/Info_Block_Usecase/project.mk
+++ b/Examples/MAX32662/Info_Block_Usecase/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/LP/.vscode/README.md
+++ b/Examples/MAX32662/LP/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/LP/Makefile
+++ b/Examples/MAX32662/LP/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/LP/README.md
+++ b/Examples/MAX32662/LP/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/LP/project.mk
+++ b/Examples/MAX32662/LP/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/Library_Generate/.vscode/README.md
+++ b/Examples/MAX32662/Library_Generate/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
   * If it's not in the README, check the UG.
   * If it's not in the UG, open a ticket!
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
@@ -31,7 +31,7 @@ The following features are supported:
 
 The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.analog.com/en/education/education-library/videos/6313212752112.html).
 
-1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
     * [Windows](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0010820A)
     * [Linux (Ubuntu)](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018720A)
     * [MacOS](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018610A)

--- a/Examples/MAX32662/Library_Generate/Makefile
+++ b/Examples/MAX32662/Library_Generate/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/Library_Generate/README.md
+++ b/Examples/MAX32662/Library_Generate/README.md
@@ -9,7 +9,7 @@ Check the Library_Use demo to see how to link static libraries to an application
 
 ### Project Usage
 
-Universal instructions on building this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/Library_Generate/project.mk
+++ b/Examples/MAX32662/Library_Generate/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
  
 # **********************************************************
 

--- a/Examples/MAX32662/Library_Use/.vscode/README.md
+++ b/Examples/MAX32662/Library_Use/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/Library_Use/Makefile
+++ b/Examples/MAX32662/Library_Use/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/Library_Use/README.md
+++ b/Examples/MAX32662/Library_Use/README.md
@@ -9,7 +9,7 @@ to project.mk to see how to include ".a" static library files into your project.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/Library_Use/project.mk
+++ b/Examples/MAX32662/Library_Use/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/RTC/.vscode/README.md
+++ b/Examples/MAX32662/RTC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/RTC/Makefile
+++ b/Examples/MAX32662/RTC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/RTC/README.md
+++ b/Examples/MAX32662/RTC/README.md
@@ -11,7 +11,7 @@ Additionally, pressing PB0 (SW2) will output the current time of the RTC to the 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/RTC/project.mk
+++ b/Examples/MAX32662/RTC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX32662/RTC_Backup/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/RTC_Backup/Makefile
+++ b/Examples/MAX32662/RTC_Backup/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/RTC_Backup/README.md
+++ b/Examples/MAX32662/RTC_Backup/README.md
@@ -10,7 +10,7 @@ The RTC time-of-day alarm is used to wake the device from backup mode every TIME
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/RTC_Backup/project.mk
+++ b/Examples/MAX32662/RTC_Backup/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/SCPA_OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32662/SCPA_OTP_Dump/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/SCPA_OTP_Dump/Makefile
+++ b/Examples/MAX32662/SCPA_OTP_Dump/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/SCPA_OTP_Dump/README.md
+++ b/Examples/MAX32662/SCPA_OTP_Dump/README.md
@@ -18,7 +18,7 @@ PROJ_CFLAGS+=-DMAX32662_A1
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/SCPA_OTP_Dump/project.mk
+++ b/Examples/MAX32662/SCPA_OTP_Dump/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/SPI/.vscode/README.md
+++ b/Examples/MAX32662/SPI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/SPI/Makefile
+++ b/Examples/MAX32662/SPI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/SPI/README.md
+++ b/Examples/MAX32662/SPI/README.md
@@ -12,7 +12,7 @@ By default, the example performs blocking SPI transactions.  To switch to non-bl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/SPI/project.mk
+++ b/Examples/MAX32662/SPI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/SPI_MasterSlave/.vscode/README.md
+++ b/Examples/MAX32662/SPI_MasterSlave/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/SPI_MasterSlave/Makefile
+++ b/Examples/MAX32662/SPI_MasterSlave/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/SPI_MasterSlave/README.md
+++ b/Examples/MAX32662/SPI_MasterSlave/README.md
@@ -11,7 +11,7 @@ Once the master ends the transaction, the data received by the master and the sl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/SPI_MasterSlave/project.mk
+++ b/Examples/MAX32662/SPI_MasterSlave/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/TMR/.vscode/README.md
+++ b/Examples/MAX32662/TMR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/TMR/Makefile
+++ b/Examples/MAX32662/TMR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/TMR/README.md
+++ b/Examples/MAX32662/TMR/README.md
@@ -13,7 +13,7 @@ Push SW2 to start the oneshot timer.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/TMR/project.mk
+++ b/Examples/MAX32662/TMR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32662/Temp_Monitor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/Temp_Monitor/Makefile
+++ b/Examples/MAX32662/Temp_Monitor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/Temp_Monitor/README.md
+++ b/Examples/MAX32662/Temp_Monitor/README.md
@@ -15,7 +15,7 @@ The temperature limits, flash storage page, and RTC time-of-day alarm period are
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/Temp_Monitor/project.mk
+++ b/Examples/MAX32662/Temp_Monitor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/UART/.vscode/README.md
+++ b/Examples/MAX32662/UART/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/UART/Makefile
+++ b/Examples/MAX32662/UART/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/UART/README.md
+++ b/Examples/MAX32662/UART/README.md
@@ -7,7 +7,7 @@ This application uses two serial ports to send and receive data.  One serial por
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/UART/project.mk
+++ b/Examples/MAX32662/UART/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/UART_Wakeup/.vscode/README.md
+++ b/Examples/MAX32662/UART_Wakeup/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/UART_Wakeup/Makefile
+++ b/Examples/MAX32662/UART_Wakeup/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/UART_Wakeup/README.md
+++ b/Examples/MAX32662/UART_Wakeup/README.md
@@ -7,7 +7,7 @@ This application uses two serial ports to send and receive data.  One serial por
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/UART_Wakeup/project.mk
+++ b/Examples/MAX32662/UART_Wakeup/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/UCL/README.md
+++ b/Examples/MAX32662/UCL/README.md
@@ -9,7 +9,7 @@ TODO:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/UCL/project.mk
+++ b/Examples/MAX32662/UCL/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/Watchdog/.vscode/README.md
+++ b/Examples/MAX32662/Watchdog/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/Watchdog/Makefile
+++ b/Examples/MAX32662/Watchdog/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/Watchdog/README.md
+++ b/Examples/MAX32662/Watchdog/README.md
@@ -14,7 +14,7 @@ After pressing SW2:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32662/Watchdog/project.mk
+++ b/Examples/MAX32662/Watchdog/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32662/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32662/WearLeveling/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32662/WearLeveling/Makefile
+++ b/Examples/MAX32662/WearLeveling/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32662/WearLeveling/README.md
+++ b/Examples/MAX32662/WearLeveling/README.md
@@ -15,11 +15,11 @@ Enter "help" in the command line to see more details on the usage of each of the
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32662EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX32662EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32662/WearLeveling/project.mk
+++ b/Examples/MAX32662/WearLeveling/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32665/ADC/.vscode/README.md
+++ b/Examples/MAX32665/ADC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/ADC/Makefile
+++ b/Examples/MAX32665/ADC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/ADC/README.md
+++ b/Examples/MAX32665/ADC/README.md
@@ -11,7 +11,7 @@ Any reading that exceeds the full-scale value of the ADC will have an '*' append
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/ADC/project.mk
+++ b/Examples/MAX32665/ADC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/ADT7320_TempMonitor/.vscode/README.md
+++ b/Examples/MAX32665/ADT7320_TempMonitor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/ADT7320_TempMonitor/Makefile
+++ b/Examples/MAX32665/ADT7320_TempMonitor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/ADT7320_TempMonitor/README.md
+++ b/Examples/MAX32665/ADT7320_TempMonitor/README.md
@@ -7,7 +7,7 @@ This example reads the temperature data from ADT7320 via SPI and writes it to th
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/ADT7320_TempMonitor/project.mk
+++ b/Examples/MAX32665/ADT7320_TempMonitor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/AES/.vscode/README.md
+++ b/Examples/MAX32665/AES/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/AES/Makefile
+++ b/Examples/MAX32665/AES/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/AES/README.md
+++ b/Examples/MAX32665/AES/README.md
@@ -7,7 +7,7 @@ This application demonstrates both encryption and decryption using AES.  A block
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/AES/project.mk
+++ b/Examples/MAX32665/AES/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/ARM-DSP/README.md
+++ b/Examples/MAX32665/ARM-DSP/README.md
@@ -14,7 +14,7 @@ Development with Visual Studio Code is also supported.  See [VSCode-Maxim](https
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_bayes_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/ARM-DSP/arm_bayes_example/project.mk
+++ b/Examples/MAX32665/ARM-DSP/arm_bayes_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32665/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_class_marks_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/ARM-DSP/arm_class_marks_example/project.mk
+++ b/Examples/MAX32665/ARM-DSP/arm_class_marks_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32665/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_convolution_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/ARM-DSP/arm_convolution_example/project.mk
+++ b/Examples/MAX32665/ARM-DSP/arm_convolution_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32665/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/ARM-DSP/arm_dotproduct_example_f32/project.mk
+++ b/Examples/MAX32665/ARM-DSP/arm_dotproduct_example_f32/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32665/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_fft_bin_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/ARM-DSP/arm_fft_bin_example/project.mk
+++ b/Examples/MAX32665/ARM-DSP/arm_fft_bin_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32665/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_fir_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/ARM-DSP/arm_fir_example/project.mk
+++ b/Examples/MAX32665/ARM-DSP/arm_fir_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32665/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/ARM-DSP/arm_graphic_equalizer_example/project.mk
+++ b/Examples/MAX32665/ARM-DSP/arm_graphic_equalizer_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32665/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_linear_interp_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/ARM-DSP/arm_linear_interp_example/project.mk
+++ b/Examples/MAX32665/ARM-DSP/arm_linear_interp_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32665/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_matrix_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/ARM-DSP/arm_matrix_example/project.mk
+++ b/Examples/MAX32665/ARM-DSP/arm_matrix_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32665/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_signal_converge_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/ARM-DSP/arm_signal_converge_example/project.mk
+++ b/Examples/MAX32665/ARM-DSP/arm_signal_converge_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32665/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_sin_cos_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/ARM-DSP/arm_sin_cos_example/project.mk
+++ b/Examples/MAX32665/ARM-DSP/arm_sin_cos_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32665/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_svm_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/ARM-DSP/arm_svm_example/project.mk
+++ b/Examples/MAX32665/ARM-DSP/arm_svm_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32665/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_variance_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/ARM-DSP/arm_variance_example/project.mk
+++ b/Examples/MAX32665/ARM-DSP/arm_variance_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32665/AUDIO_Playback/.vscode/README.md
+++ b/Examples/MAX32665/AUDIO_Playback/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/AUDIO_Playback/Makefile
+++ b/Examples/MAX32665/AUDIO_Playback/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/AUDIO_Playback/README.md
+++ b/Examples/MAX32665/AUDIO_Playback/README.md
@@ -6,7 +6,7 @@ This example utilizes the audio subsystem peripheral to receive and transmit aud
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/AUDIO_Playback/project.mk
+++ b/Examples/MAX32665/AUDIO_Playback/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Bluetooth/BLE4_ctr/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE4_ctr/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Bluetooth/BLE4_ctr/Makefile
+++ b/Examples/MAX32665/Bluetooth/BLE4_ctr/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Bluetooth/BLE4_ctr/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE4_ctr/README.md
@@ -8,7 +8,7 @@ Refer to the [BLE4_ctr](../../../Libraries/Cordio/docs/Applications/BLE4_ctr.md)
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 

--- a/Examples/MAX32665/Bluetooth/BLE4_ctr/project.mk
+++ b/Examples/MAX32665/Bluetooth/BLE4_ctr/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Bluetooth/BLE5_ctr/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE5_ctr/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Bluetooth/BLE5_ctr/Makefile
+++ b/Examples/MAX32665/Bluetooth/BLE5_ctr/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Bluetooth/BLE5_ctr/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE5_ctr/README.md
@@ -8,7 +8,7 @@ Refer to the [BLE5_ctr](../../../Libraries/Cordio/docs/Applications/BLE5_ctr.md)
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 -   Connect a USB cable between the PC and the (USB/PWR - UART) connector.

--- a/Examples/MAX32665/Bluetooth/BLE5_ctr/project.mk
+++ b/Examples/MAX32665/Bluetooth/BLE5_ctr/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Bluetooth/BLE_FreeRTOS/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_FreeRTOS/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Bluetooth/BLE_FreeRTOS/Makefile
+++ b/Examples/MAX32665/Bluetooth/BLE_FreeRTOS/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Bluetooth/BLE_FreeRTOS/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_FreeRTOS/README.md
@@ -7,7 +7,7 @@ Refer to the [BLE_FreeRTOS](../../../Libraries/Cordio/docs/Applications/BLE_Free
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 

--- a/Examples/MAX32665/Bluetooth/BLE_FreeRTOS/project.mk
+++ b/Examples/MAX32665/Bluetooth/BLE_FreeRTOS/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Bluetooth/BLE_LR_Central/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_LR_Central/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Bluetooth/BLE_LR_Central/Makefile
+++ b/Examples/MAX32665/Bluetooth/BLE_LR_Central/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Bluetooth/BLE_LR_Central/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_LR_Central/README.md
@@ -8,7 +8,7 @@ The project is modified from the BLE_datc.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.  
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.  
 
 ### Required Connections
 * Connect a USB cable between the PC and the (USB/PWR - UART) connector.  

--- a/Examples/MAX32665/Bluetooth/BLE_LR_Central/project.mk
+++ b/Examples/MAX32665/Bluetooth/BLE_LR_Central/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Bluetooth/BLE_LR_Peripheral/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_LR_Peripheral/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Bluetooth/BLE_LR_Peripheral/Makefile
+++ b/Examples/MAX32665/Bluetooth/BLE_LR_Peripheral/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Bluetooth/BLE_LR_Peripheral/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_LR_Peripheral/README.md
@@ -6,7 +6,7 @@ The project is modified from the BLE_fit project. It works with the BLE_LR_Centr
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.  
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.  
 
 ### Required Connections
 

--- a/Examples/MAX32665/Bluetooth/BLE_LR_Peripheral/project.mk
+++ b/Examples/MAX32665/Bluetooth/BLE_LR_Peripheral/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Bluetooth/BLE_datc/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_datc/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Bluetooth/BLE_datc/Makefile
+++ b/Examples/MAX32665/Bluetooth/BLE_datc/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Bluetooth/BLE_datc/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_datc/README.md
@@ -6,7 +6,7 @@ Refer to the [BLE_datc_dats](../../../Libraries/Cordio/docs/Applications/BLE_dat
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 * Connect a USB cable between the PC and the (USB/PWR - UART) connector.

--- a/Examples/MAX32665/Bluetooth/BLE_datc/project.mk
+++ b/Examples/MAX32665/Bluetooth/BLE_datc/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Bluetooth/BLE_dats/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_dats/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Bluetooth/BLE_dats/Makefile
+++ b/Examples/MAX32665/Bluetooth/BLE_dats/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Bluetooth/BLE_dats/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_dats/README.md
@@ -6,7 +6,7 @@ Refer to the [BLE_datc_dats](../../../Libraries/Cordio/docs/Applications/BLE_dat
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 * Connect a USB cable between the PC and the (USB/PWR - UART) connector.

--- a/Examples/MAX32665/Bluetooth/BLE_dats/project.mk
+++ b/Examples/MAX32665/Bluetooth/BLE_dats/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Bluetooth/BLE_fcc/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_fcc/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Bluetooth/BLE_fcc/Makefile
+++ b/Examples/MAX32665/Bluetooth/BLE_fcc/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Bluetooth/BLE_fcc/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_fcc/README.md
@@ -7,7 +7,7 @@ Refer to [BLE_fcc](../../../Libraries/Cordio/docs/Applications/BLE_fcc.md) docum
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ## Required Connections
 * Connect a USB cable between the PC and the (USB/PWR - UART) connector.

--- a/Examples/MAX32665/Bluetooth/BLE_fcc/project.mk
+++ b/Examples/MAX32665/Bluetooth/BLE_fcc/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Bluetooth/BLE_fit/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_fit/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Bluetooth/BLE_fit/Makefile
+++ b/Examples/MAX32665/Bluetooth/BLE_fit/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Bluetooth/BLE_fit/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_fit/README.md
@@ -6,7 +6,7 @@ Refer to [BLE_fit](../../../Libraries/Cordio/docs/Applications/BLE_fit.md) docum
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 

--- a/Examples/MAX32665/Bluetooth/BLE_fit/project.mk
+++ b/Examples/MAX32665/Bluetooth/BLE_fit/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Bluetooth/BLE_mcs/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_mcs/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Bluetooth/BLE_mcs/Makefile
+++ b/Examples/MAX32665/Bluetooth/BLE_mcs/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Bluetooth/BLE_mcs/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_mcs/README.md
@@ -8,7 +8,7 @@ Refer to the [BLE_mcs](../../../Libraries/Cordio/docs/Applications/BLE_mcs.md) d
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 * Connect a USB cable between the PC and the (USB/PWR - UART) connector.

--- a/Examples/MAX32665/Bluetooth/BLE_mcs/project.mk
+++ b/Examples/MAX32665/Bluetooth/BLE_mcs/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Bluetooth/BLE_otac/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_otac/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Bluetooth/BLE_otac/Makefile
+++ b/Examples/MAX32665/Bluetooth/BLE_otac/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Bluetooth/BLE_otac/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_otac/README.md
@@ -11,7 +11,7 @@ Refer to the [BLE_otac_otas](../../../Libraries/Cordio/docs/Applications/BLE_ota
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 * Connect a USB cable between the PC and the (USB/PWR - UART) connector.

--- a/Examples/MAX32665/Bluetooth/BLE_otac/project.mk
+++ b/Examples/MAX32665/Bluetooth/BLE_otac/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Bluetooth/BLE_otas/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_otas/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Bluetooth/BLE_otas/Makefile
+++ b/Examples/MAX32665/Bluetooth/BLE_otas/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Bluetooth/BLE_otas/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_otas/README.md
@@ -11,7 +11,7 @@ Refer to the [BLE_otac_otas](../../../Libraries/Cordio/docs/Applications/BLE_ota
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ## Required Connections
 * Connect a USB cable between the PC and the (USB/PWR - UART) connector.

--- a/Examples/MAX32665/Bluetooth/BLE_otas/project.mk
+++ b/Examples/MAX32665/Bluetooth/BLE_otas/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Bluetooth/BLE_periph/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_periph/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Bluetooth/BLE_periph/Makefile
+++ b/Examples/MAX32665/Bluetooth/BLE_periph/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Bluetooth/BLE_periph/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_periph/README.md
@@ -5,7 +5,7 @@ Refer to the [BLE_periph](../../../Libraries/Cordio/docs/Applications/BLE_periph
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 * Connect a USB cable between the PC and the (USB/PWR - UART) connector. An anteanna or wired connection can be used if SMA is available on the board. 

--- a/Examples/MAX32665/Bluetooth/BLE_periph/project.mk
+++ b/Examples/MAX32665/Bluetooth/BLE_periph/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Bluetooth/Bootloader/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/Bootloader/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Bluetooth/Bootloader/Makefile
+++ b/Examples/MAX32665/Bluetooth/Bootloader/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Bluetooth/Bootloader/README.md
+++ b/Examples/MAX32665/Bluetooth/Bootloader/README.md
@@ -40,7 +40,7 @@ Plesae note that: depend on your LED0/LED1 pin connection on your board, you mig
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/Bluetooth/Bootloader/project.mk
+++ b/Examples/MAX32665/Bluetooth/Bootloader/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Bluetooth/Bootloader_Host/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/Bootloader_Host/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Bluetooth/Bootloader_Host/Makefile
+++ b/Examples/MAX32665/Bluetooth/Bootloader_Host/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Bluetooth/Bootloader_Host/README.md
+++ b/Examples/MAX32665/Bluetooth/Bootloader_Host/README.md
@@ -23,7 +23,7 @@ flash based bootloader. It is designed to easily be ported on any micro.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/Bluetooth/Bootloader_Host/project.mk
+++ b/Examples/MAX32665/Bluetooth/Bootloader_Host/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Bluetooth/RF_Test/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/RF_Test/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Bluetooth/RF_Test/Makefile
+++ b/Examples/MAX32665/Bluetooth/RF_Test/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/CRC/.vscode/README.md
+++ b/Examples/MAX32665/CRC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/CRC/Makefile
+++ b/Examples/MAX32665/CRC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/CRC/README.md
+++ b/Examples/MAX32665/CRC/README.md
@@ -7,7 +7,7 @@ This example demonstrates the use of the HW CRC calculator.  The example first g
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/CRC/project.mk
+++ b/Examples/MAX32665/CRC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Coremark/.vscode/README.md
+++ b/Examples/MAX32665/Coremark/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Coremark/Makefile
+++ b/Examples/MAX32665/Coremark/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Coremark/README.md
+++ b/Examples/MAX32665/Coremark/README.md
@@ -10,7 +10,7 @@ For more information, visit the [CoreMark webpage](https://www.eembc.org/coremar
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/Coremark/project.mk
+++ b/Examples/MAX32665/Coremark/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/DES/.vscode/README.md
+++ b/Examples/MAX32665/DES/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/DES/Makefile
+++ b/Examples/MAX32665/DES/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/DES/README.md
+++ b/Examples/MAX32665/DES/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/DES/project.mk
+++ b/Examples/MAX32665/DES/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/DMA/.vscode/README.md
+++ b/Examples/MAX32665/DMA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/DMA/Makefile
+++ b/Examples/MAX32665/DMA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/DMA/README.md
+++ b/Examples/MAX32665/DMA/README.md
@@ -9,7 +9,7 @@ A second more complex memory-to-memory DMA transaction is then shown that chains
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/DMA/project.mk
+++ b/Examples/MAX32665/DMA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Demo/.vscode/README.md
+++ b/Examples/MAX32665/Demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Demo/Makefile
+++ b/Examples/MAX32665/Demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Demo/README.md
+++ b/Examples/MAX32665/Demo/README.md
@@ -16,7 +16,7 @@ Please check project.mk to learn how compile lvgl in MSDK
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/Demo/project.mk
+++ b/Examples/MAX32665/Demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Display/.vscode/README.md
+++ b/Examples/MAX32665/Display/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Display/Makefile
+++ b/Examples/MAX32665/Display/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Display/README.md
+++ b/Examples/MAX32665/Display/README.md
@@ -16,7 +16,7 @@ Please check project.mk to learn how compile lvgl in MSDK
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/Display/project.mk
+++ b/Examples/MAX32665/Display/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/ECC/.vscode/README.md
+++ b/Examples/MAX32665/ECC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/ECC/Makefile
+++ b/Examples/MAX32665/ECC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/ECC/README.md
+++ b/Examples/MAX32665/ECC/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/ECC/project.mk
+++ b/Examples/MAX32665/ECC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32665/EEPROM_Emulator/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32665/EEPROM_Emulator/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/EEPROM_Emulator/README.md
+++ b/Examples/MAX32665/EEPROM_Emulator/README.md
@@ -48,7 +48,7 @@ To help with syncronization, a "Ready Signal" is set up as an output from a GPIO
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/EEPROM_Emulator/project.mk
+++ b/Examples/MAX32665/EEPROM_Emulator/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Flash/.vscode/README.md
+++ b/Examples/MAX32665/Flash/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Flash/Makefile
+++ b/Examples/MAX32665/Flash/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Flash/README.md
+++ b/Examples/MAX32665/Flash/README.md
@@ -21,7 +21,7 @@ The _second_ time the example is run the application will see the "magic" 32-bit
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
@@ -37,7 +37,7 @@ MAX32665EVKIT:
 
 ## Building and Running
 
-**See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
+**See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
 
 ## Expected Output
 

--- a/Examples/MAX32665/Flash/project.mk
+++ b/Examples/MAX32665/Flash/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32665/Flash_CLI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Flash_CLI/Makefile
+++ b/Examples/MAX32665/Flash_CLI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Flash_CLI/README.md
+++ b/Examples/MAX32665/Flash_CLI/README.md
@@ -9,7 +9,7 @@ This example demonstates the CLI commands feature of FreeRTOS, various features 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/Flash_CLI/project.mk
+++ b/Examples/MAX32665/Flash_CLI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32665/FreeRTOSDemo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32665/FreeRTOSDemo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/FreeRTOSDemo/README.md
+++ b/Examples/MAX32665/FreeRTOSDemo/README.md
@@ -7,7 +7,7 @@ A basic getting started application for FreeRTOS.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/FreeRTOSDemo/project.mk
+++ b/Examples/MAX32665/FreeRTOSDemo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/GPIO/.vscode/README.md
+++ b/Examples/MAX32665/GPIO/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/GPIO/Makefile
+++ b/Examples/MAX32665/GPIO/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/GPIO/README.md
+++ b/Examples/MAX32665/GPIO/README.md
@@ -12,7 +12,7 @@ Please check the board.c file in ${MSDKPath}\Libraries\Boards\MAX32665\${BoardNa
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/GPIO/project.mk
+++ b/Examples/MAX32665/GPIO/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/HTMR/.vscode/README.md
+++ b/Examples/MAX32665/HTMR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/HTMR/Makefile
+++ b/Examples/MAX32665/HTMR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/HTMR/README.md
+++ b/Examples/MAX32665/HTMR/README.md
@@ -10,7 +10,7 @@ This example demonstrates features of HTimer. It sets the short interval alarm t
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/HTMR/project.mk
+++ b/Examples/MAX32665/HTMR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Hash/.vscode/README.md
+++ b/Examples/MAX32665/Hash/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Hash/Makefile
+++ b/Examples/MAX32665/Hash/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Hash/README.md
+++ b/Examples/MAX32665/Hash/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/Hash/project.mk
+++ b/Examples/MAX32665/Hash/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Hello_World/.vscode/README.md
+++ b/Examples/MAX32665/Hello_World/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Hello_World/Makefile
+++ b/Examples/MAX32665/Hello_World/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Hello_World/README.md
+++ b/Examples/MAX32665/Hello_World/README.md
@@ -11,7 +11,7 @@ Please check the board.c file in ${MSDKPath}\Libraries\Boards\MAX32665\${BoardNa
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/Hello_World/project.mk
+++ b/Examples/MAX32665/Hello_World/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32665/Hello_World_Cpp/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Hello_World_Cpp/Makefile
+++ b/Examples/MAX32665/Hello_World_Cpp/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Hello_World_Cpp/README.md
+++ b/Examples/MAX32665/Hello_World_Cpp/README.md
@@ -8,7 +8,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/Hello_World_Cpp/project.mk
+++ b/Examples/MAX32665/Hello_World_Cpp/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32665/I2C/.vscode/README.md
+++ b/Examples/MAX32665/I2C/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/I2C/Makefile
+++ b/Examples/MAX32665/I2C/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/I2C/README.md
+++ b/Examples/MAX32665/I2C/README.md
@@ -7,7 +7,7 @@ This example uses the I2C Master to read/write from/to the I2C Slave.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/I2C/project.mk
+++ b/Examples/MAX32665/I2C/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32665/I2C_MNGR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/I2C_MNGR/Makefile
+++ b/Examples/MAX32665/I2C_MNGR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/I2C_MNGR/README.md
+++ b/Examples/MAX32665/I2C_MNGR/README.md
@@ -11,7 +11,7 @@ You may change the configuration of each EEPROM's I2C transaction parameters (sl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/I2C_MNGR/project.mk
+++ b/Examples/MAX32665/I2C_MNGR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32665/I2C_SCAN/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/I2C_SCAN/Makefile
+++ b/Examples/MAX32665/I2C_SCAN/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/I2C_SCAN/README.md
+++ b/Examples/MAX32665/I2C_SCAN/README.md
@@ -7,7 +7,7 @@ This example uses the I2C Master to find the addresses of any I2C Slave devices 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/I2C_SCAN/project.mk
+++ b/Examples/MAX32665/I2C_SCAN/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32665/I2C_Sensor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/I2C_Sensor/Makefile
+++ b/Examples/MAX32665/I2C_Sensor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/I2C_Sensor/README.md
+++ b/Examples/MAX32665/I2C_Sensor/README.md
@@ -9,7 +9,7 @@ After initialization, a new reading is printed to the terminal every second.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/I2C_Sensor/project.mk
+++ b/Examples/MAX32665/I2C_Sensor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/ICC/.vscode/README.md
+++ b/Examples/MAX32665/ICC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/ICC/Makefile
+++ b/Examples/MAX32665/ICC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/ICC/README.md
+++ b/Examples/MAX32665/ICC/README.md
@@ -12,7 +12,7 @@ This example demonstrates the time differences when running code with the instru
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/ICC/project.mk
+++ b/Examples/MAX32665/ICC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/LP/.vscode/README.md
+++ b/Examples/MAX32665/LP/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/LP/Makefile
+++ b/Examples/MAX32665/LP/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/LP/README.md
+++ b/Examples/MAX32665/LP/README.md
@@ -7,7 +7,7 @@ Example to showcase the lower power modes.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/LP/project.mk
+++ b/Examples/MAX32665/LP/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Library_Generate/.vscode/README.md
+++ b/Examples/MAX32665/Library_Generate/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
   * If it's not in the README, check the UG.
   * If it's not in the UG, open a ticket!
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
@@ -31,7 +31,7 @@ The following features are supported:
 
 The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.analog.com/en/education/education-library/videos/6313212752112.html).
 
-1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
     * [Windows](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0010820A)
     * [Linux (Ubuntu)](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018720A)
     * [MacOS](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018610A)

--- a/Examples/MAX32665/Library_Generate/Makefile
+++ b/Examples/MAX32665/Library_Generate/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Library_Generate/README.md
+++ b/Examples/MAX32665/Library_Generate/README.md
@@ -9,7 +9,7 @@ Check the Library_Use demo to see how to link static libraries to an application
 
 ### Project Usage
 
-Universal instructions on building this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/Library_Generate/project.mk
+++ b/Examples/MAX32665/Library_Generate/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
  
 # **********************************************************
 

--- a/Examples/MAX32665/Library_Use/.vscode/README.md
+++ b/Examples/MAX32665/Library_Use/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Library_Use/Makefile
+++ b/Examples/MAX32665/Library_Use/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Library_Use/README.md
+++ b/Examples/MAX32665/Library_Use/README.md
@@ -9,11 +9,11 @@ to project.mk to see how to include ".a" static library files into your project.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-This example supports all available MAX32665 evaluation platforms but comes _pre-configured_ for the MAX32666EVKIT by default. See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
+This example supports all available MAX32665 evaluation platforms but comes _pre-configured_ for the MAX32666EVKIT by default. See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
 
 ## Required Connections
 

--- a/Examples/MAX32665/Library_Use/project.mk
+++ b/Examples/MAX32665/Library_Use/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/MAA/.vscode/README.md
+++ b/Examples/MAX32665/MAA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/MAA/Makefile
+++ b/Examples/MAX32665/MAA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/MAA/README.md
+++ b/Examples/MAX32665/MAA/README.md
@@ -8,7 +8,7 @@ In this particular example the MAA is configured to compute an exponentiation. T
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/MAA/project.mk
+++ b/Examples/MAX32665/MAA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32665/OTP_Dump/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/OTP_Dump/Makefile
+++ b/Examples/MAX32665/OTP_Dump/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/OWM/.vscode/README.md
+++ b/Examples/MAX32665/OWM/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/OWM/Makefile
+++ b/Examples/MAX32665/OWM/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/OWM/README.md
+++ b/Examples/MAX32665/OWM/README.md
@@ -7,7 +7,7 @@ This example demonstrate how 1-Wire master can be configured and read slave ROM 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/OWM/project.mk
+++ b/Examples/MAX32665/OWM/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Pulse_Train/.vscode/README.md
+++ b/Examples/MAX32665/Pulse_Train/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Pulse_Train/Makefile
+++ b/Examples/MAX32665/Pulse_Train/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Pulse_Train/README.md
+++ b/Examples/MAX32665/Pulse_Train/README.md
@@ -11,7 +11,7 @@ The second, PT15 (P1.15) , is set to generate a 10Hz square wave.  If you make t
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/Pulse_Train/project.mk
+++ b/Examples/MAX32665/Pulse_Train/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/RPU/.vscode/README.md
+++ b/Examples/MAX32665/RPU/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/RPU/Makefile
+++ b/Examples/MAX32665/RPU/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/RPU/README.md
+++ b/Examples/MAX32665/RPU/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/RPU/project.mk
+++ b/Examples/MAX32665/RPU/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/RTC/.vscode/README.md
+++ b/Examples/MAX32665/RTC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/RTC/Makefile
+++ b/Examples/MAX32665/RTC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/RTC/README.md
+++ b/Examples/MAX32665/RTC/README.md
@@ -12,7 +12,7 @@ The time-of-day alarm is then rearmed for another 10 sec.  Pressing push button 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/RTC/project.mk
+++ b/Examples/MAX32665/RTC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX32665/RTC_Backup/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/RTC_Backup/Makefile
+++ b/Examples/MAX32665/RTC_Backup/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/RTC_Backup/README.md
+++ b/Examples/MAX32665/RTC_Backup/README.md
@@ -10,7 +10,7 @@ The RTC time-of-day alarm is used to wake the device from backup mode every TIME
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/RTC_Backup/project.mk
+++ b/Examples/MAX32665/RTC_Backup/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/SCPA_OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32665/SCPA_OTP_Dump/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/SCPA_OTP_Dump/Makefile
+++ b/Examples/MAX32665/SCPA_OTP_Dump/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/SCPA_OTP_Dump/README.md
+++ b/Examples/MAX32665/SCPA_OTP_Dump/README.md
@@ -18,7 +18,7 @@ PROJ_CFLAGS+=-DMAX32665_A2
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/SCPA_OTP_Dump/project.mk
+++ b/Examples/MAX32665/SCPA_OTP_Dump/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/SDHC_FAT/.vscode/README.md
+++ b/Examples/MAX32665/SDHC_FAT/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/SDHC_FAT/Makefile
+++ b/Examples/MAX32665/SDHC_FAT/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/SDHC_FAT/README.md
+++ b/Examples/MAX32665/SDHC_FAT/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/SDHC_FAT/project.mk
+++ b/Examples/MAX32665/SDHC_FAT/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/SDHC_Raw/.vscode/README.md
+++ b/Examples/MAX32665/SDHC_Raw/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/SDHC_Raw/Makefile
+++ b/Examples/MAX32665/SDHC_Raw/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/SDHC_Raw/README.md
+++ b/Examples/MAX32665/SDHC_Raw/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/SDHC_Raw/project.mk
+++ b/Examples/MAX32665/SDHC_Raw/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/SPI/.vscode/README.md
+++ b/Examples/MAX32665/SPI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/SPI/Makefile
+++ b/Examples/MAX32665/SPI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/SPI/README.md
+++ b/Examples/MAX32665/SPI/README.md
@@ -11,7 +11,7 @@ By default, the example performs blocking SPI transactions.  To switch to non-bl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/SPI/project.mk
+++ b/Examples/MAX32665/SPI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/SPIXF/.vscode/README.md
+++ b/Examples/MAX32665/SPIXF/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/SPIXF/Makefile
+++ b/Examples/MAX32665/SPIXF/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/SPIXF/README.md
+++ b/Examples/MAX32665/SPIXF/README.md
@@ -7,7 +7,7 @@ This example communicates with the MX25 flash on the EvKit. It loads code onto i
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/SPIXF/project.mk
+++ b/Examples/MAX32665/SPIXF/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/SPIXF_SFCC/.vscode/README.md
+++ b/Examples/MAX32665/SPIXF_SFCC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/SPIXF_SFCC/Makefile
+++ b/Examples/MAX32665/SPIXF_SFCC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/SPIXF_SFCC/README.md
+++ b/Examples/MAX32665/SPIXF_SFCC/README.md
@@ -9,7 +9,7 @@ To demonstrate, a sample function is loaded into the MX25 external flash chip. T
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/SPIXF_SFCC/project.mk
+++ b/Examples/MAX32665/SPIXF_SFCC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/SPIXR/.vscode/README.md
+++ b/Examples/MAX32665/SPIXR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/SPIXR/Makefile
+++ b/Examples/MAX32665/SPIXR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/SPIXR/README.md
+++ b/Examples/MAX32665/SPIXR/README.md
@@ -9,7 +9,7 @@ It writes random data to the MX25 SPI RAM and reads it back.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/SPIXR/project.mk
+++ b/Examples/MAX32665/SPIXR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/SPI_3Wire/.vscode/README.md
+++ b/Examples/MAX32665/SPI_3Wire/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/SPI_3Wire/Makefile
+++ b/Examples/MAX32665/SPI_3Wire/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/SPI_3Wire/README.md
+++ b/Examples/MAX32665/SPI_3Wire/README.md
@@ -6,7 +6,7 @@ This example sends data between two SPI peripherals operating in 3-wire SPI mode
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/SPI_3Wire/project.mk
+++ b/Examples/MAX32665/SPI_3Wire/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/SRCC/.vscode/README.md
+++ b/Examples/MAX32665/SRCC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/SRCC/Makefile
+++ b/Examples/MAX32665/SRCC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/SRCC/README.md
+++ b/Examples/MAX32665/SRCC/README.md
@@ -7,7 +7,7 @@ The example compares the execution times required to read from MX25 RAM with the
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/SRCC/project.mk
+++ b/Examples/MAX32665/SRCC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Semaphore/.vscode/README.md
+++ b/Examples/MAX32665/Semaphore/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Semaphore/Makefile
+++ b/Examples/MAX32665/Semaphore/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Semaphore/README.md
+++ b/Examples/MAX32665/Semaphore/README.md
@@ -13,7 +13,7 @@ Please note that: Depend on the number of button on your board the example outpu
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/Semaphore/project.mk
+++ b/Examples/MAX32665/Semaphore/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/TMR/.vscode/README.md
+++ b/Examples/MAX32665/TMR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/TMR/Makefile
+++ b/Examples/MAX32665/TMR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/TMR/README.md
+++ b/Examples/MAX32665/TMR/README.md
@@ -13,7 +13,7 @@ Two timers are used to demonstrate two different modes of the general purpose ti
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/TMR/project.mk
+++ b/Examples/MAX32665/TMR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/TRNG/.vscode/README.md
+++ b/Examples/MAX32665/TRNG/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/TRNG/Makefile
+++ b/Examples/MAX32665/TRNG/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/TRNG/README.md
+++ b/Examples/MAX32665/TRNG/README.md
@@ -7,7 +7,7 @@ The true random number generator (TRNG) hardware is exercised in this example.  
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/TRNG/project.mk
+++ b/Examples/MAX32665/TRNG/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32665/Temp_Monitor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Temp_Monitor/Makefile
+++ b/Examples/MAX32665/Temp_Monitor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Temp_Monitor/README.md
+++ b/Examples/MAX32665/Temp_Monitor/README.md
@@ -15,7 +15,7 @@ The temperature limits, flash storage page, and RTC time-of-day alarm period are
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/Temp_Monitor/project.mk
+++ b/Examples/MAX32665/Temp_Monitor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/UART/.vscode/README.md
+++ b/Examples/MAX32665/UART/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/UART/Makefile
+++ b/Examples/MAX32665/UART/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/UART/README.md
+++ b/Examples/MAX32665/UART/README.md
@@ -7,7 +7,7 @@ This application uses two serial ports to send and receive data.  One serial por
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/UART/project.mk
+++ b/Examples/MAX32665/UART/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/UCL/README.md
+++ b/Examples/MAX32665/UCL/README.md
@@ -9,7 +9,7 @@ TODO:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/UCL/project.mk
+++ b/Examples/MAX32665/UCL/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/USB/USB_CDCACM/.vscode/README.md
+++ b/Examples/MAX32665/USB/USB_CDCACM/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/USB/USB_CDCACM/Makefile
+++ b/Examples/MAX32665/USB/USB_CDCACM/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/USB/USB_CDCACM/README.md
+++ b/Examples/MAX32665/USB/USB_CDCACM/README.md
@@ -7,7 +7,7 @@ The example demonstartes the use of USB CDC-ACM driver class. After doing the re
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/USB/USB_CDCACM/project.mk
+++ b/Examples/MAX32665/USB/USB_CDCACM/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/USB/USB_CompositeDevice_MSC_CDC/.vscode/README.md
+++ b/Examples/MAX32665/USB/USB_CompositeDevice_MSC_CDC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/USB/USB_CompositeDevice_MSC_CDC/Makefile
+++ b/Examples/MAX32665/USB/USB_CompositeDevice_MSC_CDC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/USB/USB_CompositeDevice_MSC_CDC/README.md
+++ b/Examples/MAX32665/USB/USB_CompositeDevice_MSC_CDC/README.md
@@ -7,7 +7,7 @@ The example demonstartes the use of USB composite device with Mass Storage drive
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/USB/USB_CompositeDevice_MSC_CDC/project.mk
+++ b/Examples/MAX32665/USB/USB_CompositeDevice_MSC_CDC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/USB/USB_CompositeDevice_MSC_HID/.vscode/README.md
+++ b/Examples/MAX32665/USB/USB_CompositeDevice_MSC_HID/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/USB/USB_CompositeDevice_MSC_HID/Makefile
+++ b/Examples/MAX32665/USB/USB_CompositeDevice_MSC_HID/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/USB/USB_CompositeDevice_MSC_HID/README.md
+++ b/Examples/MAX32665/USB/USB_CompositeDevice_MSC_HID/README.md
@@ -7,7 +7,7 @@ The example demonstartes the use of USB composite device with Mass Storage drive
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/USB/USB_CompositeDevice_MSC_HID/project.mk
+++ b/Examples/MAX32665/USB/USB_CompositeDevice_MSC_HID/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/USB/USB_HIDKeyboard/.vscode/README.md
+++ b/Examples/MAX32665/USB/USB_HIDKeyboard/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/USB/USB_HIDKeyboard/Makefile
+++ b/Examples/MAX32665/USB/USB_HIDKeyboard/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/USB/USB_HIDKeyboard/README.md
+++ b/Examples/MAX32665/USB/USB_HIDKeyboard/README.md
@@ -7,7 +7,7 @@ The example demonstartes the use of USB CHID driver class. After doing the requi
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/USB/USB_HIDKeyboard/project.mk
+++ b/Examples/MAX32665/USB/USB_HIDKeyboard/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/USB/USB_MassStorage/.vscode/README.md
+++ b/Examples/MAX32665/USB/USB_MassStorage/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/USB/USB_MassStorage/Makefile
+++ b/Examples/MAX32665/USB/USB_MassStorage/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/USB/USB_MassStorage/README.md
+++ b/Examples/MAX32665/USB/USB_MassStorage/README.md
@@ -7,7 +7,7 @@ The example demonstartes the use of USB Mass Storage driver class. After doing t
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/USB/USB_MassStorage/project.mk
+++ b/Examples/MAX32665/USB/USB_MassStorage/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/WUT/.vscode/README.md
+++ b/Examples/MAX32665/WUT/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/WUT/Makefile
+++ b/Examples/MAX32665/WUT/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/WUT/README.md
+++ b/Examples/MAX32665/WUT/README.md
@@ -6,7 +6,7 @@ This Example shows how to wake up a device after it is asleep with a wake up tim
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/WUT/project.mk
+++ b/Examples/MAX32665/WUT/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/Watchdog/.vscode/README.md
+++ b/Examples/MAX32665/Watchdog/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/Watchdog/Makefile
+++ b/Examples/MAX32665/Watchdog/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/Watchdog/README.md
+++ b/Examples/MAX32665/Watchdog/README.md
@@ -11,7 +11,7 @@ When the application begins, it initializes and starts the watchdog timer.  The 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32665/Watchdog/project.mk
+++ b/Examples/MAX32665/Watchdog/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32665/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32665/WearLeveling/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32665/WearLeveling/Makefile
+++ b/Examples/MAX32665/WearLeveling/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32665/WearLeveling/README.md
+++ b/Examples/MAX32665/WearLeveling/README.md
@@ -15,11 +15,11 @@ Enter "help" in the command line to see more details on the usage of each of the
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32665EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX32665EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32665/WearLeveling/project.mk
+++ b/Examples/MAX32665/WearLeveling/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32670/AES/.vscode/README.md
+++ b/Examples/MAX32670/AES/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/AES/Makefile
+++ b/Examples/MAX32670/AES/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/AES/README.md
+++ b/Examples/MAX32670/AES/README.md
@@ -7,7 +7,7 @@ This application demonstrates both encryption and decryption using AES.  A block
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/AES/project.mk
+++ b/Examples/MAX32670/AES/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/ARM-DSP/README.md
+++ b/Examples/MAX32670/ARM-DSP/README.md
@@ -14,7 +14,7 @@ Development with Visual Studio Code is also supported.  See [VSCode-Maxim](https
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_bayes_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/ARM-DSP/arm_bayes_example/project.mk
+++ b/Examples/MAX32670/ARM-DSP/arm_bayes_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_class_marks_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/ARM-DSP/arm_class_marks_example/project.mk
+++ b/Examples/MAX32670/ARM-DSP/arm_class_marks_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_convolution_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/ARM-DSP/arm_convolution_example/project.mk
+++ b/Examples/MAX32670/ARM-DSP/arm_convolution_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/ARM-DSP/arm_dotproduct_example_f32/project.mk
+++ b/Examples/MAX32670/ARM-DSP/arm_dotproduct_example_f32/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_fft_bin_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/ARM-DSP/arm_fft_bin_example/project.mk
+++ b/Examples/MAX32670/ARM-DSP/arm_fft_bin_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_fir_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/ARM-DSP/arm_fir_example/project.mk
+++ b/Examples/MAX32670/ARM-DSP/arm_fir_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/ARM-DSP/arm_graphic_equalizer_example/project.mk
+++ b/Examples/MAX32670/ARM-DSP/arm_graphic_equalizer_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_linear_interp_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/ARM-DSP/arm_linear_interp_example/project.mk
+++ b/Examples/MAX32670/ARM-DSP/arm_linear_interp_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_matrix_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/ARM-DSP/arm_matrix_example/project.mk
+++ b/Examples/MAX32670/ARM-DSP/arm_matrix_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_signal_converge_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/ARM-DSP/arm_signal_converge_example/project.mk
+++ b/Examples/MAX32670/ARM-DSP/arm_signal_converge_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_sin_cos_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/ARM-DSP/arm_sin_cos_example/project.mk
+++ b/Examples/MAX32670/ARM-DSP/arm_sin_cos_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_svm_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/ARM-DSP/arm_svm_example/project.mk
+++ b/Examples/MAX32670/ARM-DSP/arm_svm_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_variance_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/ARM-DSP/arm_variance_example/project.mk
+++ b/Examples/MAX32670/ARM-DSP/arm_variance_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/CRC/.vscode/README.md
+++ b/Examples/MAX32670/CRC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/CRC/Makefile
+++ b/Examples/MAX32670/CRC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/CRC/README.md
+++ b/Examples/MAX32670/CRC/README.md
@@ -7,7 +7,7 @@ This example demonstrates the use of the HW CRC calculator.  The example first g
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/CRC/project.mk
+++ b/Examples/MAX32670/CRC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/Coremark/.vscode/README.md
+++ b/Examples/MAX32670/Coremark/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/Coremark/Makefile
+++ b/Examples/MAX32670/Coremark/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/Coremark/README.md
+++ b/Examples/MAX32670/Coremark/README.md
@@ -10,7 +10,7 @@ For more information, visit the [CoreMark webpage](https://www.eembc.org/coremar
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/Coremark/project.mk
+++ b/Examples/MAX32670/Coremark/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32670/DMA/.vscode/README.md
+++ b/Examples/MAX32670/DMA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/DMA/Makefile
+++ b/Examples/MAX32670/DMA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/DMA/README.md
+++ b/Examples/MAX32670/DMA/README.md
@@ -9,7 +9,7 @@ A second more complex memory-to-memory DMA transaction is then shown that chains
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/DMA/project.mk
+++ b/Examples/MAX32670/DMA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32670/EEPROM_Emulator/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32670/EEPROM_Emulator/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/EEPROM_Emulator/README.md
+++ b/Examples/MAX32670/EEPROM_Emulator/README.md
@@ -48,7 +48,7 @@ To help with syncronization, a "Ready Signal" is set up as an output from a GPIO
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/EEPROM_Emulator/project.mk
+++ b/Examples/MAX32670/EEPROM_Emulator/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32670/EXT_CLK/.vscode/README.md
+++ b/Examples/MAX32670/EXT_CLK/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/EXT_CLK/Makefile
+++ b/Examples/MAX32670/EXT_CLK/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/EXT_CLK/README.md
+++ b/Examples/MAX32670/EXT_CLK/README.md
@@ -8,7 +8,7 @@ Operation requires a clean external clock signal (square wave, 50% duty cycle) f
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/EXT_CLK/project.mk
+++ b/Examples/MAX32670/EXT_CLK/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 
 

--- a/Examples/MAX32670/Flash/.vscode/README.md
+++ b/Examples/MAX32670/Flash/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/Flash/Makefile
+++ b/Examples/MAX32670/Flash/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/Flash/README.md
+++ b/Examples/MAX32670/Flash/README.md
@@ -21,7 +21,7 @@ The _second_ time the example is run the application will see the "magic" 32-bit
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
@@ -37,7 +37,7 @@ MAX32670EVKIT:
 
 ## Building and Running
 
-**See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
+**See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
 
 ## Expected Output
 

--- a/Examples/MAX32670/Flash/project.mk
+++ b/Examples/MAX32670/Flash/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32670/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32670/Flash_CLI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/Flash_CLI/Makefile
+++ b/Examples/MAX32670/Flash_CLI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/Flash_CLI/README.md
+++ b/Examples/MAX32670/Flash_CLI/README.md
@@ -9,7 +9,7 @@ This example demonstates various features of the Flash Controller (page erase an
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/Flash_CLI/project.mk
+++ b/Examples/MAX32670/Flash_CLI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32670/FreeRTOSDemo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32670/FreeRTOSDemo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/FreeRTOSDemo/README.md
+++ b/Examples/MAX32670/FreeRTOSDemo/README.md
@@ -7,7 +7,7 @@ A basic getting started application for FreeRTOS.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/FreeRTOSDemo/project.mk
+++ b/Examples/MAX32670/FreeRTOSDemo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/GPIO/.vscode/README.md
+++ b/Examples/MAX32670/GPIO/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/GPIO/Makefile
+++ b/Examples/MAX32670/GPIO/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/GPIO/README.md
+++ b/Examples/MAX32670/GPIO/README.md
@@ -9,7 +9,7 @@ P0.16 is continuously scanned and whatever value is read on that pin is then out
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/GPIO/project.mk
+++ b/Examples/MAX32670/GPIO/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/Hello_World/.vscode/README.md
+++ b/Examples/MAX32670/Hello_World/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/Hello_World/Makefile
+++ b/Examples/MAX32670/Hello_World/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/Hello_World/README.md
+++ b/Examples/MAX32670/Hello_World/README.md
@@ -9,7 +9,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/Hello_World/project.mk
+++ b/Examples/MAX32670/Hello_World/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32670/Hello_World_Cpp/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/Hello_World_Cpp/Makefile
+++ b/Examples/MAX32670/Hello_World_Cpp/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/Hello_World_Cpp/README.md
+++ b/Examples/MAX32670/Hello_World_Cpp/README.md
@@ -8,7 +8,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/Hello_World_Cpp/project.mk
+++ b/Examples/MAX32670/Hello_World_Cpp/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32670/I2C/.vscode/README.md
+++ b/Examples/MAX32670/I2C/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/I2C/Makefile
+++ b/Examples/MAX32670/I2C/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/I2C/README.md
+++ b/Examples/MAX32670/I2C/README.md
@@ -7,7 +7,7 @@ This example uses the I2C Master to read/write from/to the I2C Slave.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/I2C/project.mk
+++ b/Examples/MAX32670/I2C/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32670/I2C_MNGR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/I2C_MNGR/Makefile
+++ b/Examples/MAX32670/I2C_MNGR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/I2C_MNGR/README.md
+++ b/Examples/MAX32670/I2C_MNGR/README.md
@@ -11,7 +11,7 @@ You may change the configuration of each EEPROM's I2C transaction parameters (sl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/I2C_MNGR/project.mk
+++ b/Examples/MAX32670/I2C_MNGR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32670/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32670/I2C_SCAN/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/I2C_SCAN/Makefile
+++ b/Examples/MAX32670/I2C_SCAN/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/I2C_SCAN/README.md
+++ b/Examples/MAX32670/I2C_SCAN/README.md
@@ -6,7 +6,7 @@ This example uses the I2C Master to find the addresses of any I2C Slave devices 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/I2C_SCAN/project.mk
+++ b/Examples/MAX32670/I2C_SCAN/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32670/I2C_Sensor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/I2C_Sensor/Makefile
+++ b/Examples/MAX32670/I2C_Sensor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/I2C_Sensor/README.md
+++ b/Examples/MAX32670/I2C_Sensor/README.md
@@ -9,7 +9,7 @@ After initialization, a new reading is printed to the terminal every second.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/I2C_Sensor/project.mk
+++ b/Examples/MAX32670/I2C_Sensor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32670/I2S/.vscode/README.md
+++ b/Examples/MAX32670/I2S/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/I2S/Makefile
+++ b/Examples/MAX32670/I2S/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/I2S/README.md
+++ b/Examples/MAX32670/I2S/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/I2S/project.mk
+++ b/Examples/MAX32670/I2S/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/ICC/.vscode/README.md
+++ b/Examples/MAX32670/ICC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/ICC/Makefile
+++ b/Examples/MAX32670/ICC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/ICC/README.md
+++ b/Examples/MAX32670/ICC/README.md
@@ -12,7 +12,7 @@ This example demonstrates the time differences when running code with the instru
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/ICC/project.mk
+++ b/Examples/MAX32670/ICC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/LP/.vscode/README.md
+++ b/Examples/MAX32670/LP/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/LP/Makefile
+++ b/Examples/MAX32670/LP/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/LP/README.md
+++ b/Examples/MAX32670/LP/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/LP/project.mk
+++ b/Examples/MAX32670/LP/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/Library_Generate/.vscode/README.md
+++ b/Examples/MAX32670/Library_Generate/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
   * If it's not in the README, check the UG.
   * If it's not in the UG, open a ticket!
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
@@ -31,7 +31,7 @@ The following features are supported:
 
 The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.analog.com/en/education/education-library/videos/6313212752112.html).
 
-1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
     * [Windows](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0010820A)
     * [Linux (Ubuntu)](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018720A)
     * [MacOS](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018610A)

--- a/Examples/MAX32670/Library_Generate/Makefile
+++ b/Examples/MAX32670/Library_Generate/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/Library_Generate/README.md
+++ b/Examples/MAX32670/Library_Generate/README.md
@@ -9,7 +9,7 @@ Check the Library_Use demo to see how to link static libraries to an application
 
 ### Project Usage
 
-Universal instructions on building this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/Library_Generate/project.mk
+++ b/Examples/MAX32670/Library_Generate/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
  
 # **********************************************************
 

--- a/Examples/MAX32670/Library_Use/.vscode/README.md
+++ b/Examples/MAX32670/Library_Use/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/Library_Use/Makefile
+++ b/Examples/MAX32670/Library_Use/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/Library_Use/README.md
+++ b/Examples/MAX32670/Library_Use/README.md
@@ -9,7 +9,7 @@ to project.mk to see how to include ".a" static library files into your project.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/Library_Use/project.mk
+++ b/Examples/MAX32670/Library_Use/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32670/RTC/.vscode/README.md
+++ b/Examples/MAX32670/RTC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/RTC/Makefile
+++ b/Examples/MAX32670/RTC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/RTC/README.md
+++ b/Examples/MAX32670/RTC/README.md
@@ -13,7 +13,7 @@ The RTC is enabled and the sub-second alarm set to trigger every 250 ms.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/RTC/project.mk
+++ b/Examples/MAX32670/RTC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX32670/RTC_Backup/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/RTC_Backup/Makefile
+++ b/Examples/MAX32670/RTC_Backup/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/RTC_Backup/README.md
+++ b/Examples/MAX32670/RTC_Backup/README.md
@@ -10,7 +10,7 @@ The RTC time-of-day alarm is used to wake the device from backup mode every TIME
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/RTC_Backup/project.mk
+++ b/Examples/MAX32670/RTC_Backup/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/SPI/.vscode/README.md
+++ b/Examples/MAX32670/SPI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/SPI/Makefile
+++ b/Examples/MAX32670/SPI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/SPI/README.md
+++ b/Examples/MAX32670/SPI/README.md
@@ -11,7 +11,7 @@ By default, the example performs blocking SPI transactions.  To switch to non-bl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/SPI/project.mk
+++ b/Examples/MAX32670/SPI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/SPI_MasterSlave/.vscode/README.md
+++ b/Examples/MAX32670/SPI_MasterSlave/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/SPI_MasterSlave/Makefile
+++ b/Examples/MAX32670/SPI_MasterSlave/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/SPI_MasterSlave/README.md
+++ b/Examples/MAX32670/SPI_MasterSlave/README.md
@@ -11,7 +11,7 @@ Once the master ends the transaction, the data received by the master and the sl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/SPI_MasterSlave/project.mk
+++ b/Examples/MAX32670/SPI_MasterSlave/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32670/SPI_Usecase/.vscode/README.md
+++ b/Examples/MAX32670/SPI_Usecase/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/SPI_Usecase/Makefile
+++ b/Examples/MAX32670/SPI_Usecase/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/SPI_Usecase/README.md
+++ b/Examples/MAX32670/SPI_Usecase/README.md
@@ -9,7 +9,7 @@ Please connect SPI0 pins to SPI1 on EvKit
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/SPI_Usecase/project.mk
+++ b/Examples/MAX32670/SPI_Usecase/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/SecureROM_BL_Host/.vscode/README.md
+++ b/Examples/MAX32670/SecureROM_BL_Host/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/SecureROM_BL_Host/Makefile
+++ b/Examples/MAX32670/SecureROM_BL_Host/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/SecureROM_BL_Host/README.md
+++ b/Examples/MAX32670/SecureROM_BL_Host/README.md
@@ -22,7 +22,7 @@ Please check:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/SecureROM_BL_Host/project.mk
+++ b/Examples/MAX32670/SecureROM_BL_Host/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 
 # **********************************************************

--- a/Examples/MAX32670/SecureROM_BL_Host/script/README.md
+++ b/Examples/MAX32670/SecureROM_BL_Host/script/README.md
@@ -9,7 +9,7 @@ then each packet array will linked with a C structure.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/TMR/.vscode/README.md
+++ b/Examples/MAX32670/TMR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/TMR/Makefile
+++ b/Examples/MAX32670/TMR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/TMR/README.md
+++ b/Examples/MAX32670/TMR/README.md
@@ -15,7 +15,7 @@ Push PB1 to start the timers.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/TMR/project.mk
+++ b/Examples/MAX32670/TMR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/TRNG/.vscode/README.md
+++ b/Examples/MAX32670/TRNG/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/TRNG/Makefile
+++ b/Examples/MAX32670/TRNG/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/TRNG/README.md
+++ b/Examples/MAX32670/TRNG/README.md
@@ -7,7 +7,7 @@ The true random number generator (TRNG) hardware is exercised in this example.  
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/TRNG/project.mk
+++ b/Examples/MAX32670/TRNG/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32670/Temp_Monitor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/Temp_Monitor/Makefile
+++ b/Examples/MAX32670/Temp_Monitor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/Temp_Monitor/README.md
+++ b/Examples/MAX32670/Temp_Monitor/README.md
@@ -15,7 +15,7 @@ The temperature limits, flash storage page, and RTC time-of-day alarm period are
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/Temp_Monitor/project.mk
+++ b/Examples/MAX32670/Temp_Monitor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32670/UART/.vscode/README.md
+++ b/Examples/MAX32670/UART/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/UART/Makefile
+++ b/Examples/MAX32670/UART/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/UART/README.md
+++ b/Examples/MAX32670/UART/README.md
@@ -7,7 +7,7 @@ This application uses two serial ports to send and receive data.  One serial por
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/UART/project.mk
+++ b/Examples/MAX32670/UART/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/UCL/README.md
+++ b/Examples/MAX32670/UCL/README.md
@@ -9,7 +9,7 @@ TODO:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/UCL/project.mk
+++ b/Examples/MAX32670/UCL/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/Watchdog/.vscode/README.md
+++ b/Examples/MAX32670/Watchdog/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/Watchdog/Makefile
+++ b/Examples/MAX32670/Watchdog/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/Watchdog/README.md
+++ b/Examples/MAX32670/Watchdog/README.md
@@ -11,7 +11,7 @@ When the application begins, it initializes and starts the watchdog timer.  The 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32670/Watchdog/project.mk
+++ b/Examples/MAX32670/Watchdog/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32670/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32670/WearLeveling/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32670/WearLeveling/Makefile
+++ b/Examples/MAX32670/WearLeveling/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32670/WearLeveling/README.md
+++ b/Examples/MAX32670/WearLeveling/README.md
@@ -15,11 +15,11 @@ Enter "help" in the command line to see more details on the usage of each of the
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32670EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX32670EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32670/WearLeveling/project.mk
+++ b/Examples/MAX32670/WearLeveling/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32672/ADC/.vscode/README.md
+++ b/Examples/MAX32672/ADC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/ADC/Makefile
+++ b/Examples/MAX32672/ADC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/ADC/README.md
+++ b/Examples/MAX32672/ADC/README.md
@@ -14,7 +14,7 @@ The example can be configured to either use a polling, interrupt, or DMA driven 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/ADC/project.mk
+++ b/Examples/MAX32672/ADC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/AES/.vscode/README.md
+++ b/Examples/MAX32672/AES/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/AES/Makefile
+++ b/Examples/MAX32672/AES/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/AES/README.md
+++ b/Examples/MAX32672/AES/README.md
@@ -6,7 +6,7 @@ This application demonstrates both encryption and decryption using AES.  A block
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/AES/project.mk
+++ b/Examples/MAX32672/AES/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/ARM-DSP/README.md
+++ b/Examples/MAX32672/ARM-DSP/README.md
@@ -14,7 +14,7 @@ Development with Visual Studio Code is also supported.  See [VSCode-Maxim](https
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_bayes_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/ARM-DSP/arm_bayes_example/project.mk
+++ b/Examples/MAX32672/ARM-DSP/arm_bayes_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32672/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_class_marks_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/ARM-DSP/arm_class_marks_example/project.mk
+++ b/Examples/MAX32672/ARM-DSP/arm_class_marks_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32672/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_convolution_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/ARM-DSP/arm_convolution_example/project.mk
+++ b/Examples/MAX32672/ARM-DSP/arm_convolution_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32672/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/ARM-DSP/arm_dotproduct_example_f32/project.mk
+++ b/Examples/MAX32672/ARM-DSP/arm_dotproduct_example_f32/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32672/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_fft_bin_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/ARM-DSP/arm_fft_bin_example/project.mk
+++ b/Examples/MAX32672/ARM-DSP/arm_fft_bin_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32672/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_fir_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/ARM-DSP/arm_fir_example/project.mk
+++ b/Examples/MAX32672/ARM-DSP/arm_fir_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32672/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/ARM-DSP/arm_graphic_equalizer_example/project.mk
+++ b/Examples/MAX32672/ARM-DSP/arm_graphic_equalizer_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32672/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_linear_interp_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/ARM-DSP/arm_linear_interp_example/project.mk
+++ b/Examples/MAX32672/ARM-DSP/arm_linear_interp_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32672/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_matrix_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/ARM-DSP/arm_matrix_example/project.mk
+++ b/Examples/MAX32672/ARM-DSP/arm_matrix_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32672/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_signal_converge_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/ARM-DSP/arm_signal_converge_example/project.mk
+++ b/Examples/MAX32672/ARM-DSP/arm_signal_converge_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32672/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_sin_cos_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/ARM-DSP/arm_sin_cos_example/project.mk
+++ b/Examples/MAX32672/ARM-DSP/arm_sin_cos_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32672/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_svm_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/ARM-DSP/arm_svm_example/project.mk
+++ b/Examples/MAX32672/ARM-DSP/arm_svm_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32672/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_variance_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/ARM-DSP/arm_variance_example/project.mk
+++ b/Examples/MAX32672/ARM-DSP/arm_variance_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32672/CRC/.vscode/README.md
+++ b/Examples/MAX32672/CRC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/CRC/Makefile
+++ b/Examples/MAX32672/CRC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/CRC/README.md
+++ b/Examples/MAX32672/CRC/README.md
@@ -6,7 +6,7 @@ This example demonstrates the use of the HW CRC calculator.  The example first g
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/CRC/project.mk
+++ b/Examples/MAX32672/CRC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/CTB_AES/.vscode/README.md
+++ b/Examples/MAX32672/CTB_AES/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/CTB_AES/Makefile
+++ b/Examples/MAX32672/CTB_AES/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/CTB_AES/README.md
+++ b/Examples/MAX32672/CTB_AES/README.md
@@ -6,7 +6,7 @@ This application demonstrates both encryption and decryption using the Crypto To
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/CTB_AES/project.mk
+++ b/Examples/MAX32672/CTB_AES/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/Comparator/.vscode/README.md
+++ b/Examples/MAX32672/Comparator/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/Comparator/Makefile
+++ b/Examples/MAX32672/Comparator/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/Comparator/README.md
+++ b/Examples/MAX32672/Comparator/README.md
@@ -8,7 +8,7 @@ The example is configured to use analog channels 3 and 7 as the negative and pos
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/Comparator/project.mk
+++ b/Examples/MAX32672/Comparator/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/Coremark/.vscode/README.md
+++ b/Examples/MAX32672/Coremark/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/Coremark/Makefile
+++ b/Examples/MAX32672/Coremark/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/Coremark/README.md
+++ b/Examples/MAX32672/Coremark/README.md
@@ -10,7 +10,7 @@ For more information, visit the [CoreMark webpage](https://www.eembc.org/coremar
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/Coremark/project.mk
+++ b/Examples/MAX32672/Coremark/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/DMA/.vscode/README.md
+++ b/Examples/MAX32672/DMA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/DMA/Makefile
+++ b/Examples/MAX32672/DMA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/DMA/README.md
+++ b/Examples/MAX32672/DMA/README.md
@@ -8,7 +8,7 @@ A second more complex memory-to-memory DMA transaction is then shown that chains
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/DMA/project.mk
+++ b/Examples/MAX32672/DMA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/Demo/.vscode/README.md
+++ b/Examples/MAX32672/Demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/Demo/Makefile
+++ b/Examples/MAX32672/Demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/Demo/README.md
+++ b/Examples/MAX32672/Demo/README.md
@@ -12,7 +12,7 @@ Features:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/Demo/project.mk
+++ b/Examples/MAX32672/Demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/Display/.vscode/README.md
+++ b/Examples/MAX32672/Display/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/Display/Makefile
+++ b/Examples/MAX32672/Display/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/Display/README.md
+++ b/Examples/MAX32672/Display/README.md
@@ -17,7 +17,7 @@ Note: This example only works on MAX32672EVKIT not on MAX32672FTHR board.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/Display/project.mk
+++ b/Examples/MAX32672/Display/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32672/EEPROM_Emulator/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32672/EEPROM_Emulator/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/EEPROM_Emulator/README.md
+++ b/Examples/MAX32672/EEPROM_Emulator/README.md
@@ -47,7 +47,7 @@ To help with syncronization, a "Ready Signal" is set up as an output from a GPIO
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/EEPROM_Emulator/project.mk
+++ b/Examples/MAX32672/EEPROM_Emulator/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/Flash/.vscode/README.md
+++ b/Examples/MAX32672/Flash/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/Flash/Makefile
+++ b/Examples/MAX32672/Flash/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/Flash/README.md
+++ b/Examples/MAX32672/Flash/README.md
@@ -21,7 +21,7 @@ The _second_ time the example is run the application will see the "magic" 32-bit
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
@@ -42,9 +42,9 @@ If using the MAX32672FTHR:
 
 ## Building and Running
 
-**See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
+**See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
 
-This example supports all available MAX32672 evaluation platforms but comes _pre-configured_ for the MAX32672EVKIT by default.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
+This example supports all available MAX32672 evaluation platforms but comes _pre-configured_ for the MAX32672EVKIT by default.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
 
 ## Expected Output
 

--- a/Examples/MAX32672/Flash/project.mk
+++ b/Examples/MAX32672/Flash/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32672/Flash_CLI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/Flash_CLI/Makefile
+++ b/Examples/MAX32672/Flash_CLI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/Flash_CLI/README.md
+++ b/Examples/MAX32672/Flash_CLI/README.md
@@ -16,7 +16,7 @@ For more details on how to input these commands, enter "help" in the terminal wi
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/Flash_CLI/project.mk
+++ b/Examples/MAX32672/Flash_CLI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32672/FreeRTOSDemo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32672/FreeRTOSDemo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/FreeRTOSDemo/README.md
+++ b/Examples/MAX32672/FreeRTOSDemo/README.md
@@ -19,7 +19,7 @@ For more information on how to input these commands enter "help" into the serial
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/FreeRTOSDemo/project.mk
+++ b/Examples/MAX32672/FreeRTOSDemo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/GPIO/.vscode/README.md
+++ b/Examples/MAX32672/GPIO/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/GPIO/Makefile
+++ b/Examples/MAX32672/GPIO/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/GPIO/README.md
+++ b/Examples/MAX32672/GPIO/README.md
@@ -8,7 +8,7 @@ An interrupt is set up to trigger when the button (SW3, P0.18) is pressed. When 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/GPIO/project.mk
+++ b/Examples/MAX32672/GPIO/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/Hello_World/.vscode/README.md
+++ b/Examples/MAX32672/Hello_World/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/Hello_World/Makefile
+++ b/Examples/MAX32672/Hello_World/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/Hello_World/README.md
+++ b/Examples/MAX32672/Hello_World/README.md
@@ -8,7 +8,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/Hello_World/project.mk
+++ b/Examples/MAX32672/Hello_World/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32672/Hello_World_Cpp/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/Hello_World_Cpp/Makefile
+++ b/Examples/MAX32672/Hello_World_Cpp/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/Hello_World_Cpp/README.md
+++ b/Examples/MAX32672/Hello_World_Cpp/README.md
@@ -8,7 +8,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/Hello_World_Cpp/project.mk
+++ b/Examples/MAX32672/Hello_World_Cpp/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32672/I2C/.vscode/README.md
+++ b/Examples/MAX32672/I2C/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/I2C/Makefile
+++ b/Examples/MAX32672/I2C/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/I2C/README.md
+++ b/Examples/MAX32672/I2C/README.md
@@ -6,7 +6,7 @@ This example uses the I2C0 as an I2C master to read/write from/to I2C2, an I2C s
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/I2C/project.mk
+++ b/Examples/MAX32672/I2C/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32672/I2C_MNGR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/I2C_MNGR/Makefile
+++ b/Examples/MAX32672/I2C_MNGR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/I2C_MNGR/README.md
+++ b/Examples/MAX32672/I2C_MNGR/README.md
@@ -8,7 +8,7 @@ More specifically, in this example the EEPROM0 task attempts to read data from E
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/I2C_MNGR/project.mk
+++ b/Examples/MAX32672/I2C_MNGR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32672/I2C_SCAN/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/I2C_SCAN/Makefile
+++ b/Examples/MAX32672/I2C_SCAN/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/I2C_SCAN/README.md
+++ b/Examples/MAX32672/I2C_SCAN/README.md
@@ -6,7 +6,7 @@ This example finds the addresses of any I2C Slave devices connected to the bus.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/I2C_SCAN/project.mk
+++ b/Examples/MAX32672/I2C_SCAN/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32672/I2C_Sensor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/I2C_Sensor/Makefile
+++ b/Examples/MAX32672/I2C_Sensor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/I2C_Sensor/README.md
+++ b/Examples/MAX32672/I2C_Sensor/README.md
@@ -8,7 +8,7 @@ After initialization, a new reading is printed to the terminal every second.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/I2C_Sensor/project.mk
+++ b/Examples/MAX32672/I2C_Sensor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/I2S/.vscode/README.md
+++ b/Examples/MAX32672/I2S/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/I2S/Makefile
+++ b/Examples/MAX32672/I2S/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/I2S/README.md
+++ b/Examples/MAX32672/I2S/README.md
@@ -6,7 +6,7 @@ This example demonstrates the use of I2S peripheral. In this example sixty four 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/I2S/project.mk
+++ b/Examples/MAX32672/I2S/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/ICC/.vscode/README.md
+++ b/Examples/MAX32672/ICC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/ICC/Makefile
+++ b/Examples/MAX32672/ICC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/ICC/README.md
+++ b/Examples/MAX32672/ICC/README.md
@@ -8,7 +8,7 @@ Two test functions (one which runs 2.5 million operations and the other which ru
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/ICC/project.mk
+++ b/Examples/MAX32672/ICC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/LP/.vscode/README.md
+++ b/Examples/MAX32672/LP/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/LP/Makefile
+++ b/Examples/MAX32672/LP/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/LP/README.md
+++ b/Examples/MAX32672/LP/README.md
@@ -10,7 +10,7 @@ Either the push button or the RTC may be used as a wakeup source in this example
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/LP/project.mk
+++ b/Examples/MAX32672/LP/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/Library_Generate/.vscode/README.md
+++ b/Examples/MAX32672/Library_Generate/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
   * If it's not in the README, check the UG.
   * If it's not in the UG, open a ticket!
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
@@ -31,7 +31,7 @@ The following features are supported:
 
 The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.analog.com/en/education/education-library/videos/6313212752112.html).
 
-1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
     * [Windows](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0010820A)
     * [Linux (Ubuntu)](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018720A)
     * [MacOS](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018610A)

--- a/Examples/MAX32672/Library_Generate/Makefile
+++ b/Examples/MAX32672/Library_Generate/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/Library_Generate/README.md
+++ b/Examples/MAX32672/Library_Generate/README.md
@@ -9,7 +9,7 @@ Check the Library_Use demo to see how to link static libraries to an application
 
 ### Project Usage
 
-Universal instructions on building this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/Library_Generate/project.mk
+++ b/Examples/MAX32672/Library_Generate/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
  
 # **********************************************************
 

--- a/Examples/MAX32672/Library_Use/.vscode/README.md
+++ b/Examples/MAX32672/Library_Use/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/Library_Use/Makefile
+++ b/Examples/MAX32672/Library_Use/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/Library_Use/README.md
+++ b/Examples/MAX32672/Library_Use/README.md
@@ -9,11 +9,11 @@ to project.mk to see how to include ".a" static library files into your project.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-This example supports all available MAX32672 evaluation platforms but comes _pre-configured_ for the MAX32672EVKIT by default. See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
+This example supports all available MAX32672 evaluation platforms but comes _pre-configured_ for the MAX32672EVKIT by default. See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
 
 ## Required Connections
 

--- a/Examples/MAX32672/Library_Use/project.mk
+++ b/Examples/MAX32672/Library_Use/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/OLED_Demo/.vscode/README.md
+++ b/Examples/MAX32672/OLED_Demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/OLED_Demo/Makefile
+++ b/Examples/MAX32672/OLED_Demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/OLED_Demo/README.md
+++ b/Examples/MAX32672/OLED_Demo/README.md
@@ -15,7 +15,7 @@ Please check project.mk to learn how compile lvgl in MSDK.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/OLED_Demo/project.mk
+++ b/Examples/MAX32672/OLED_Demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/QDEC/.vscode/README.md
+++ b/Examples/MAX32672/QDEC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/QDEC/Makefile
+++ b/Examples/MAX32672/QDEC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/QDEC/README.md
+++ b/Examples/MAX32672/QDEC/README.md
@@ -8,7 +8,7 @@ The example configures the QDEC with the Compare and Reset on MAXCNT functions. 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/QDEC/project.mk
+++ b/Examples/MAX32672/QDEC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/RTC/.vscode/README.md
+++ b/Examples/MAX32672/RTC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/RTC/Makefile
+++ b/Examples/MAX32672/RTC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/RTC/README.md
+++ b/Examples/MAX32672/RTC/README.md
@@ -13,7 +13,7 @@ Pressing SW3 will output the current value of the RTC to the console UART.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/RTC/project.mk
+++ b/Examples/MAX32672/RTC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX32672/RTC_Backup/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/RTC_Backup/Makefile
+++ b/Examples/MAX32672/RTC_Backup/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/RTC_Backup/README.md
+++ b/Examples/MAX32672/RTC_Backup/README.md
@@ -8,7 +8,7 @@ The RTC time-of-day alarm is used to wake the device from backup mode every TIME
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/RTC_Backup/project.mk
+++ b/Examples/MAX32672/RTC_Backup/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/SCPA_OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32672/SCPA_OTP_Dump/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/SCPA_OTP_Dump/Makefile
+++ b/Examples/MAX32672/SCPA_OTP_Dump/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/SCPA_OTP_Dump/README.md
+++ b/Examples/MAX32672/SCPA_OTP_Dump/README.md
@@ -18,7 +18,7 @@ PROJ_CFLAGS+=-DMAX32672_A1
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/SCPA_OTP_Dump/project.mk
+++ b/Examples/MAX32672/SCPA_OTP_Dump/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/SPI/.vscode/README.md
+++ b/Examples/MAX32672/SPI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/SPI/Makefile
+++ b/Examples/MAX32672/SPI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/SPI/README.md
+++ b/Examples/MAX32672/SPI/README.md
@@ -10,7 +10,7 @@ By default, the example performs blocking SPI transactions.  To switch to non-bl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/SPI/project.mk
+++ b/Examples/MAX32672/SPI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/SPI_MasterSlave/.vscode/README.md
+++ b/Examples/MAX32672/SPI_MasterSlave/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/SPI_MasterSlave/Makefile
+++ b/Examples/MAX32672/SPI_MasterSlave/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/SPI_MasterSlave/README.md
+++ b/Examples/MAX32672/SPI_MasterSlave/README.md
@@ -10,7 +10,7 @@ Once the master ends the transaction, the data received by the master and the sl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/SPI_MasterSlave/project.mk
+++ b/Examples/MAX32672/SPI_MasterSlave/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/TMR/.vscode/README.md
+++ b/Examples/MAX32672/TMR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/TMR/Makefile
+++ b/Examples/MAX32672/TMR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/TMR/README.md
+++ b/Examples/MAX32672/TMR/README.md
@@ -14,7 +14,7 @@ LED pins on FTHR  board:  LED0:P0.2   LED1:P0.3
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/TMR/project.mk
+++ b/Examples/MAX32672/TMR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/TRNG/.vscode/README.md
+++ b/Examples/MAX32672/TRNG/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/TRNG/Makefile
+++ b/Examples/MAX32672/TRNG/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/TRNG/README.md
+++ b/Examples/MAX32672/TRNG/README.md
@@ -6,7 +6,7 @@ The true random number generator (TRNG) hardware is exercised in this example.  
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/TRNG/project.mk
+++ b/Examples/MAX32672/TRNG/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32672/Temp_Monitor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/Temp_Monitor/Makefile
+++ b/Examples/MAX32672/Temp_Monitor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/Temp_Monitor/README.md
+++ b/Examples/MAX32672/Temp_Monitor/README.md
@@ -14,7 +14,7 @@ The temperature limits, flash storage page, and RTC time-of-day alarm period are
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/Temp_Monitor/project.mk
+++ b/Examples/MAX32672/Temp_Monitor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/UART/.vscode/README.md
+++ b/Examples/MAX32672/UART/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/UART/Makefile
+++ b/Examples/MAX32672/UART/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/UART/README.md
+++ b/Examples/MAX32672/UART/README.md
@@ -8,7 +8,7 @@ By default the reading UART does an asynchronus read, however it can instead do 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/UART/project.mk
+++ b/Examples/MAX32672/UART/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/UCL/README.md
+++ b/Examples/MAX32672/UCL/README.md
@@ -9,7 +9,7 @@ TODO:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/UCL/project.mk
+++ b/Examples/MAX32672/UCL/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/Watchdog/.vscode/README.md
+++ b/Examples/MAX32672/Watchdog/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/Watchdog/Makefile
+++ b/Examples/MAX32672/Watchdog/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/Watchdog/README.md
+++ b/Examples/MAX32672/Watchdog/README.md
@@ -10,7 +10,7 @@ When SW3 (P0.18) is pressed, the application will intentionally force a watchdog
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32672/Watchdog/project.mk
+++ b/Examples/MAX32672/Watchdog/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32672/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32672/WearLeveling/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32672/WearLeveling/Makefile
+++ b/Examples/MAX32672/WearLeveling/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32672/WearLeveling/README.md
+++ b/Examples/MAX32672/WearLeveling/README.md
@@ -15,11 +15,11 @@ Enter "help" in the command line to see more details on the usage of each of the
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32672EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX32672EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32672/WearLeveling/project.mk
+++ b/Examples/MAX32672/WearLeveling/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32675/ADC/.vscode/README.md
+++ b/Examples/MAX32675/ADC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/ADC/Makefile
+++ b/Examples/MAX32675/ADC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/ADC/README.md
+++ b/Examples/MAX32675/ADC/README.md
@@ -9,7 +9,7 @@ Each of the ADC modules are set to sample differentially between ADC channels AI
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/ADC/project.mk
+++ b/Examples/MAX32675/ADC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/AES/.vscode/README.md
+++ b/Examples/MAX32675/AES/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/AES/Makefile
+++ b/Examples/MAX32675/AES/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/AES/README.md
+++ b/Examples/MAX32675/AES/README.md
@@ -7,7 +7,7 @@ This application demonstrates both encryption and decryption using AES.  A block
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/AES/project.mk
+++ b/Examples/MAX32675/AES/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/AFE_DAC/.vscode/README.md
+++ b/Examples/MAX32675/AFE_DAC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/AFE_DAC/Makefile
+++ b/Examples/MAX32675/AFE_DAC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/AFE_DAC/README.md
+++ b/Examples/MAX32675/AFE_DAC/README.md
@@ -7,7 +7,7 @@ This example configures the MAX32675 AFE 12-Bit DAC to output 1V.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/AFE_DAC/project.mk
+++ b/Examples/MAX32675/AFE_DAC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/ARM-DSP/README.md
+++ b/Examples/MAX32675/ARM-DSP/README.md
@@ -14,7 +14,7 @@ Development with Visual Studio Code is also supported.  See [VSCode-Maxim](https
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_bayes_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/ARM-DSP/arm_bayes_example/project.mk
+++ b/Examples/MAX32675/ARM-DSP/arm_bayes_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32675/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_class_marks_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/ARM-DSP/arm_class_marks_example/project.mk
+++ b/Examples/MAX32675/ARM-DSP/arm_class_marks_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32675/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_convolution_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/ARM-DSP/arm_convolution_example/project.mk
+++ b/Examples/MAX32675/ARM-DSP/arm_convolution_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32675/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/ARM-DSP/arm_dotproduct_example_f32/project.mk
+++ b/Examples/MAX32675/ARM-DSP/arm_dotproduct_example_f32/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32675/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_fft_bin_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/ARM-DSP/arm_fft_bin_example/project.mk
+++ b/Examples/MAX32675/ARM-DSP/arm_fft_bin_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32675/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_fir_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/ARM-DSP/arm_fir_example/project.mk
+++ b/Examples/MAX32675/ARM-DSP/arm_fir_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32675/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/ARM-DSP/arm_graphic_equalizer_example/project.mk
+++ b/Examples/MAX32675/ARM-DSP/arm_graphic_equalizer_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32675/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_linear_interp_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/ARM-DSP/arm_linear_interp_example/project.mk
+++ b/Examples/MAX32675/ARM-DSP/arm_linear_interp_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32675/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_matrix_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/ARM-DSP/arm_matrix_example/project.mk
+++ b/Examples/MAX32675/ARM-DSP/arm_matrix_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32675/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_signal_converge_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/ARM-DSP/arm_signal_converge_example/project.mk
+++ b/Examples/MAX32675/ARM-DSP/arm_signal_converge_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32675/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_sin_cos_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/ARM-DSP/arm_sin_cos_example/project.mk
+++ b/Examples/MAX32675/ARM-DSP/arm_sin_cos_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32675/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_svm_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/ARM-DSP/arm_svm_example/project.mk
+++ b/Examples/MAX32675/ARM-DSP/arm_svm_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32675/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_variance_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/ARM-DSP/arm_variance_example/project.mk
+++ b/Examples/MAX32675/ARM-DSP/arm_variance_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32675/CRC/.vscode/README.md
+++ b/Examples/MAX32675/CRC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/CRC/Makefile
+++ b/Examples/MAX32675/CRC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/CRC/README.md
+++ b/Examples/MAX32675/CRC/README.md
@@ -7,7 +7,7 @@ This example demonstrates the various uses of the Flash Memory Controller. Initi
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/CRC/project.mk
+++ b/Examples/MAX32675/CRC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/Coremark/.vscode/README.md
+++ b/Examples/MAX32675/Coremark/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/Coremark/Makefile
+++ b/Examples/MAX32675/Coremark/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/Coremark/README.md
+++ b/Examples/MAX32675/Coremark/README.md
@@ -10,7 +10,7 @@ For more information, visit the [CoreMark webpage](https://www.eembc.org/coremar
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/Coremark/project.mk
+++ b/Examples/MAX32675/Coremark/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/DMA/.vscode/README.md
+++ b/Examples/MAX32675/DMA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/DMA/Makefile
+++ b/Examples/MAX32675/DMA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/DMA/README.md
+++ b/Examples/MAX32675/DMA/README.md
@@ -9,7 +9,7 @@ A second more complex memory-to-memory DMA transaction is then shown that chains
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/DMA/project.mk
+++ b/Examples/MAX32675/DMA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32675/EEPROM_Emulator/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32675/EEPROM_Emulator/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/EEPROM_Emulator/README.md
+++ b/Examples/MAX32675/EEPROM_Emulator/README.md
@@ -48,7 +48,7 @@ To help with syncronization, a "Ready Signal" is set up as an output from a GPIO
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/EEPROM_Emulator/project.mk
+++ b/Examples/MAX32675/EEPROM_Emulator/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/Flash/.vscode/README.md
+++ b/Examples/MAX32675/Flash/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/Flash/Makefile
+++ b/Examples/MAX32675/Flash/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/Flash/README.md
+++ b/Examples/MAX32675/Flash/README.md
@@ -21,7 +21,7 @@ The _second_ time the example is run the application will see the "magic" 32-bit
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
@@ -37,7 +37,7 @@ MAX32675EVKIT:
 
 ## Building and Running
 
-**See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
+**See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
 
 ## Expected Output
 

--- a/Examples/MAX32675/Flash/project.mk
+++ b/Examples/MAX32675/Flash/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32675/Flash_CLI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/Flash_CLI/Makefile
+++ b/Examples/MAX32675/Flash_CLI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/Flash_CLI/README.md
+++ b/Examples/MAX32675/Flash_CLI/README.md
@@ -9,7 +9,7 @@ This example demonstates the CLI commands feature of FreeRTOS, various features 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/Flash_CLI/project.mk
+++ b/Examples/MAX32675/Flash_CLI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32675/FreeRTOSDemo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32675/FreeRTOSDemo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/FreeRTOSDemo/README.md
+++ b/Examples/MAX32675/FreeRTOSDemo/README.md
@@ -7,7 +7,7 @@ A basic getting started application for FreeRTOS.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/FreeRTOSDemo/project.mk
+++ b/Examples/MAX32675/FreeRTOSDemo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/GPIO/.vscode/README.md
+++ b/Examples/MAX32675/GPIO/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/GPIO/Makefile
+++ b/Examples/MAX32675/GPIO/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/GPIO/README.md
+++ b/Examples/MAX32675/GPIO/README.md
@@ -11,7 +11,7 @@ Please check the board.c file in ${MSDKPath}\Libraries\Boards\MAX32675\${BoardNa
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/GPIO/project.mk
+++ b/Examples/MAX32675/GPIO/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/HART_UART/.vscode/README.md
+++ b/Examples/MAX32675/HART_UART/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/HART_UART/Makefile
+++ b/Examples/MAX32675/HART_UART/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/HART_UART/README.md
+++ b/Examples/MAX32675/HART_UART/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/HART_UART/project.mk
+++ b/Examples/MAX32675/HART_UART/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/Hello_World/.vscode/README.md
+++ b/Examples/MAX32675/Hello_World/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/Hello_World/Makefile
+++ b/Examples/MAX32675/Hello_World/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/Hello_World/README.md
+++ b/Examples/MAX32675/Hello_World/README.md
@@ -9,7 +9,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/Hello_World/project.mk
+++ b/Examples/MAX32675/Hello_World/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32675/Hello_World_Cpp/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/Hello_World_Cpp/Makefile
+++ b/Examples/MAX32675/Hello_World_Cpp/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/Hello_World_Cpp/README.md
+++ b/Examples/MAX32675/Hello_World_Cpp/README.md
@@ -8,7 +8,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/Hello_World_Cpp/project.mk
+++ b/Examples/MAX32675/Hello_World_Cpp/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32675/I2C/.vscode/README.md
+++ b/Examples/MAX32675/I2C/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/I2C/Makefile
+++ b/Examples/MAX32675/I2C/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/I2C/README.md
+++ b/Examples/MAX32675/I2C/README.md
@@ -7,7 +7,7 @@ This example uses the I2C Master to read/write from/to the I2C Slave.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/I2C/project.mk
+++ b/Examples/MAX32675/I2C/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32675/I2C_MNGR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/I2C_MNGR/Makefile
+++ b/Examples/MAX32675/I2C_MNGR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/I2C_MNGR/README.md
+++ b/Examples/MAX32675/I2C_MNGR/README.md
@@ -11,7 +11,7 @@ You may change the configuration of each EEPROM's I2C transaction parameters (sl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/I2C_MNGR/project.mk
+++ b/Examples/MAX32675/I2C_MNGR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32675/I2C_SCAN/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/I2C_SCAN/Makefile
+++ b/Examples/MAX32675/I2C_SCAN/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/I2C_SCAN/README.md
+++ b/Examples/MAX32675/I2C_SCAN/README.md
@@ -6,7 +6,7 @@ This example uses the I2C Master to find the addresses of any I2C Slave devices 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/I2C_SCAN/project.mk
+++ b/Examples/MAX32675/I2C_SCAN/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32675/I2C_Sensor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/I2C_Sensor/Makefile
+++ b/Examples/MAX32675/I2C_Sensor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/I2C_Sensor/README.md
+++ b/Examples/MAX32675/I2C_Sensor/README.md
@@ -9,7 +9,7 @@ After initialization, a new reading is printed to the terminal every second.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/I2C_Sensor/project.mk
+++ b/Examples/MAX32675/I2C_Sensor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/I2S/.vscode/README.md
+++ b/Examples/MAX32675/I2S/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/I2S/Makefile
+++ b/Examples/MAX32675/I2S/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/I2S/README.md
+++ b/Examples/MAX32675/I2S/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/I2S/project.mk
+++ b/Examples/MAX32675/I2S/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/ICC/.vscode/README.md
+++ b/Examples/MAX32675/ICC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/ICC/Makefile
+++ b/Examples/MAX32675/ICC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/ICC/README.md
+++ b/Examples/MAX32675/ICC/README.md
@@ -12,7 +12,7 @@ This example demonstrates the time differences when running code with the instru
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/ICC/project.mk
+++ b/Examples/MAX32675/ICC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/LP/.vscode/README.md
+++ b/Examples/MAX32675/LP/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/LP/Makefile
+++ b/Examples/MAX32675/LP/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/LP/README.md
+++ b/Examples/MAX32675/LP/README.md
@@ -9,7 +9,7 @@ To move to the next power state push button 0 (SW1).
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/LP/project.mk
+++ b/Examples/MAX32675/LP/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/Library_Generate/.vscode/README.md
+++ b/Examples/MAX32675/Library_Generate/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
   * If it's not in the README, check the UG.
   * If it's not in the UG, open a ticket!
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
@@ -31,7 +31,7 @@ The following features are supported:
 
 The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.analog.com/en/education/education-library/videos/6313212752112.html).
 
-1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
     * [Windows](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0010820A)
     * [Linux (Ubuntu)](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018720A)
     * [MacOS](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018610A)

--- a/Examples/MAX32675/Library_Generate/Makefile
+++ b/Examples/MAX32675/Library_Generate/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/Library_Generate/README.md
+++ b/Examples/MAX32675/Library_Generate/README.md
@@ -9,7 +9,7 @@ Check the Library_Use demo to see how to link static libraries to an application
 
 ### Project Usage
 
-Universal instructions on building this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/Library_Generate/project.mk
+++ b/Examples/MAX32675/Library_Generate/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
  
 # **********************************************************
 

--- a/Examples/MAX32675/Library_Use/.vscode/README.md
+++ b/Examples/MAX32675/Library_Use/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/Library_Use/Makefile
+++ b/Examples/MAX32675/Library_Use/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/Library_Use/README.md
+++ b/Examples/MAX32675/Library_Use/README.md
@@ -9,11 +9,11 @@ to project.mk to see how to include ".a" static library files into your project.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-This example supports all available MAX32675 evaluation platforms but comes _pre-configured_ for the MAX32675EVKIT by default. See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
+This example supports all available MAX32675 evaluation platforms but comes _pre-configured_ for the MAX32675EVKIT by default. See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
 
 ## Required Connections
 

--- a/Examples/MAX32675/Library_Use/project.mk
+++ b/Examples/MAX32675/Library_Use/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/SPI/.vscode/README.md
+++ b/Examples/MAX32675/SPI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/SPI/Makefile
+++ b/Examples/MAX32675/SPI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/SPI/README.md
+++ b/Examples/MAX32675/SPI/README.md
@@ -11,7 +11,7 @@ By default, the example performs blocking SPI transactions.  To switch to non-bl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/SPI/project.mk
+++ b/Examples/MAX32675/SPI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/TMR/.vscode/README.md
+++ b/Examples/MAX32675/TMR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/TMR/Makefile
+++ b/Examples/MAX32675/TMR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/TMR/README.md
+++ b/Examples/MAX32675/TMR/README.md
@@ -15,7 +15,7 @@ Push PB1 to start the timers.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/TMR/project.mk
+++ b/Examples/MAX32675/TMR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/TRNG/.vscode/README.md
+++ b/Examples/MAX32675/TRNG/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/TRNG/Makefile
+++ b/Examples/MAX32675/TRNG/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/TRNG/README.md
+++ b/Examples/MAX32675/TRNG/README.md
@@ -7,7 +7,7 @@ The true random number generator (TRNG) hardware is exercised in this example.  
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/TRNG/project.mk
+++ b/Examples/MAX32675/TRNG/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/UART/.vscode/README.md
+++ b/Examples/MAX32675/UART/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/UART/Makefile
+++ b/Examples/MAX32675/UART/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/UART/README.md
+++ b/Examples/MAX32675/UART/README.md
@@ -7,7 +7,7 @@ This application uses two serial ports to send and receive data.  One serial por
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/UART/project.mk
+++ b/Examples/MAX32675/UART/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/Watchdog/.vscode/README.md
+++ b/Examples/MAX32675/Watchdog/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/Watchdog/Makefile
+++ b/Examples/MAX32675/Watchdog/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/Watchdog/README.md
+++ b/Examples/MAX32675/Watchdog/README.md
@@ -13,7 +13,7 @@ Please check the board.c file in ${MSDKPath}\Libraries\Boards\MAX32675\${BoardNa
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32675/Watchdog/project.mk
+++ b/Examples/MAX32675/Watchdog/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32675/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32675/WearLeveling/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32675/WearLeveling/Makefile
+++ b/Examples/MAX32675/WearLeveling/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32675/WearLeveling/README.md
+++ b/Examples/MAX32675/WearLeveling/README.md
@@ -15,11 +15,11 @@ Enter "help" in the command line to see more details on the usage of each of the
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32675EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX32675EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32675/WearLeveling/project.mk
+++ b/Examples/MAX32675/WearLeveling/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32680/ADC/.vscode/README.md
+++ b/Examples/MAX32680/ADC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/ADC/Makefile
+++ b/Examples/MAX32680/ADC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/ADC/README.md
+++ b/Examples/MAX32680/ADC/README.md
@@ -11,7 +11,7 @@ Any reading that exceeds the full-scale value of the ADC will have an '*' append
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/ADC/project.mk
+++ b/Examples/MAX32680/ADC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/AES/.vscode/README.md
+++ b/Examples/MAX32680/AES/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/AES/Makefile
+++ b/Examples/MAX32680/AES/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/AES/README.md
+++ b/Examples/MAX32680/AES/README.md
@@ -8,7 +8,7 @@ This application demonstrates both encryption and decryption using AES.  A block
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/AES/project.mk
+++ b/Examples/MAX32680/AES/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/AFE_ADC/.vscode/README.md
+++ b/Examples/MAX32680/AFE_ADC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/AFE_ADC/Makefile
+++ b/Examples/MAX32680/AFE_ADC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/AFE_ADC/README.md
+++ b/Examples/MAX32680/AFE_ADC/README.md
@@ -9,7 +9,7 @@ Each of the ADC modules are set to sample differentially between ADC channels AI
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/AFE_ADC/project.mk
+++ b/Examples/MAX32680/AFE_ADC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/ARM-DSP/README.md
+++ b/Examples/MAX32680/ARM-DSP/README.md
@@ -14,7 +14,7 @@ Development with Visual Studio Code is also supported.  See [VSCode-Maxim](https
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_bayes_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_class_marks_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_convolution_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_fft_bin_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_fir_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_linear_interp_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_matrix_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_signal_converge_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_sin_cos_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_svm_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_variance_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/Bluetooth/BLE4_ctr/.vscode/README.md
+++ b/Examples/MAX32680/Bluetooth/BLE4_ctr/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/Bluetooth/BLE4_ctr/Makefile
+++ b/Examples/MAX32680/Bluetooth/BLE4_ctr/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/Bluetooth/BLE4_ctr/README.md
+++ b/Examples/MAX32680/Bluetooth/BLE4_ctr/README.md
@@ -95,7 +95,7 @@ lctrSlvAdvExecuteSm: state=0, event=0
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/Bluetooth/BLE4_ctr/project.mk
+++ b/Examples/MAX32680/Bluetooth/BLE4_ctr/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/Bluetooth/BLE_dats/.vscode/README.md
+++ b/Examples/MAX32680/Bluetooth/BLE_dats/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/Bluetooth/BLE_dats/Makefile
+++ b/Examples/MAX32680/Bluetooth/BLE_dats/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/Bluetooth/BLE_dats/README.md
+++ b/Examples/MAX32680/Bluetooth/BLE_dats/README.md
@@ -191,7 +191,7 @@ __extra long__ press is greater than 1000 ms
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/Bluetooth/BLE_dats/project.mk
+++ b/Examples/MAX32680/Bluetooth/BLE_dats/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/CRC/.vscode/README.md
+++ b/Examples/MAX32680/CRC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/CRC/Makefile
+++ b/Examples/MAX32680/CRC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/CRC/README.md
+++ b/Examples/MAX32680/CRC/README.md
@@ -7,7 +7,7 @@ This example demonstrates the use of the HW CRC calculator.  The example first g
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/CRC/project.mk
+++ b/Examples/MAX32680/CRC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/Coremark/.vscode/README.md
+++ b/Examples/MAX32680/Coremark/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/Coremark/Makefile
+++ b/Examples/MAX32680/Coremark/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/Coremark/README.md
+++ b/Examples/MAX32680/Coremark/README.md
@@ -10,7 +10,7 @@ For more information, visit the [CoreMark webpage](https://www.eembc.org/coremar
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/Coremark/project.mk
+++ b/Examples/MAX32680/Coremark/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/DMA/.vscode/README.md
+++ b/Examples/MAX32680/DMA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/DMA/Makefile
+++ b/Examples/MAX32680/DMA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/DMA/README.md
+++ b/Examples/MAX32680/DMA/README.md
@@ -9,7 +9,7 @@ A second more complex memory-to-memory DMA transaction is then shown that chains
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/DMA/project.mk
+++ b/Examples/MAX32680/DMA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32680/EEPROM_Emulator/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32680/EEPROM_Emulator/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/EEPROM_Emulator/README.md
+++ b/Examples/MAX32680/EEPROM_Emulator/README.md
@@ -48,7 +48,7 @@ To help with syncronization, a "Ready Signal" is set up as an output from a GPIO
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/EEPROM_Emulator/project.mk
+++ b/Examples/MAX32680/EEPROM_Emulator/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/Flash/.vscode/README.md
+++ b/Examples/MAX32680/Flash/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/Flash/Makefile
+++ b/Examples/MAX32680/Flash/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/Flash/README.md
+++ b/Examples/MAX32680/Flash/README.md
@@ -21,7 +21,7 @@ The _second_ time the example is run the application will see the "magic" 32-bit
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
@@ -37,7 +37,7 @@ MAX32680EVKIT:
 
 ## Building and Running
 
-**See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
+**See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)** for detailed instructions on building and running example projects from supported development environments.
 
 ## Expected Output
 

--- a/Examples/MAX32680/Flash/project.mk
+++ b/Examples/MAX32680/Flash/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32680/Flash_CLI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/Flash_CLI/Makefile
+++ b/Examples/MAX32680/Flash_CLI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/Flash_CLI/README.md
+++ b/Examples/MAX32680/Flash_CLI/README.md
@@ -9,7 +9,7 @@ This example demonstates the CLI commands feature of FreeRTOS, various features 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/Flash_CLI/project.mk
+++ b/Examples/MAX32680/Flash_CLI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32680/FreeRTOSDemo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32680/FreeRTOSDemo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/FreeRTOSDemo/README.md
+++ b/Examples/MAX32680/FreeRTOSDemo/README.md
@@ -7,7 +7,7 @@ A basic getting started application for FreeRTOS.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/FreeRTOSDemo/project.mk
+++ b/Examples/MAX32680/FreeRTOSDemo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/GPIO/.vscode/README.md
+++ b/Examples/MAX32680/GPIO/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/GPIO/Makefile
+++ b/Examples/MAX32680/GPIO/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/GPIO/README.md
+++ b/Examples/MAX32680/GPIO/README.md
@@ -21,7 +21,7 @@ On the Featherboard:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/GPIO/project.mk
+++ b/Examples/MAX32680/GPIO/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/HART_UART/.vscode/README.md
+++ b/Examples/MAX32680/HART_UART/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/HART_UART/Makefile
+++ b/Examples/MAX32680/HART_UART/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/HART_UART/README.md
+++ b/Examples/MAX32680/HART_UART/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/HART_UART/project.mk
+++ b/Examples/MAX32680/HART_UART/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/Hello_World-riscv/.vscode/README.md
+++ b/Examples/MAX32680/Hello_World-riscv/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/Hello_World-riscv/README.md
+++ b/Examples/MAX32680/Hello_World-riscv/README.md
@@ -11,7 +11,7 @@ The ARM core initializes the RISC-V core before relinquishing control of executi
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/Hello_World/.vscode/README.md
+++ b/Examples/MAX32680/Hello_World/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/Hello_World/Makefile
+++ b/Examples/MAX32680/Hello_World/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/Hello_World/README.md
+++ b/Examples/MAX32680/Hello_World/README.md
@@ -9,7 +9,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/Hello_World/project.mk
+++ b/Examples/MAX32680/Hello_World/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32680/Hello_World_Cpp/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/Hello_World_Cpp/Makefile
+++ b/Examples/MAX32680/Hello_World_Cpp/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/Hello_World_Cpp/README.md
+++ b/Examples/MAX32680/Hello_World_Cpp/README.md
@@ -8,7 +8,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/Hello_World_Cpp/project.mk
+++ b/Examples/MAX32680/Hello_World_Cpp/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32680/I2C/.vscode/README.md
+++ b/Examples/MAX32680/I2C/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/I2C/Makefile
+++ b/Examples/MAX32680/I2C/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/I2C/README.md
+++ b/Examples/MAX32680/I2C/README.md
@@ -7,7 +7,7 @@ This example uses the I2C Master to read/write from/to the I2C Slave.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/I2C/project.mk
+++ b/Examples/MAX32680/I2C/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32680/I2C_MNGR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/I2C_MNGR/Makefile
+++ b/Examples/MAX32680/I2C_MNGR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/I2C_MNGR/README.md
+++ b/Examples/MAX32680/I2C_MNGR/README.md
@@ -11,7 +11,7 @@ You may change the configuration of each EEPROM's I2C transaction parameters (sl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/I2C_MNGR/project.mk
+++ b/Examples/MAX32680/I2C_MNGR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32680/I2C_SCAN/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/I2C_SCAN/Makefile
+++ b/Examples/MAX32680/I2C_SCAN/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/I2C_SCAN/README.md
+++ b/Examples/MAX32680/I2C_SCAN/README.md
@@ -6,7 +6,7 @@ This example uses the I2C Master to find the addresses of any I2C Slave devices 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/I2C_SCAN/project.mk
+++ b/Examples/MAX32680/I2C_SCAN/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32680/I2C_Sensor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/I2C_Sensor/Makefile
+++ b/Examples/MAX32680/I2C_Sensor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/I2C_Sensor/README.md
+++ b/Examples/MAX32680/I2C_Sensor/README.md
@@ -9,7 +9,7 @@ After initialization, a new reading is printed to the terminal every second.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/I2C_Sensor/project.mk
+++ b/Examples/MAX32680/I2C_Sensor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/I2S/.vscode/README.md
+++ b/Examples/MAX32680/I2S/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/I2S/Makefile
+++ b/Examples/MAX32680/I2S/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/I2S/README.md
+++ b/Examples/MAX32680/I2S/README.md
@@ -7,7 +7,7 @@ This example demonstrates an I2S transmission. The I2S signals can be viewed on 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/I2S/project.mk
+++ b/Examples/MAX32680/I2S/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/ICC/.vscode/README.md
+++ b/Examples/MAX32680/ICC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/ICC/Makefile
+++ b/Examples/MAX32680/ICC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/ICC/README.md
+++ b/Examples/MAX32680/ICC/README.md
@@ -12,7 +12,7 @@ This example demonstrates the time differences when running code with the instru
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/ICC/project.mk
+++ b/Examples/MAX32680/ICC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/LP/.vscode/README.md
+++ b/Examples/MAX32680/LP/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/LP/Makefile
+++ b/Examples/MAX32680/LP/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/LP/README.md
+++ b/Examples/MAX32680/LP/README.md
@@ -7,7 +7,7 @@ TBD<!--TBD-->
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/LP/project.mk
+++ b/Examples/MAX32680/LP/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/Library_Generate/.vscode/README.md
+++ b/Examples/MAX32680/Library_Generate/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
   * If it's not in the README, check the UG.
   * If it's not in the UG, open a ticket!
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
@@ -31,7 +31,7 @@ The following features are supported:
 
 The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.analog.com/en/education/education-library/videos/6313212752112.html).
 
-1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
     * [Windows](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0010820A)
     * [Linux (Ubuntu)](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018720A)
     * [MacOS](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018610A)

--- a/Examples/MAX32680/Library_Generate/Makefile
+++ b/Examples/MAX32680/Library_Generate/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/Library_Generate/README.md
+++ b/Examples/MAX32680/Library_Generate/README.md
@@ -9,7 +9,7 @@ Check the Library_Use demo to see how to link static libraries to an application
 
 ### Project Usage
 
-Universal instructions on building this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/Library_Generate/project.mk
+++ b/Examples/MAX32680/Library_Generate/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
  
 # **********************************************************
 

--- a/Examples/MAX32680/Library_Use/.vscode/README.md
+++ b/Examples/MAX32680/Library_Use/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/Library_Use/Makefile
+++ b/Examples/MAX32680/Library_Use/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/Library_Use/README.md
+++ b/Examples/MAX32680/Library_Use/README.md
@@ -9,7 +9,7 @@ to project.mk to see how to include ".a" static library files into your project.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/Library_Use/project.mk
+++ b/Examples/MAX32680/Library_Use/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/Pulse_Train/.vscode/README.md
+++ b/Examples/MAX32680/Pulse_Train/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/Pulse_Train/Makefile
+++ b/Examples/MAX32680/Pulse_Train/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/Pulse_Train/README.md
+++ b/Examples/MAX32680/Pulse_Train/README.md
@@ -19,7 +19,7 @@ On the Featherboard:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/Pulse_Train/project.mk
+++ b/Examples/MAX32680/Pulse_Train/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/RV_ARM_Loader/.vscode/README.md
+++ b/Examples/MAX32680/RV_ARM_Loader/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/RV_ARM_Loader/Makefile
+++ b/Examples/MAX32680/RV_ARM_Loader/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/RV_ARM_Loader/README.md
+++ b/Examples/MAX32680/RV_ARM_Loader/README.md
@@ -8,7 +8,7 @@ RV_ARM_Loader runs on the ARM core to load the RISCV code space, setup the RISCV
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/RV_ARM_Loader/project.mk
+++ b/Examples/MAX32680/RV_ARM_Loader/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/SPI/.vscode/README.md
+++ b/Examples/MAX32680/SPI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/SPI/Makefile
+++ b/Examples/MAX32680/SPI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/SPI/README.md
+++ b/Examples/MAX32680/SPI/README.md
@@ -12,7 +12,7 @@ By default, the example performs blocking SPI transactions.  To switch to non-bl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/SPI/project.mk
+++ b/Examples/MAX32680/SPI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/TMR/.vscode/README.md
+++ b/Examples/MAX32680/TMR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/TMR/Makefile
+++ b/Examples/MAX32680/TMR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/TMR/README.md
+++ b/Examples/MAX32680/TMR/README.md
@@ -18,7 +18,7 @@ Push PB1 to start the PWM and continuous timer and PB2 to start the oneshot time
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/TMR/project.mk
+++ b/Examples/MAX32680/TMR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/TRNG/.vscode/README.md
+++ b/Examples/MAX32680/TRNG/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/TRNG/Makefile
+++ b/Examples/MAX32680/TRNG/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/TRNG/README.md
+++ b/Examples/MAX32680/TRNG/README.md
@@ -7,7 +7,7 @@ The true random number generator (TRNG) hardware is exercised in this example.  
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/TRNG/project.mk
+++ b/Examples/MAX32680/TRNG/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32680/Temp_Monitor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/Temp_Monitor/Makefile
+++ b/Examples/MAX32680/Temp_Monitor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/Temp_Monitor/README.md
+++ b/Examples/MAX32680/Temp_Monitor/README.md
@@ -15,7 +15,7 @@ The temperature limits, flash storage page, and RTC time-of-day alarm period are
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/Temp_Monitor/project.mk
+++ b/Examples/MAX32680/Temp_Monitor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/UART/.vscode/README.md
+++ b/Examples/MAX32680/UART/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/UART/Makefile
+++ b/Examples/MAX32680/UART/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/UART/README.md
+++ b/Examples/MAX32680/UART/README.md
@@ -7,7 +7,7 @@ This application uses two serial ports to send and receive data.  One serial por
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/UART/project.mk
+++ b/Examples/MAX32680/UART/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/WUT/.vscode/README.md
+++ b/Examples/MAX32680/WUT/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/WUT/Makefile
+++ b/Examples/MAX32680/WUT/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/WUT/README.md
+++ b/Examples/MAX32680/WUT/README.md
@@ -8,7 +8,7 @@ This Example shows how to wake up a device after it is asleep with a wake up tim
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/WUT/project.mk
+++ b/Examples/MAX32680/WUT/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/Watchdog/.vscode/README.md
+++ b/Examples/MAX32680/Watchdog/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/Watchdog/Makefile
+++ b/Examples/MAX32680/Watchdog/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/Watchdog/README.md
+++ b/Examples/MAX32680/Watchdog/README.md
@@ -9,7 +9,7 @@ When the application begins, it initializes and starts the watchdog timer.  You 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32680/Watchdog/project.mk
+++ b/Examples/MAX32680/Watchdog/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32680/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32680/WearLeveling/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32680/WearLeveling/Makefile
+++ b/Examples/MAX32680/WearLeveling/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32680/WearLeveling/README.md
+++ b/Examples/MAX32680/WearLeveling/README.md
@@ -15,11 +15,11 @@ Enter "help" in the command line to see more details on the usage of each of the
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32680EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX32680EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32680/WearLeveling/project.mk
+++ b/Examples/MAX32680/WearLeveling/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32690/ADC/.vscode/README.md
+++ b/Examples/MAX32690/ADC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/ADC/Makefile
+++ b/Examples/MAX32690/ADC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/ADC/README.md
+++ b/Examples/MAX32690/ADC/README.md
@@ -10,7 +10,7 @@ Additionally the trigger source that starts the ADC conversion can be selected a
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project on supported boards can be found in the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/).
+Universal instructions on building, flashing, and debugging this project on supported boards can be found in the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/).
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/ADC/project.mk
+++ b/Examples/MAX32690/ADC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/ARM-DSP/README.md
+++ b/Examples/MAX32690/ARM-DSP/README.md
@@ -14,7 +14,7 @@ Development with Visual Studio Code is also supported.  See [VSCode-Maxim](https
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_bayes_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/ARM-DSP/arm_bayes_example/project.mk
+++ b/Examples/MAX32690/ARM-DSP/arm_bayes_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32690/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_class_marks_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/ARM-DSP/arm_class_marks_example/project.mk
+++ b/Examples/MAX32690/ARM-DSP/arm_class_marks_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32690/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_convolution_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/ARM-DSP/arm_convolution_example/project.mk
+++ b/Examples/MAX32690/ARM-DSP/arm_convolution_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32690/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/ARM-DSP/arm_dotproduct_example_f32/project.mk
+++ b/Examples/MAX32690/ARM-DSP/arm_dotproduct_example_f32/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32690/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_fft_bin_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/ARM-DSP/arm_fft_bin_example/project.mk
+++ b/Examples/MAX32690/ARM-DSP/arm_fft_bin_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32690/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_fir_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/ARM-DSP/arm_fir_example/project.mk
+++ b/Examples/MAX32690/ARM-DSP/arm_fir_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32690/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/ARM-DSP/arm_graphic_equalizer_example/project.mk
+++ b/Examples/MAX32690/ARM-DSP/arm_graphic_equalizer_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32690/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_linear_interp_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/ARM-DSP/arm_linear_interp_example/project.mk
+++ b/Examples/MAX32690/ARM-DSP/arm_linear_interp_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32690/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_matrix_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/ARM-DSP/arm_matrix_example/project.mk
+++ b/Examples/MAX32690/ARM-DSP/arm_matrix_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32690/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_signal_converge_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/ARM-DSP/arm_signal_converge_example/project.mk
+++ b/Examples/MAX32690/ARM-DSP/arm_signal_converge_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32690/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_sin_cos_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/ARM-DSP/arm_sin_cos_example/project.mk
+++ b/Examples/MAX32690/ARM-DSP/arm_sin_cos_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32690/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_svm_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/ARM-DSP/arm_svm_example/project.mk
+++ b/Examples/MAX32690/ARM-DSP/arm_svm_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32690/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_variance_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/ARM-DSP/arm_variance_example/project.mk
+++ b/Examples/MAX32690/ARM-DSP/arm_variance_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32690/Bluetooth/BLE4_ctr/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE4_ctr/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Bluetooth/BLE4_ctr/Makefile
+++ b/Examples/MAX32690/Bluetooth/BLE4_ctr/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Bluetooth/BLE4_ctr/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE4_ctr/README.md
@@ -8,7 +8,7 @@ Refer to the [BLE4_ctr](../../../Libraries/Cordio/docs/Applications/BLE4_ctr.md)
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 

--- a/Examples/MAX32690/Bluetooth/BLE4_ctr/project.mk
+++ b/Examples/MAX32690/Bluetooth/BLE4_ctr/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Bluetooth/BLE5_ctr/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE5_ctr/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Bluetooth/BLE5_ctr/Makefile
+++ b/Examples/MAX32690/Bluetooth/BLE5_ctr/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Bluetooth/BLE5_ctr/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE5_ctr/README.md
@@ -8,7 +8,7 @@ Refer to the [BLE5_ctr](../../../Libraries/Cordio/docs/Applications/BLE5_ctr.md)
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 

--- a/Examples/MAX32690/Bluetooth/BLE5_ctr/project.mk
+++ b/Examples/MAX32690/Bluetooth/BLE5_ctr/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/Makefile
+++ b/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/README.md
@@ -7,7 +7,7 @@ Refer to the [BLE_FreeRTOS](../../../Libraries/Cordio/docs/Applications/BLE_Free
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 

--- a/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/project.mk
+++ b/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Bluetooth/BLE_datc/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_datc/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Bluetooth/BLE_datc/Makefile
+++ b/Examples/MAX32690/Bluetooth/BLE_datc/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Bluetooth/BLE_datc/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_datc/README.md
@@ -6,7 +6,7 @@ Refer to the [BLE_datc_dats](../../../Libraries/Cordio/docs/Applications/BLE_dat
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 

--- a/Examples/MAX32690/Bluetooth/BLE_datc/project.mk
+++ b/Examples/MAX32690/Bluetooth/BLE_datc/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Bluetooth/BLE_dats/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_dats/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Bluetooth/BLE_dats/Makefile
+++ b/Examples/MAX32690/Bluetooth/BLE_dats/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Bluetooth/BLE_dats/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_dats/README.md
@@ -6,7 +6,7 @@ Refer to the [BLE_datc_dats](../../../Libraries/Cordio/docs/Applications/BLE_dat
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 

--- a/Examples/MAX32690/Bluetooth/BLE_dats/project.mk
+++ b/Examples/MAX32690/Bluetooth/BLE_dats/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Bluetooth/BLE_fcc/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_fcc/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Bluetooth/BLE_fcc/Makefile
+++ b/Examples/MAX32690/Bluetooth/BLE_fcc/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Bluetooth/BLE_fcc/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_fcc/README.md
@@ -7,7 +7,7 @@ Refer to [BLE_fcc](../../../Libraries/Cordio/docs/Applications/BLE_fcc.md) docum
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 

--- a/Examples/MAX32690/Bluetooth/BLE_fcc/project.mk
+++ b/Examples/MAX32690/Bluetooth/BLE_fcc/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Bluetooth/BLE_fit/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_fit/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Bluetooth/BLE_fit/Makefile
+++ b/Examples/MAX32690/Bluetooth/BLE_fit/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Bluetooth/BLE_fit/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_fit/README.md
@@ -6,7 +6,7 @@ Refer to [BLE_fit](../../../Libraries/Cordio/docs/Applications/BLE_fit.md) docum
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 

--- a/Examples/MAX32690/Bluetooth/BLE_fit/project.mk
+++ b/Examples/MAX32690/Bluetooth/BLE_fit/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Bluetooth/BLE_mcs/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_mcs/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Bluetooth/BLE_mcs/Makefile
+++ b/Examples/MAX32690/Bluetooth/BLE_mcs/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Bluetooth/BLE_mcs/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_mcs/README.md
@@ -8,7 +8,7 @@ Refer to the [BLE_mcs](../../../Libraries/Cordio/docs/Applications/BLE_mcs.md) d
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 

--- a/Examples/MAX32690/Bluetooth/BLE_mcs/project.mk
+++ b/Examples/MAX32690/Bluetooth/BLE_mcs/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Bluetooth/BLE_otac/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_otac/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Bluetooth/BLE_otac/Makefile
+++ b/Examples/MAX32690/Bluetooth/BLE_otac/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Bluetooth/BLE_otac/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_otac/README.md
@@ -11,7 +11,7 @@ Refer to the [BLE_otac_otas](../../../Libraries/Cordio/docs/Applications/BLE_ota
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 * Connect a USB cable between the PC and the (USB/PWR - UART) connector.

--- a/Examples/MAX32690/Bluetooth/BLE_otac/project.mk
+++ b/Examples/MAX32690/Bluetooth/BLE_otac/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Bluetooth/BLE_otas/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_otas/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Bluetooth/BLE_otas/Makefile
+++ b/Examples/MAX32690/Bluetooth/BLE_otas/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Bluetooth/BLE_otas/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_otas/README.md
@@ -11,7 +11,7 @@ Refer to the [BLE_otac_otas](../../../Libraries/Cordio/docs/Applications/BLE_ota
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ## Required Connections
 * Connect a USB cable between the PC and the (USB/PWR - UART) connector.

--- a/Examples/MAX32690/Bluetooth/BLE_otas/project.mk
+++ b/Examples/MAX32690/Bluetooth/BLE_otas/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Bluetooth/BLE_periph/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_periph/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Bluetooth/BLE_periph/Makefile
+++ b/Examples/MAX32690/Bluetooth/BLE_periph/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Bluetooth/BLE_periph/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_periph/README.md
@@ -5,7 +5,7 @@ Refer to the [BLE_periph](../../../Libraries/Cordio/docs/Applications/BLE_periph
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Required Connections
 

--- a/Examples/MAX32690/Bluetooth/BLE_periph/project.mk
+++ b/Examples/MAX32690/Bluetooth/BLE_periph/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Bluetooth/Bootloader/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/Bootloader/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Bluetooth/Bootloader/Makefile
+++ b/Examples/MAX32690/Bluetooth/Bootloader/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Bluetooth/Bootloader/README.md
+++ b/Examples/MAX32690/Bluetooth/Bootloader/README.md
@@ -16,7 +16,7 @@ __0x10300000__: Update flash space
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/Bluetooth/Bootloader/project.mk
+++ b/Examples/MAX32690/Bluetooth/Bootloader/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Bluetooth/RF_Test/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/RF_Test/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Bluetooth/RF_Test/Makefile
+++ b/Examples/MAX32690/Bluetooth/RF_Test/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/CAN/.vscode/README.md
+++ b/Examples/MAX32690/CAN/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/CAN/Makefile
+++ b/Examples/MAX32690/CAN/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/CAN/README.md
+++ b/Examples/MAX32690/CAN/README.md
@@ -8,7 +8,7 @@ Connect CAN signals on header JH8 to CAN bus.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/CAN/project.mk
+++ b/Examples/MAX32690/CAN/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/CRC/.vscode/README.md
+++ b/Examples/MAX32690/CRC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/CRC/Makefile
+++ b/Examples/MAX32690/CRC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/CRC/README.md
+++ b/Examples/MAX32690/CRC/README.md
@@ -6,7 +6,7 @@ This example demonstrates the use of the HW CRC calculator.  The example first g
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/CRC/project.mk
+++ b/Examples/MAX32690/CRC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/CTB_AES/.vscode/README.md
+++ b/Examples/MAX32690/CTB_AES/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/CTB_AES/Makefile
+++ b/Examples/MAX32690/CTB_AES/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/CTB_AES/README.md
+++ b/Examples/MAX32690/CTB_AES/README.md
@@ -6,7 +6,7 @@ This application demonstrates both encryption and decryption using the Crypto To
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/CTB_AES/project.mk
+++ b/Examples/MAX32690/CTB_AES/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Coremark/.vscode/README.md
+++ b/Examples/MAX32690/Coremark/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Coremark/Makefile
+++ b/Examples/MAX32690/Coremark/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Coremark/README.md
+++ b/Examples/MAX32690/Coremark/README.md
@@ -10,7 +10,7 @@ For more information, visit the [CoreMark webpage](https://www.eembc.org/coremar
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/Coremark/project.mk
+++ b/Examples/MAX32690/Coremark/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/DMA/.vscode/README.md
+++ b/Examples/MAX32690/DMA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/DMA/Makefile
+++ b/Examples/MAX32690/DMA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/DMA/README.md
+++ b/Examples/MAX32690/DMA/README.md
@@ -8,7 +8,7 @@ A second more complex memory-to-memory DMA transaction is then shown that chains
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/DMA/project.mk
+++ b/Examples/MAX32690/DMA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32690/EEPROM_Emulator/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32690/EEPROM_Emulator/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/EEPROM_Emulator/README.md
+++ b/Examples/MAX32690/EEPROM_Emulator/README.md
@@ -47,7 +47,7 @@ To help with syncronization, a "Ready Signal" is set up as an output from a GPIO
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/EEPROM_Emulator/project.mk
+++ b/Examples/MAX32690/EEPROM_Emulator/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Flash/.vscode/README.md
+++ b/Examples/MAX32690/Flash/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Flash/Makefile
+++ b/Examples/MAX32690/Flash/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Flash/README.md
+++ b/Examples/MAX32690/Flash/README.md
@@ -20,7 +20,7 @@ The _second_ time the example is run the application will see the "magic" 32-bit
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/Flash/project.mk
+++ b/Examples/MAX32690/Flash/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32690/Flash_CLI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Flash_CLI/Makefile
+++ b/Examples/MAX32690/Flash_CLI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Flash_CLI/README.md
+++ b/Examples/MAX32690/Flash_CLI/README.md
@@ -8,7 +8,7 @@ This example demonstates the CLI commands feature of FreeRTOS, various features 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/Flash_CLI/project.mk
+++ b/Examples/MAX32690/Flash_CLI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32690/FreeRTOSDemo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32690/FreeRTOSDemo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/FreeRTOSDemo/README.md
+++ b/Examples/MAX32690/FreeRTOSDemo/README.md
@@ -6,7 +6,7 @@ A basic getting started application for FreeRTOS.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/FreeRTOSDemo/project.mk
+++ b/Examples/MAX32690/FreeRTOSDemo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/GPIO/.vscode/README.md
+++ b/Examples/MAX32690/GPIO/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/GPIO/Makefile
+++ b/Examples/MAX32690/GPIO/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/GPIO/README.md
+++ b/Examples/MAX32690/GPIO/README.md
@@ -8,7 +8,7 @@ P2.11 (P1.11 on MAX32690FTHR) is continuously scanned and whatever value is read
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/GPIO/project.mk
+++ b/Examples/MAX32690/GPIO/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/HBMC/.vscode/README.md
+++ b/Examples/MAX32690/HBMC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/HBMC/Makefile
+++ b/Examples/MAX32690/HBMC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/HBMC/README.md
+++ b/Examples/MAX32690/HBMC/README.md
@@ -10,7 +10,7 @@ A function to blink an LED (found in ramfunc.c) is copied to external memory and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/HBMC/project.mk
+++ b/Examples/MAX32690/HBMC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Hash/.vscode/README.md
+++ b/Examples/MAX32690/Hash/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Hash/Makefile
+++ b/Examples/MAX32690/Hash/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Hash/README.md
+++ b/Examples/MAX32690/Hash/README.md
@@ -6,7 +6,7 @@ This example demonstrates the use of the CTB Hash Function: SHA-256.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/Hash/project.mk
+++ b/Examples/MAX32690/Hash/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Hello_World/.vscode/README.md
+++ b/Examples/MAX32690/Hello_World/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Hello_World/Makefile
+++ b/Examples/MAX32690/Hello_World/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Hello_World/README.md
+++ b/Examples/MAX32690/Hello_World/README.md
@@ -8,7 +8,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/Hello_World/project.mk
+++ b/Examples/MAX32690/Hello_World/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32690/Hello_World_Cpp/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Hello_World_Cpp/Makefile
+++ b/Examples/MAX32690/Hello_World_Cpp/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Hello_World_Cpp/README.md
+++ b/Examples/MAX32690/Hello_World_Cpp/README.md
@@ -8,7 +8,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/Hello_World_Cpp/project.mk
+++ b/Examples/MAX32690/Hello_World_Cpp/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX32690/I2C/.vscode/README.md
+++ b/Examples/MAX32690/I2C/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/I2C/Makefile
+++ b/Examples/MAX32690/I2C/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/I2C/README.md
+++ b/Examples/MAX32690/I2C/README.md
@@ -6,7 +6,7 @@ This example uses the I2C Master to read/write from/to the I2C Slave.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/I2C/project.mk
+++ b/Examples/MAX32690/I2C/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32690/I2C_MNGR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/I2C_MNGR/Makefile
+++ b/Examples/MAX32690/I2C_MNGR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/I2C_MNGR/README.md
+++ b/Examples/MAX32690/I2C_MNGR/README.md
@@ -10,7 +10,7 @@ You may change the configuration of each EEPROM's I2C transaction parameters (sl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/I2C_MNGR/project.mk
+++ b/Examples/MAX32690/I2C_MNGR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32690/I2C_SCAN/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/I2C_SCAN/Makefile
+++ b/Examples/MAX32690/I2C_SCAN/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/I2C_SCAN/README.md
+++ b/Examples/MAX32690/I2C_SCAN/README.md
@@ -5,7 +5,7 @@ This example uses the I2C Master to find the addresses of any I2C Slave devices 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/I2C_SCAN/project.mk
+++ b/Examples/MAX32690/I2C_SCAN/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32690/I2C_Sensor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/I2C_Sensor/Makefile
+++ b/Examples/MAX32690/I2C_Sensor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/I2C_Sensor/README.md
+++ b/Examples/MAX32690/I2C_Sensor/README.md
@@ -8,7 +8,7 @@ After initialization, a new reading is printed to the terminal every second.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/I2C_Sensor/project.mk
+++ b/Examples/MAX32690/I2C_Sensor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/I2S/.vscode/README.md
+++ b/Examples/MAX32690/I2S/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/I2S/Makefile
+++ b/Examples/MAX32690/I2S/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/I2S/README.md
+++ b/Examples/MAX32690/I2S/README.md
@@ -6,7 +6,7 @@ This example demonstrates use of the I2S peripheral on the MAX32690 by transmitt
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/I2S/project.mk
+++ b/Examples/MAX32690/I2S/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/ICC/.vscode/README.md
+++ b/Examples/MAX32690/ICC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/ICC/Makefile
+++ b/Examples/MAX32690/ICC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/ICC/README.md
+++ b/Examples/MAX32690/ICC/README.md
@@ -11,7 +11,7 @@ This example demonstrates the time differences when running code with the instru
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/ICC/project.mk
+++ b/Examples/MAX32690/ICC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/LP/.vscode/README.md
+++ b/Examples/MAX32690/LP/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/LP/Makefile
+++ b/Examples/MAX32690/LP/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/LP/README.md
+++ b/Examples/MAX32690/LP/README.md
@@ -6,7 +6,7 @@ This example demonstrates entering and exiting from the various operating modes.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/LP/project.mk
+++ b/Examples/MAX32690/LP/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/LPCMP/.vscode/README.md
+++ b/Examples/MAX32690/LPCMP/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/LPCMP/Makefile
+++ b/Examples/MAX32690/LPCMP/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/LPCMP/README.md
+++ b/Examples/MAX32690/LPCMP/README.md
@@ -8,7 +8,7 @@ The example is configured to use analog channels 0 and 1 as the negative and pos
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/LPCMP/project.mk
+++ b/Examples/MAX32690/LPCMP/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Library_Generate/.vscode/README.md
+++ b/Examples/MAX32690/Library_Generate/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
   * If it's not in the README, check the UG.
   * If it's not in the UG, open a ticket!
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
@@ -31,7 +31,7 @@ The following features are supported:
 
 The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.analog.com/en/education/education-library/videos/6313212752112.html).
 
-1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
     * [Windows](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0010820A)
     * [Linux (Ubuntu)](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018720A)
     * [MacOS](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018610A)

--- a/Examples/MAX32690/Library_Generate/Makefile
+++ b/Examples/MAX32690/Library_Generate/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Library_Generate/README.md
+++ b/Examples/MAX32690/Library_Generate/README.md
@@ -9,7 +9,7 @@ Check the Library_Use demo to see how to link static libraries to an application
 
 ### Project Usage
 
-Universal instructions on building this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/Library_Generate/project.mk
+++ b/Examples/MAX32690/Library_Generate/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
  
 # **********************************************************
 

--- a/Examples/MAX32690/Library_Use/.vscode/README.md
+++ b/Examples/MAX32690/Library_Use/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Library_Use/Makefile
+++ b/Examples/MAX32690/Library_Use/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Library_Use/README.md
+++ b/Examples/MAX32690/Library_Use/README.md
@@ -9,7 +9,7 @@ to project.mk to see how to include ".a" static library files into your project.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/Library_Use/project.mk
+++ b/Examples/MAX32690/Library_Use/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Pulse_Train/.vscode/README.md
+++ b/Examples/MAX32690/Pulse_Train/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Pulse_Train/Makefile
+++ b/Examples/MAX32690/Pulse_Train/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Pulse_Train/README.md
+++ b/Examples/MAX32690/Pulse_Train/README.md
@@ -16,7 +16,7 @@ On the feather board, use a logic analyzer to observe the signals on P1.8 and P1
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/Pulse_Train/project.mk
+++ b/Examples/MAX32690/Pulse_Train/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/RTC/.vscode/README.md
+++ b/Examples/MAX32690/RTC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/RTC/Makefile
+++ b/Examples/MAX32690/RTC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/RTC/README.md
+++ b/Examples/MAX32690/RTC/README.md
@@ -21,7 +21,7 @@ On feather board:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/RTC/project.mk
+++ b/Examples/MAX32690/RTC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX32690/RTC_Backup/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/RTC_Backup/Makefile
+++ b/Examples/MAX32690/RTC_Backup/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/RTC_Backup/README.md
+++ b/Examples/MAX32690/RTC_Backup/README.md
@@ -8,7 +8,7 @@ The RTC time-of-day alarm is used to wake the device from backup mode every TIME
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/RTC_Backup/project.mk
+++ b/Examples/MAX32690/RTC_Backup/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/RV_ARM_Loader/.vscode/README.md
+++ b/Examples/MAX32690/RV_ARM_Loader/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/RV_ARM_Loader/Makefile
+++ b/Examples/MAX32690/RV_ARM_Loader/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/RV_ARM_Loader/README.md
+++ b/Examples/MAX32690/RV_ARM_Loader/README.md
@@ -8,7 +8,7 @@ RV_ARM_Loader runs on the ARM core to load the RISCV code space, setup the RISCV
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/RV_ARM_Loader/project.mk
+++ b/Examples/MAX32690/RV_ARM_Loader/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/SCPA_OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32690/SCPA_OTP_Dump/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/SCPA_OTP_Dump/Makefile
+++ b/Examples/MAX32690/SCPA_OTP_Dump/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/SCPA_OTP_Dump/README.md
+++ b/Examples/MAX32690/SCPA_OTP_Dump/README.md
@@ -17,7 +17,7 @@ PROJ_CFLAGS+=-DMAX32690_A1
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/SCPA_OTP_Dump/project.mk
+++ b/Examples/MAX32690/SCPA_OTP_Dump/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/SPI/.vscode/README.md
+++ b/Examples/MAX32690/SPI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/SPI/Makefile
+++ b/Examples/MAX32690/SPI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/SPI/README.md
+++ b/Examples/MAX32690/SPI/README.md
@@ -11,7 +11,7 @@ By default, the example performs blocking SPI transactions.  To switch to non-bl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/SPI/project.mk
+++ b/Examples/MAX32690/SPI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/TFT_Demo/.vscode/README.md
+++ b/Examples/MAX32690/TFT_Demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/TFT_Demo/Makefile
+++ b/Examples/MAX32690/TFT_Demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/TFT_Demo/README.md
+++ b/Examples/MAX32690/TFT_Demo/README.md
@@ -8,7 +8,7 @@ The main functions which are shown in this example are displaying a bitmap image
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/TFT_Demo/project.mk
+++ b/Examples/MAX32690/TFT_Demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX32690/TFT_Demo/resources/tft_demo/bmp/README.md
+++ b/Examples/MAX32690/TFT_Demo/resources/tft_demo/bmp/README.md
@@ -38,7 +38,7 @@ Examples:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/TMR/.vscode/README.md
+++ b/Examples/MAX32690/TMR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/TMR/Makefile
+++ b/Examples/MAX32690/TMR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/TMR/README.md
+++ b/Examples/MAX32690/TMR/README.md
@@ -14,7 +14,7 @@ Push SW2 to start the PWM and continuous timers initially. After the PWM and con
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/TMR/project.mk
+++ b/Examples/MAX32690/TMR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/TRNG/.vscode/README.md
+++ b/Examples/MAX32690/TRNG/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/TRNG/Makefile
+++ b/Examples/MAX32690/TRNG/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/TRNG/README.md
+++ b/Examples/MAX32690/TRNG/README.md
@@ -6,7 +6,7 @@ The true random number generator (TRNG) hardware is exercised in this example.  
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/TRNG/project.mk
+++ b/Examples/MAX32690/TRNG/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32690/Temp_Monitor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Temp_Monitor/Makefile
+++ b/Examples/MAX32690/Temp_Monitor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Temp_Monitor/README.md
+++ b/Examples/MAX32690/Temp_Monitor/README.md
@@ -14,7 +14,7 @@ The temperature limits, flash storage page, and RTC time-of-day alarm period are
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/Temp_Monitor/project.mk
+++ b/Examples/MAX32690/Temp_Monitor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/UART/.vscode/README.md
+++ b/Examples/MAX32690/UART/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/UART/Makefile
+++ b/Examples/MAX32690/UART/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/UART/README.md
+++ b/Examples/MAX32690/UART/README.md
@@ -6,7 +6,7 @@ This application uses two serial ports to send and receive data.  One serial por
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/UART/project.mk
+++ b/Examples/MAX32690/UART/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/UCL/README.md
+++ b/Examples/MAX32690/UCL/README.md
@@ -6,7 +6,7 @@ UCL usecase example.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/UCL/project.mk
+++ b/Examples/MAX32690/UCL/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/USB/USB_CDCACM/.vscode/README.md
+++ b/Examples/MAX32690/USB/USB_CDCACM/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/USB/USB_CDCACM/Makefile
+++ b/Examples/MAX32690/USB/USB_CDCACM/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/USB/USB_CDCACM/README.md
+++ b/Examples/MAX32690/USB/USB_CDCACM/README.md
@@ -6,7 +6,7 @@ The example demonstartes the use of USB CDC-ACM driver class. After doing the re
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/USB/USB_CDCACM/project.mk
+++ b/Examples/MAX32690/USB/USB_CDCACM/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/USB/USB_CompositeDevice_MSC_CDC/.vscode/README.md
+++ b/Examples/MAX32690/USB/USB_CompositeDevice_MSC_CDC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/USB/USB_CompositeDevice_MSC_CDC/Makefile
+++ b/Examples/MAX32690/USB/USB_CompositeDevice_MSC_CDC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/USB/USB_CompositeDevice_MSC_CDC/README.md
+++ b/Examples/MAX32690/USB/USB_CompositeDevice_MSC_CDC/README.md
@@ -6,7 +6,7 @@ The example demonstartes the use of USB composite device with Mass Storage drive
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/USB/USB_CompositeDevice_MSC_CDC/project.mk
+++ b/Examples/MAX32690/USB/USB_CompositeDevice_MSC_CDC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/USB/USB_CompositeDevice_MSC_HID/.vscode/README.md
+++ b/Examples/MAX32690/USB/USB_CompositeDevice_MSC_HID/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/USB/USB_CompositeDevice_MSC_HID/Makefile
+++ b/Examples/MAX32690/USB/USB_CompositeDevice_MSC_HID/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/USB/USB_CompositeDevice_MSC_HID/README.md
+++ b/Examples/MAX32690/USB/USB_CompositeDevice_MSC_HID/README.md
@@ -6,7 +6,7 @@ The example demonstartes the use of USB composite device with Mass Storage drive
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/USB/USB_CompositeDevice_MSC_HID/project.mk
+++ b/Examples/MAX32690/USB/USB_CompositeDevice_MSC_HID/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/USB/USB_HIDKeyboard/.vscode/README.md
+++ b/Examples/MAX32690/USB/USB_HIDKeyboard/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/USB/USB_HIDKeyboard/Makefile
+++ b/Examples/MAX32690/USB/USB_HIDKeyboard/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/USB/USB_HIDKeyboard/README.md
+++ b/Examples/MAX32690/USB/USB_HIDKeyboard/README.md
@@ -6,7 +6,7 @@ The example demonstartes the use of USB HID driver class. After doing the requir
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/USB/USB_HIDKeyboard/project.mk
+++ b/Examples/MAX32690/USB/USB_HIDKeyboard/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/USB/USB_MassStorage/.vscode/README.md
+++ b/Examples/MAX32690/USB/USB_MassStorage/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/USB/USB_MassStorage/Makefile
+++ b/Examples/MAX32690/USB/USB_MassStorage/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/USB/USB_MassStorage/README.md
+++ b/Examples/MAX32690/USB/USB_MassStorage/README.md
@@ -6,7 +6,7 @@ The example demonstates the use of USB Mass Storage driver class. After doing th
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/USB/USB_MassStorage/project.mk
+++ b/Examples/MAX32690/USB/USB_MassStorage/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/WUT/.vscode/README.md
+++ b/Examples/MAX32690/WUT/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/WUT/Makefile
+++ b/Examples/MAX32690/WUT/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/WUT/README.md
+++ b/Examples/MAX32690/WUT/README.md
@@ -5,7 +5,7 @@ This example shows how to wake up a device with the wakeup timer. Pressing SW2 (
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/WUT/project.mk
+++ b/Examples/MAX32690/WUT/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/Watchdog/.vscode/README.md
+++ b/Examples/MAX32690/Watchdog/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/Watchdog/Makefile
+++ b/Examples/MAX32690/Watchdog/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/Watchdog/README.md
+++ b/Examples/MAX32690/Watchdog/README.md
@@ -13,7 +13,7 @@ On feather board, SW3 is used instead of SW2.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/Watchdog/project.mk
+++ b/Examples/MAX32690/Watchdog/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX32690/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32690/WearLeveling/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX32690/WearLeveling/Makefile
+++ b/Examples/MAX32690/WearLeveling/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX32690/WearLeveling/README.md
+++ b/Examples/MAX32690/WearLeveling/README.md
@@ -15,7 +15,7 @@ Enter "help" in the command line to see more details on the usage of each of the
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX32690/WearLeveling/project.mk
+++ b/Examples/MAX32690/WearLeveling/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/ADC/.vscode/README.md
+++ b/Examples/MAX78000/ADC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/ADC/Makefile
+++ b/Examples/MAX78000/ADC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/ADC/README.md
+++ b/Examples/MAX78000/ADC/README.md
@@ -10,11 +10,11 @@ Any reading that exceeds the full-scale value of the ADC will have an '*' append
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX78000/ADC/project.mk
+++ b/Examples/MAX78000/ADC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/AES/.vscode/README.md
+++ b/Examples/MAX78000/AES/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/AES/Makefile
+++ b/Examples/MAX78000/AES/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/AES/README.md
+++ b/Examples/MAX78000/AES/README.md
@@ -6,11 +6,11 @@ This application demonstrates both encryption and decryption using AES.  A block
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections:
 If using the MAX78000EVKIT (EvKit_V1):

--- a/Examples/MAX78000/AES/project.mk
+++ b/Examples/MAX78000/AES/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/ARM-DSP/README.md
+++ b/Examples/MAX78000/ARM-DSP/README.md
@@ -14,7 +14,7 @@ Development with Visual Studio Code is also supported.  See [VSCode-Maxim](https
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_bayes_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/ARM-DSP/arm_bayes_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_bayes_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_class_marks_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/ARM-DSP/arm_class_marks_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_class_marks_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_convolution_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/ARM-DSP/arm_convolution_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_convolution_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_fir_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/ARM-DSP/arm_fir_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_fir_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_matrix_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/ARM-DSP/arm_matrix_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_matrix_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_svm_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/ARM-DSP/arm_svm_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_svm_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_variance_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/ARM-DSP/arm_variance_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_variance_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/UNet-demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/UNet-demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/UNet-demo/Makefile
+++ b/Examples/MAX78000/CNN/UNet-demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/UNet-demo/README.md
+++ b/Examples/MAX78000/CNN/UNet-demo/README.md
@@ -16,11 +16,11 @@ This demo shows a U-Net network, trained to segment images into four categories 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 * Before building the firmware, please make sure to enable your intended mode of operation by enabling/disabling the following defines in [main.c](main.c):
 

--- a/Examples/MAX78000/CNN/UNet-demo/TFT/fthr/bmp/README.md
+++ b/Examples/MAX78000/CNN/UNet-demo/TFT/fthr/bmp/README.md
@@ -38,7 +38,7 @@ Examples:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/UNet-demo/Utility/README.md
+++ b/Examples/MAX78000/CNN/UNet-demo/Utility/README.md
@@ -65,7 +65,7 @@ The image is expected to be 80 by 80, or it will be resized. The EVKIT will show
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/UNet-demo/project.mk
+++ b/Examples/MAX78000/CNN/UNet-demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/UNet-highres-demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/UNet-highres-demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/UNet-highres-demo/Makefile
+++ b/Examples/MAX78000/CNN/UNet-highres-demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/UNet-highres-demo/README.md
+++ b/Examples/MAX78000/CNN/UNet-highres-demo/README.md
@@ -16,11 +16,11 @@ This demo shows a UNet network with 352x352 resolution input, trained to segment
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 * Before building the firmware, please make sure to enable your intended mode of operation by enabling/disabling the following define in [main.c](main.c):
 

--- a/Examples/MAX78000/CNN/UNet-highres-demo/TFT/fthr/bmp/README.md
+++ b/Examples/MAX78000/CNN/UNet-highres-demo/TFT/fthr/bmp/README.md
@@ -38,7 +38,7 @@ Examples:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/UNet-highres-demo/Utility/README.md
+++ b/Examples/MAX78000/CNN/UNet-highres-demo/Utility/README.md
@@ -10,7 +10,7 @@ segmentation mask
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/UNet-highres-demo/project.mk
+++ b/Examples/MAX78000/CNN/UNet-highres-demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/actionrecognition-demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/actionrecognition-demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/actionrecognition-demo/Makefile
+++ b/Examples/MAX78000/CNN/actionrecognition-demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/actionrecognition-demo/README.md
+++ b/Examples/MAX78000/CNN/actionrecognition-demo/README.md
@@ -10,7 +10,7 @@ The model is trained using the [Kinetics Human Action Video Dataset](https://res
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/aisegment_unet-demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/aisegment_unet-demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/aisegment_unet-demo/Makefile
+++ b/Examples/MAX78000/CNN/aisegment_unet-demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/aisegment_unet-demo/README.md
+++ b/Examples/MAX78000/CNN/aisegment_unet-demo/README.md
@@ -14,7 +14,7 @@ This demo shows a UNet network with 352x352 resolution input, trained to segment
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/aisegment_unet-demo/TFT/fthr/bmp/README.md
+++ b/Examples/MAX78000/CNN/aisegment_unet-demo/TFT/fthr/bmp/README.md
@@ -38,7 +38,7 @@ Examples:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/aisegment_unet-demo/Utility/README.md
+++ b/Examples/MAX78000/CNN/aisegment_unet-demo/Utility/README.md
@@ -10,7 +10,7 @@ segmentation mask
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/aisegment_unet-demo/project.mk
+++ b/Examples/MAX78000/CNN/aisegment_unet-demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/aisegment_unet/.vscode/README.md
+++ b/Examples/MAX78000/CNN/aisegment_unet/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/aisegment_unet/Makefile
+++ b/Examples/MAX78000/CNN/aisegment_unet/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/aisegment_unet/project.mk
+++ b/Examples/MAX78000/CNN/aisegment_unet/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/asl/.vscode/README.md
+++ b/Examples/MAX78000/CNN/asl/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/asl/Makefile
+++ b/Examples/MAX78000/CNN/asl/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/asl/project.mk
+++ b/Examples/MAX78000/CNN/asl/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/asl_demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/asl_demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/asl_demo/Makefile
+++ b/Examples/MAX78000/CNN/asl_demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/asl_demo/README.md
+++ b/Examples/MAX78000/CNN/asl_demo/README.md
@@ -18,11 +18,11 @@ In the demo, “empty” represents blank images missing hand symbols.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 * This project supports output to a TFT display.
     * For the MAX78000EVKIT, the TFT display is **enabled** by default.  It can be _disabled_ by commenting out `#define TFT_ENABLE` in [example_config.h](example_config.h).

--- a/Examples/MAX78000/CNN/asl_demo/TFT/fthr/bmp/README.md
+++ b/Examples/MAX78000/CNN/asl_demo/TFT/fthr/bmp/README.md
@@ -38,7 +38,7 @@ Examples:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/asl_demo/project.mk
+++ b/Examples/MAX78000/CNN/asl_demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/cam01_facedetect_demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cam01_facedetect_demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/cam01_facedetect_demo/Makefile
+++ b/Examples/MAX78000/CNN/cam01_facedetect_demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/cam01_facedetect_demo/README.md
+++ b/Examples/MAX78000/CNN/cam01_facedetect_demo/README.md
@@ -6,7 +6,7 @@ This project demonstrates object detection running on the MAX78000CAM01 board.  
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/cam01_facedetect_demo/project.mk
+++ b/Examples/MAX78000/CNN/cam01_facedetect_demo/project.mk
@@ -14,5 +14,5 @@ CAMERA = HM0360_COLOR
 BOARD = CAM01_RevA
 
 ifneq ($(BOARD),CAM01_RevA)
-$(error ERR_NOTSUPPORTED: This project is only supported on the MAX78000CAM01 board.  (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages))
+$(error ERR_NOTSUPPORTED: This project is only supported on the MAX78000CAM01 board.  (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages))
 endif

--- a/Examples/MAX78000/CNN/cam02_facedetect_demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cam02_facedetect_demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/cam02_facedetect_demo/Makefile
+++ b/Examples/MAX78000/CNN/cam02_facedetect_demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/cam02_facedetect_demo/README.md
+++ b/Examples/MAX78000/CNN/cam02_facedetect_demo/README.md
@@ -6,7 +6,7 @@ This project demonstrates object detection running on the MAX78000CAM02 board.  
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/cam02_facedetect_demo/project.mk
+++ b/Examples/MAX78000/CNN/cam02_facedetect_demo/project.mk
@@ -12,5 +12,5 @@
 BOARD = CAM02_RevA
 
 ifneq ($(BOARD),CAM02_RevA)
-$(error ERR_NOTSUPPORTED: This project is only supported on the MAX78000CAM02 board.  (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages))
+$(error ERR_NOTSUPPORTED: This project is only supported on the MAX78000CAM02 board.  (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages))
 endif

--- a/Examples/MAX78000/CNN/camvid_unet/.vscode/README.md
+++ b/Examples/MAX78000/CNN/camvid_unet/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/camvid_unet/Makefile
+++ b/Examples/MAX78000/CNN/camvid_unet/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/camvid_unet/project.mk
+++ b/Examples/MAX78000/CNN/camvid_unet/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/cats-dogs/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cats-dogs/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/cats-dogs/Makefile
+++ b/Examples/MAX78000/CNN/cats-dogs/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/cats-dogs/project.mk
+++ b/Examples/MAX78000/CNN/cats-dogs/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/cats-dogs_demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cats-dogs_demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/cats-dogs_demo/Makefile
+++ b/Examples/MAX78000/CNN/cats-dogs_demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/cats-dogs_demo/README.md
+++ b/Examples/MAX78000/CNN/cats-dogs_demo/README.md
@@ -13,11 +13,11 @@ The code uses a sampledata header (sampledata.h) file to test a pre-defined inpu
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 * This project supports output to a TFT display.  When building for the MAX78000EVKIT, the display is **enabled** by default.
     * To _disable_ the TFT display code, comment out `PROJ_CFLAGS += -DTFT_ENABLE` in [project.mk](project.mk)

--- a/Examples/MAX78000/CNN/cats-dogs_demo/TFT/fthr/bmp/README.md
+++ b/Examples/MAX78000/CNN/cats-dogs_demo/TFT/fthr/bmp/README.md
@@ -38,7 +38,7 @@ Examples:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/cats-dogs_demo/project.mk
+++ b/Examples/MAX78000/CNN/cats-dogs_demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/cifar-10-auto-test/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cifar-10-auto-test/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/cifar-10-auto-test/Makefile
+++ b/Examples/MAX78000/CNN/cifar-10-auto-test/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/cifar-10-auto-test/README.md
+++ b/Examples/MAX78000/CNN/cifar-10-auto-test/README.md
@@ -6,11 +6,11 @@ This project is based on the CIFAR-10 example.  Where the original example perfo
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections:
 

--- a/Examples/MAX78000/CNN/cifar-10-auto-test/cifar-10-png-loader/README.md
+++ b/Examples/MAX78000/CNN/cifar-10-auto-test/cifar-10-png-loader/README.md
@@ -103,7 +103,7 @@ airplane4.png	Class:0
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/cifar-10-auto-test/project.mk
+++ b/Examples/MAX78000/CNN/cifar-10-auto-test/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/cifar-10/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cifar-10/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/cifar-10/Makefile
+++ b/Examples/MAX78000/CNN/cifar-10/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/cifar-10/README.md
+++ b/Examples/MAX78000/CNN/cifar-10/README.md
@@ -10,11 +10,11 @@ output in the near future.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections:
 

--- a/Examples/MAX78000/CNN/cifar-10/project.mk
+++ b/Examples/MAX78000/CNN/cifar-10/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/cifar-100-mixed/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cifar-100-mixed/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/cifar-100-mixed/Makefile
+++ b/Examples/MAX78000/CNN/cifar-100-mixed/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/cifar-100-mixed/project.mk
+++ b/Examples/MAX78000/CNN/cifar-100-mixed/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/cifar-100-residual/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cifar-100-residual/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/cifar-100-residual/Makefile
+++ b/Examples/MAX78000/CNN/cifar-100-residual/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/cifar-100-residual/project.mk
+++ b/Examples/MAX78000/CNN/cifar-100-residual/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/Makefile
+++ b/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/project.mk
+++ b/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/cifar-100/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cifar-100/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/cifar-100/Makefile
+++ b/Examples/MAX78000/CNN/cifar-100/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/cifar-100/README.md
+++ b/Examples/MAX78000/CNN/cifar-100/README.md
@@ -10,11 +10,11 @@ output in the near future.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections:
 

--- a/Examples/MAX78000/CNN/cifar-100/project.mk
+++ b/Examples/MAX78000/CNN/cifar-100/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/digit-detection-demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/digit-detection-demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/digit-detection-demo/Makefile
+++ b/Examples/MAX78000/CNN/digit-detection-demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/digit-detection-demo/README.md
+++ b/Examples/MAX78000/CNN/digit-detection-demo/README.md
@@ -13,11 +13,11 @@ The image input size is 74x74 pixels RGB which is 74x74x3 in HWC format.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 * By default, this project is configured for [camera mode](#camera-mode).  It can be configured for [offline mode](#offline-mode) in [example_config.h](example_config.h) by defining `USE_SAMPLE_DATA`.
 

--- a/Examples/MAX78000/CNN/digit-detection-demo/TFT/fthr/bmp/README.md
+++ b/Examples/MAX78000/CNN/digit-detection-demo/TFT/fthr/bmp/README.md
@@ -38,7 +38,7 @@ Examples:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/digit-detection-demo/project.mk
+++ b/Examples/MAX78000/CNN/digit-detection-demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/faceid_112/.vscode/README.md
+++ b/Examples/MAX78000/CNN/faceid_112/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/faceid_112/Makefile
+++ b/Examples/MAX78000/CNN/faceid_112/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/facial_recognition/.vscode/README.md
+++ b/Examples/MAX78000/CNN/facial_recognition/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/facial_recognition/Makefile
+++ b/Examples/MAX78000/CNN/facial_recognition/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/facial_recognition/README.md
+++ b/Examples/MAX78000/CNN/facial_recognition/README.md
@@ -20,7 +20,7 @@ Alternatively, the [SDHC_weights](SDHC_weights) sub-project can be used to load 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/facial_recognition/SDHC_weights/.vscode/README.md
+++ b/Examples/MAX78000/CNN/facial_recognition/SDHC_weights/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/facial_recognition/SDHC_weights/Makefile
+++ b/Examples/MAX78000/CNN/facial_recognition/SDHC_weights/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/facial_recognition/SDHC_weights/README.md
+++ b/Examples/MAX78000/CNN/facial_recognition/SDHC_weights/README.md
@@ -10,7 +10,7 @@ Once loaded, the SD card is ready for use with the [facial_recognition](../READM
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/facial_recognition/project.mk
+++ b/Examples/MAX78000/CNN/facial_recognition/project.mk
@@ -28,7 +28,7 @@ ifneq "$(BOARD)" "FTHR_RevA"
 define ERR_MSG
 ERR_NOTSUPPORTED: 
 This project is only supported on the MAX78000FTHR (FTHR_RevA)
-See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages
+See https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages
 endef
 $(error $(ERR_MSG))
 endif

--- a/Examples/MAX78000/CNN/kws20_demo-riscv/.vscode/README.md
+++ b/Examples/MAX78000/CNN/kws20_demo-riscv/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/kws20_demo-riscv/README.md
+++ b/Examples/MAX78000/CNN/kws20_demo-riscv/README.md
@@ -424,7 +424,7 @@ If a new network is developed and synthesized, the new weight file and related A
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/kws20_demo-riscv/TFT/fthr/bmp/README.md
+++ b/Examples/MAX78000/CNN/kws20_demo-riscv/TFT/fthr/bmp/README.md
@@ -38,7 +38,7 @@ Examples:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/kws20_demo-riscv/project.mk
+++ b/Examples/MAX78000/CNN/kws20_demo-riscv/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78000/CNN/kws20_demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/kws20_demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/kws20_demo/Makefile
+++ b/Examples/MAX78000/CNN/kws20_demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/kws20_demo/README.md
+++ b/Examples/MAX78000/CNN/kws20_demo/README.md
@@ -22,13 +22,13 @@ To improve the unknown detection, the model in version 3.2 is trained with an ad
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
 Note:  fully clean and re-build this project after changing any of the config options below.
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 * This project supports output to a TFT display.  When building for the MAX78000EVKIT, the display is **enabled** by default.
     * To _disable_ the TFT display code, comment out `PROJ_CFLAGS += -DTFT_ENABLE` in [project.mk](project.mk)

--- a/Examples/MAX78000/CNN/kws20_demo/TFT/fthr/bmp/README.md
+++ b/Examples/MAX78000/CNN/kws20_demo/TFT/fthr/bmp/README.md
@@ -38,7 +38,7 @@ Examples:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/kws20_demo/project.mk
+++ b/Examples/MAX78000/CNN/kws20_demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/kws20_v3/.vscode/README.md
+++ b/Examples/MAX78000/CNN/kws20_v3/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/kws20_v3/Makefile
+++ b/Examples/MAX78000/CNN/kws20_v3/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/kws20_v3/README.md
+++ b/Examples/MAX78000/CNN/kws20_v3/README.md
@@ -11,11 +11,11 @@ output in the near future.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.

--- a/Examples/MAX78000/CNN/kws20_v3/project.mk
+++ b/Examples/MAX78000/CNN/kws20_v3/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/mnist-riscv/.vscode/README.md
+++ b/Examples/MAX78000/CNN/mnist-riscv/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/mnist-riscv/README.md
+++ b/Examples/MAX78000/CNN/mnist-riscv/README.md
@@ -12,11 +12,11 @@ output in the near future.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections:
 

--- a/Examples/MAX78000/CNN/mnist/.vscode/README.md
+++ b/Examples/MAX78000/CNN/mnist/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/mnist/Makefile
+++ b/Examples/MAX78000/CNN/mnist/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/mnist/README.md
+++ b/Examples/MAX78000/CNN/mnist/README.md
@@ -11,11 +11,11 @@ output in the near future.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/CNN/mnist/project.mk
+++ b/Examples/MAX78000/CNN/mnist/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/rps-demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/rps-demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/rps-demo/Makefile
+++ b/Examples/MAX78000/CNN/rps-demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/rps-demo/README.md
+++ b/Examples/MAX78000/CNN/rps-demo/README.md
@@ -8,11 +8,11 @@ The example supports live capture from camera module and displays the result on 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 * By default, this project is configured for [camera mode](#camera-mode).  It can be configured for [offline mode](#offline-mode) by defining `USE_SAMPLE_DATA` in [main.c](main.c).
 

--- a/Examples/MAX78000/CNN/rps-demo/TFT/fthr/bmp/README.md
+++ b/Examples/MAX78000/CNN/rps-demo/TFT/fthr/bmp/README.md
@@ -38,7 +38,7 @@ Examples:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/rps-demo/project.mk
+++ b/Examples/MAX78000/CNN/rps-demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/rps/.vscode/README.md
+++ b/Examples/MAX78000/CNN/rps/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/rps/Makefile
+++ b/Examples/MAX78000/CNN/rps/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/rps/README.md
+++ b/Examples/MAX78000/CNN/rps/README.md
@@ -10,11 +10,11 @@ output is located in "rps-demo: directory.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections:
 

--- a/Examples/MAX78000/CNN/rps/project.mk
+++ b/Examples/MAX78000/CNN/rps/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/snake_game_demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/snake_game_demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/snake_game_demo/Makefile
+++ b/Examples/MAX78000/CNN/snake_game_demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/snake_game_demo/README.md
+++ b/Examples/MAX78000/CNN/snake_game_demo/README.md
@@ -29,11 +29,11 @@ Here are the instructions to play this game using speech command:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## MAX78000 EVKIT operations
 

--- a/Examples/MAX78000/CNN/snake_game_demo/TFT/fthr/bmp/README.md
+++ b/Examples/MAX78000/CNN/snake_game_demo/TFT/fthr/bmp/README.md
@@ -38,7 +38,7 @@ Examples:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CNN/snake_game_demo/project.mk
+++ b/Examples/MAX78000/CNN/snake_game_demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CNN/svhn_tinierssd/.vscode/README.md
+++ b/Examples/MAX78000/CNN/svhn_tinierssd/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CNN/svhn_tinierssd/Makefile
+++ b/Examples/MAX78000/CNN/svhn_tinierssd/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CNN/svhn_tinierssd/project.mk
+++ b/Examples/MAX78000/CNN/svhn_tinierssd/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CRC/.vscode/README.md
+++ b/Examples/MAX78000/CRC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CRC/Makefile
+++ b/Examples/MAX78000/CRC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CRC/README.md
+++ b/Examples/MAX78000/CRC/README.md
@@ -6,11 +6,11 @@ This example demonstrates the use of the HW CRC calculator.  The example first g
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections:
 

--- a/Examples/MAX78000/CRC/project.mk
+++ b/Examples/MAX78000/CRC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/CameraIF/.vscode/README.md
+++ b/Examples/MAX78000/CameraIF/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CameraIF/Makefile
+++ b/Examples/MAX78000/CameraIF/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CameraIF/README.md
+++ b/Examples/MAX78000/CameraIF/README.md
@@ -12,10 +12,10 @@ This example demonstrates the Parallel Camera Interface (PCIF) drivers and camer
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 * To change the camera drivers, set the `CAMERA` build [configuration variable](.vscode/README.md#build-configuration) in [project.mk](project.mk).

--- a/Examples/MAX78000/CameraIF/pc_utility/README.md
+++ b/Examples/MAX78000/CameraIF/pc_utility/README.md
@@ -17,7 +17,7 @@ The default baudrate is 921600 but if you would like to change it, do not forget
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CameraIF/project.mk
+++ b/Examples/MAX78000/CameraIF/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78000/CameraIF_Debayer/.vscode/README.md
+++ b/Examples/MAX78000/CameraIF_Debayer/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/CameraIF_Debayer/Makefile
+++ b/Examples/MAX78000/CameraIF_Debayer/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/CameraIF_Debayer/README.md
+++ b/Examples/MAX78000/CameraIF_Debayer/README.md
@@ -8,7 +8,7 @@ It requires debayering/demosaicing and color correction post-processing algorith
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CameraIF_Debayer/pc_utility/README.md
+++ b/Examples/MAX78000/CameraIF_Debayer/pc_utility/README.md
@@ -13,7 +13,7 @@ to update the board side too.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/CameraIF_Debayer/project.mk
+++ b/Examples/MAX78000/CameraIF_Debayer/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78000/Coremark/.vscode/README.md
+++ b/Examples/MAX78000/Coremark/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/Coremark/Makefile
+++ b/Examples/MAX78000/Coremark/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/Coremark/README.md
+++ b/Examples/MAX78000/Coremark/README.md
@@ -10,7 +10,7 @@ For more information, visit the [CoreMark webpage](https://www.eembc.org/coremar
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/Coremark/project.mk
+++ b/Examples/MAX78000/Coremark/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78000/DMA/.vscode/README.md
+++ b/Examples/MAX78000/DMA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/DMA/Makefile
+++ b/Examples/MAX78000/DMA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/DMA/README.md
+++ b/Examples/MAX78000/DMA/README.md
@@ -8,11 +8,11 @@ A second more complex memory-to-memory DMA transaction is then shown that chains
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections:
 

--- a/Examples/MAX78000/DMA/project.mk
+++ b/Examples/MAX78000/DMA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/ECC/.vscode/README.md
+++ b/Examples/MAX78000/ECC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/ECC/Makefile
+++ b/Examples/MAX78000/ECC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/ECC/README.md
+++ b/Examples/MAX78000/ECC/README.md
@@ -10,11 +10,11 @@ That same word is modified again to contain a double bit error.  The word is rea
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections:
 

--- a/Examples/MAX78000/ECC/project.mk
+++ b/Examples/MAX78000/ECC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX78000/EEPROM_Emulator/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/EEPROM_Emulator/Makefile
+++ b/Examples/MAX78000/EEPROM_Emulator/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/EEPROM_Emulator/README.md
+++ b/Examples/MAX78000/EEPROM_Emulator/README.md
@@ -47,11 +47,11 @@ To help with syncronization, a "Ready Signal" is set up as an output from a GPIO
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX78000/EEPROM_Emulator/project.mk
+++ b/Examples/MAX78000/EEPROM_Emulator/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78000/FTHR_I2C/.vscode/README.md
+++ b/Examples/MAX78000/FTHR_I2C/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/FTHR_I2C/Makefile
+++ b/Examples/MAX78000/FTHR_I2C/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/FTHR_I2C/README.md
+++ b/Examples/MAX78000/FTHR_I2C/README.md
@@ -8,7 +8,7 @@ This example uses I2C to cycle through the 8 colors of the RGB LED connected to 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/FTHR_I2C/project.mk
+++ b/Examples/MAX78000/FTHR_I2C/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/FTHR_SRAM/.vscode/README.md
+++ b/Examples/MAX78000/FTHR_SRAM/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/FTHR_SRAM/Makefile
+++ b/Examples/MAX78000/FTHR_SRAM/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/FTHR_SRAM/README.md
+++ b/Examples/MAX78000/FTHR_SRAM/README.md
@@ -6,7 +6,7 @@ This example demonstrates with the N01S830HA external SRAM IC on the MAX78000FTH
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/FTHR_SRAM/project.mk
+++ b/Examples/MAX78000/FTHR_SRAM/project.mk
@@ -3,12 +3,12 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 
 BOARD = FTHR_RevA
 
 ifneq "$(BOARD)" "FTHR_RevA"
-$(error ERR_NOTSUPPORTED: This example is only supported on the MAX78000FTHR board!  See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages)
+$(error ERR_NOTSUPPORTED: This example is only supported on the MAX78000FTHR board!  See https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages)
 endif

--- a/Examples/MAX78000/Flash/.vscode/README.md
+++ b/Examples/MAX78000/Flash/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/Flash/Makefile
+++ b/Examples/MAX78000/Flash/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/Flash/README.md
+++ b/Examples/MAX78000/Flash/README.md
@@ -20,11 +20,11 @@ The _second_ time the example is run the application will see the "magic" 32-bit
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Hardware Connections
 

--- a/Examples/MAX78000/Flash/project.mk
+++ b/Examples/MAX78000/Flash/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78000/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX78000/Flash_CLI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/Flash_CLI/Makefile
+++ b/Examples/MAX78000/Flash_CLI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/Flash_CLI/README.md
+++ b/Examples/MAX78000/Flash_CLI/README.md
@@ -8,11 +8,11 @@ This example demonstates the CLI commands feature of FreeRTOS, various features 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/Flash_CLI/project.mk
+++ b/Examples/MAX78000/Flash_CLI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX78000/FreeRTOSDemo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/FreeRTOSDemo/Makefile
+++ b/Examples/MAX78000/FreeRTOSDemo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/FreeRTOSDemo/README.md
+++ b/Examples/MAX78000/FreeRTOSDemo/README.md
@@ -6,11 +6,11 @@ A basic getting started application for FreeRTOS.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX78000/FreeRTOSDemo/project.mk
+++ b/Examples/MAX78000/FreeRTOSDemo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/GPIO/.vscode/README.md
+++ b/Examples/MAX78000/GPIO/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/GPIO/Makefile
+++ b/Examples/MAX78000/GPIO/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/GPIO/README.md
+++ b/Examples/MAX78000/GPIO/README.md
@@ -14,11 +14,11 @@ P1.7 (SW2) is continuously scanned and whatever value is read on that pin is the
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/GPIO/project.mk
+++ b/Examples/MAX78000/GPIO/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/Hello_World/.vscode/README.md
+++ b/Examples/MAX78000/Hello_World/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/Hello_World/Makefile
+++ b/Examples/MAX78000/Hello_World/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/Hello_World/README.md
+++ b/Examples/MAX78000/Hello_World/README.md
@@ -8,11 +8,11 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/Hello_World/project.mk
+++ b/Examples/MAX78000/Hello_World/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX78000/Hello_World_Cpp/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/Hello_World_Cpp/Makefile
+++ b/Examples/MAX78000/Hello_World_Cpp/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/Hello_World_Cpp/README.md
+++ b/Examples/MAX78000/Hello_World_Cpp/README.md
@@ -8,11 +8,11 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/Hello_World_Cpp/project.mk
+++ b/Examples/MAX78000/Hello_World_Cpp/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/I2C_ADXL343/.vscode/README.md
+++ b/Examples/MAX78000/I2C_ADXL343/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/I2C_ADXL343/Makefile
+++ b/Examples/MAX78000/I2C_ADXL343/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/I2C_ADXL343/README.md
+++ b/Examples/MAX78000/I2C_ADXL343/README.md
@@ -6,11 +6,11 @@ This application demonstrates I2C communication between the MAX78000FTHR Applica
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/I2C_ADXL343/project.mk
+++ b/Examples/MAX78000/I2C_ADXL343/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX78000/I2C_MNGR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/I2C_MNGR/Makefile
+++ b/Examples/MAX78000/I2C_MNGR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/I2C_MNGR/README.md
+++ b/Examples/MAX78000/I2C_MNGR/README.md
@@ -10,11 +10,11 @@ You may change the configuration of each EEPROM's I2C transaction parameters (sl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/I2C_MNGR/project.mk
+++ b/Examples/MAX78000/I2C_MNGR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78000/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX78000/I2C_SCAN/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/I2C_SCAN/Makefile
+++ b/Examples/MAX78000/I2C_SCAN/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/I2C_SCAN/README.md
+++ b/Examples/MAX78000/I2C_SCAN/README.md
@@ -6,11 +6,11 @@ This example uses the I2C Master to find the addresses of any I2C Slave devices 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/I2C_SCAN/project.mk
+++ b/Examples/MAX78000/I2C_SCAN/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX78000/I2C_Sensor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/I2C_Sensor/Makefile
+++ b/Examples/MAX78000/I2C_Sensor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/I2C_Sensor/README.md
+++ b/Examples/MAX78000/I2C_Sensor/README.md
@@ -8,11 +8,11 @@ After initialization, a new reading is printed to the terminal every second.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/I2C_Sensor/project.mk
+++ b/Examples/MAX78000/I2C_Sensor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78000/I2S/.vscode/README.md
+++ b/Examples/MAX78000/I2S/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/I2S/Makefile
+++ b/Examples/MAX78000/I2S/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/I2S/README.md
+++ b/Examples/MAX78000/I2S/README.md
@@ -6,11 +6,11 @@ This application demonstrates receiving data from the microphone on the MAX78000
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/I2S/project.mk
+++ b/Examples/MAX78000/I2S/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/I2S_DMA/.vscode/README.md
+++ b/Examples/MAX78000/I2S_DMA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/I2S_DMA/Makefile
+++ b/Examples/MAX78000/I2S_DMA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/I2S_DMA/README.md
+++ b/Examples/MAX78000/I2S_DMA/README.md
@@ -6,11 +6,11 @@ This application demonstrates receiving data from the microphone on the MAX78000
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/I2S_DMA/project.mk
+++ b/Examples/MAX78000/I2S_DMA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/I2S_DMA_Target/.vscode/README.md
+++ b/Examples/MAX78000/I2S_DMA_Target/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/I2S_DMA_Target/Makefile
+++ b/Examples/MAX78000/I2S_DMA_Target/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/I2S_DMA_Target/README.md
+++ b/Examples/MAX78000/I2S_DMA_Target/README.md
@@ -6,7 +6,7 @@ This application demonstrates simultaneous CODEC recording and playback using DM
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/I2S_DMA_Target/project.mk
+++ b/Examples/MAX78000/I2S_DMA_Target/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 
@@ -12,6 +12,6 @@
 # This example is only compatible with the FTHR board,
 # so we override the BOARD value to hard-set it.
 ifneq ($(BOARD),FTHR_RevA)
-$(error ERR_NOTSUPPORTED: This project is only supported on the MAX78000FTHR board.  See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages)
+$(error ERR_NOTSUPPORTED: This project is only supported on the MAX78000FTHR board.  See https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages)
 endif
 

--- a/Examples/MAX78000/ICC/.vscode/README.md
+++ b/Examples/MAX78000/ICC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/ICC/Makefile
+++ b/Examples/MAX78000/ICC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/ICC/README.md
+++ b/Examples/MAX78000/ICC/README.md
@@ -11,11 +11,11 @@ This example demonstrates the time differences when running code with the instru
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/ICC/project.mk
+++ b/Examples/MAX78000/ICC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/ImgCapture/.vscode/README.md
+++ b/Examples/MAX78000/ImgCapture/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/ImgCapture/Makefile
+++ b/Examples/MAX78000/ImgCapture/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/ImgCapture/README.md
+++ b/Examples/MAX78000/ImgCapture/README.md
@@ -23,11 +23,11 @@ It supports the following output destinations:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 #### Enabling Firmware Features
 

--- a/Examples/MAX78000/ImgCapture/project.mk
+++ b/Examples/MAX78000/ImgCapture/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78000/LP/.vscode/README.md
+++ b/Examples/MAX78000/LP/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/LP/Makefile
+++ b/Examples/MAX78000/LP/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/LP/README.md
+++ b/Examples/MAX78000/LP/README.md
@@ -17,11 +17,11 @@ Following modes can be tested:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/LP/project.mk
+++ b/Examples/MAX78000/LP/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/LPCMP/.vscode/README.md
+++ b/Examples/MAX78000/LPCMP/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/LPCMP/Makefile
+++ b/Examples/MAX78000/LPCMP/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/LPCMP/README.md
+++ b/Examples/MAX78000/LPCMP/README.md
@@ -8,11 +8,11 @@ The example is configured to use two analog channels as the negative and positiv
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/LPCMP/project.mk
+++ b/Examples/MAX78000/LPCMP/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/Library_Generate/.vscode/README.md
+++ b/Examples/MAX78000/Library_Generate/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
   * If it's not in the README, check the UG.
   * If it's not in the UG, open a ticket!
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
@@ -31,7 +31,7 @@ The following features are supported:
 
 The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.analog.com/en/education/education-library/videos/6313212752112.html).
 
-1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
     * [Windows](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0010820A)
     * [Linux (Ubuntu)](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018720A)
     * [MacOS](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018610A)

--- a/Examples/MAX78000/Library_Generate/Makefile
+++ b/Examples/MAX78000/Library_Generate/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/Library_Generate/README.md
+++ b/Examples/MAX78000/Library_Generate/README.md
@@ -9,7 +9,7 @@ Check the Library_Use demo to see how to link static libraries to an application
 
 ### Project Usage
 
-Universal instructions on building this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/Library_Generate/project.mk
+++ b/Examples/MAX78000/Library_Generate/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
  
 # **********************************************************
 

--- a/Examples/MAX78000/Library_Use/.vscode/README.md
+++ b/Examples/MAX78000/Library_Use/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/Library_Use/Makefile
+++ b/Examples/MAX78000/Library_Use/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/Library_Use/README.md
+++ b/Examples/MAX78000/Library_Use/README.md
@@ -9,11 +9,11 @@ to project.mk to see how to include ".a" static library files into your project.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-This example supports all available MAX78000 evaluation platforms but comes _pre-configured_ for the MAX78000EVKIT by default. See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
+This example supports all available MAX78000 evaluation platforms but comes _pre-configured_ for the MAX78000EVKIT by default. See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) for instructions on how to configure the project for a different board.
 
 ## Required Connections
 

--- a/Examples/MAX78000/Library_Use/project.mk
+++ b/Examples/MAX78000/Library_Use/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78000/Pulse_Train/.vscode/README.md
+++ b/Examples/MAX78000/Pulse_Train/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/Pulse_Train/Makefile
+++ b/Examples/MAX78000/Pulse_Train/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/Pulse_Train/README.md
+++ b/Examples/MAX78000/Pulse_Train/README.md
@@ -14,11 +14,11 @@ On the featherboard, the continuous bit pattern and square wave signals are outp
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/Pulse_Train/project.mk
+++ b/Examples/MAX78000/Pulse_Train/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/RTC/.vscode/README.md
+++ b/Examples/MAX78000/RTC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/RTC/Makefile
+++ b/Examples/MAX78000/RTC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/RTC/README.md
+++ b/Examples/MAX78000/RTC/README.md
@@ -13,11 +13,11 @@ Pressing SW2 will output the current value of the RTC to the console UART.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/RTC/project.mk
+++ b/Examples/MAX78000/RTC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX78000/RTC_Backup/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/RTC_Backup/Makefile
+++ b/Examples/MAX78000/RTC_Backup/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/RTC_Backup/README.md
+++ b/Examples/MAX78000/RTC_Backup/README.md
@@ -8,11 +8,11 @@ The RTC time-of-day alarm is used to wake the device from backup mode every TIME
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX78000/RTC_Backup/project.mk
+++ b/Examples/MAX78000/RTC_Backup/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/RV_ARM_Loader/.vscode/README.md
+++ b/Examples/MAX78000/RV_ARM_Loader/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/RV_ARM_Loader/Makefile
+++ b/Examples/MAX78000/RV_ARM_Loader/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/RV_ARM_Loader/README.md
+++ b/Examples/MAX78000/RV_ARM_Loader/README.md
@@ -8,7 +8,7 @@ RV_ARM_Loader runs on the ARM core to load the RISCV code space, setup the RISCV
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/RV_ARM_Loader/project.mk
+++ b/Examples/MAX78000/RV_ARM_Loader/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78000/SDHC_FTHR/.vscode/README.md
+++ b/Examples/MAX78000/SDHC_FTHR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/SDHC_FTHR/Makefile
+++ b/Examples/MAX78000/SDHC_FTHR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/SDHC_FTHR/README.md
+++ b/Examples/MAX78000/SDHC_FTHR/README.md
@@ -6,11 +6,11 @@ This example demonstrates the SDHC FAT Filesystem. The terminal prompts with a l
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000FTHR.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000FTHR.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX78000/SDHC_FTHR/project.mk
+++ b/Examples/MAX78000/SDHC_FTHR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/SPI/.vscode/README.md
+++ b/Examples/MAX78000/SPI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/SPI/Makefile
+++ b/Examples/MAX78000/SPI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/SPI/README.md
+++ b/Examples/MAX78000/SPI/README.md
@@ -8,11 +8,11 @@ By default, the example performs blocking SPI transactions.  To switch to non-bl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/SPI/project.mk
+++ b/Examples/MAX78000/SPI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/TFT_Demo/.vscode/README.md
+++ b/Examples/MAX78000/TFT_Demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/TFT_Demo/Makefile
+++ b/Examples/MAX78000/TFT_Demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/TFT_Demo/README.md
+++ b/Examples/MAX78000/TFT_Demo/README.md
@@ -33,11 +33,11 @@ bitmap files has to be encoded 8 bits (256 color bitmap).
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ### MAX78000 Feather operations
 

--- a/Examples/MAX78000/TFT_Demo/project.mk
+++ b/Examples/MAX78000/TFT_Demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/TFT_Demo/resources/tft_fthr/bmp/README.md
+++ b/Examples/MAX78000/TFT_Demo/resources/tft_fthr/bmp/README.md
@@ -38,7 +38,7 @@ Examples:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78000/TMR/.vscode/README.md
+++ b/Examples/MAX78000/TMR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/TMR/Makefile
+++ b/Examples/MAX78000/TMR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/TMR/README.md
+++ b/Examples/MAX78000/TMR/README.md
@@ -12,11 +12,11 @@ Push PB1/SW1 to start the PWM and continuous timers and PB2/SW2 to start the one
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX78000/TMR/project.mk
+++ b/Examples/MAX78000/TMR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/TRNG/.vscode/README.md
+++ b/Examples/MAX78000/TRNG/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/TRNG/Makefile
+++ b/Examples/MAX78000/TRNG/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/TRNG/README.md
+++ b/Examples/MAX78000/TRNG/README.md
@@ -6,11 +6,11 @@ The true random number generator (TRNG) hardware is exercised in this example.  
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections:
 

--- a/Examples/MAX78000/TRNG/project.mk
+++ b/Examples/MAX78000/TRNG/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX78000/Temp_Monitor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/Temp_Monitor/Makefile
+++ b/Examples/MAX78000/Temp_Monitor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/Temp_Monitor/README.md
+++ b/Examples/MAX78000/Temp_Monitor/README.md
@@ -14,11 +14,11 @@ The temperature limits, flash storage page, and RTC time-of-day alarm period are
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX78000/Temp_Monitor/project.mk
+++ b/Examples/MAX78000/Temp_Monitor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78000/UART/.vscode/README.md
+++ b/Examples/MAX78000/UART/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/UART/Makefile
+++ b/Examples/MAX78000/UART/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/UART/README.md
+++ b/Examples/MAX78000/UART/README.md
@@ -6,11 +6,11 @@ This application demonstrates a UART transaction between two serial ports on the
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX78000/UART/project.mk
+++ b/Examples/MAX78000/UART/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/UCL/README.md
+++ b/Examples/MAX78000/UCL/README.md
@@ -8,11 +8,11 @@ TODO:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX78000/UCL/project.mk
+++ b/Examples/MAX78000/UCL/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
 # ^ For example, you can uncomment this line to make the 

--- a/Examples/MAX78000/WUT/.vscode/README.md
+++ b/Examples/MAX78000/WUT/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/WUT/Makefile
+++ b/Examples/MAX78000/WUT/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/WUT/README.md
+++ b/Examples/MAX78000/WUT/README.md
@@ -6,11 +6,11 @@ This example shows how to wake up a device after it is asleep with a wake up tim
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections:
 

--- a/Examples/MAX78000/WUT/project.mk
+++ b/Examples/MAX78000/WUT/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/Watchdog/.vscode/README.md
+++ b/Examples/MAX78000/Watchdog/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/Watchdog/Makefile
+++ b/Examples/MAX78000/Watchdog/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/Watchdog/README.md
+++ b/Examples/MAX78000/Watchdog/README.md
@@ -11,11 +11,11 @@ When the application begins, it initializes and starts the watchdog timer.  The 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections:
 

--- a/Examples/MAX78000/Watchdog/project.mk
+++ b/Examples/MAX78000/Watchdog/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78000/WearLeveling/.vscode/README.md
+++ b/Examples/MAX78000/WearLeveling/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78000/WearLeveling/Makefile
+++ b/Examples/MAX78000/WearLeveling/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78000/WearLeveling/README.md
+++ b/Examples/MAX78000/WearLeveling/README.md
@@ -15,11 +15,11 @@ Enter "help" in the command line to see more details on the usage of each of the
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78000EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX78000/WearLeveling/project.mk
+++ b/Examples/MAX78000/WearLeveling/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/ADC/.vscode/README.md
+++ b/Examples/MAX78002/ADC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/ADC/Makefile
+++ b/Examples/MAX78002/ADC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/ADC/README.md
+++ b/Examples/MAX78002/ADC/README.md
@@ -12,7 +12,7 @@ Beware which Port 2 (channel) you use. Some of the Port 2 pins are connected to 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project on supported boards can be found in the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/).
+Universal instructions on building, flashing, and debugging this project on supported boards can be found in the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/).
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/ADC/project.mk
+++ b/Examples/MAX78002/ADC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/AES/.vscode/README.md
+++ b/Examples/MAX78002/AES/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/AES/Makefile
+++ b/Examples/MAX78002/AES/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/AES/README.md
+++ b/Examples/MAX78002/AES/README.md
@@ -6,7 +6,7 @@ This application demonstrates both encryption and decryption using AES.  A block
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/AES/project.mk
+++ b/Examples/MAX78002/AES/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/ARM-DSP/README.md
+++ b/Examples/MAX78002/ARM-DSP/README.md
@@ -14,7 +14,7 @@ Development with Visual Studio Code is also supported.  See [VSCode-Maxim](https
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_bayes_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/ARM-DSP/arm_bayes_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_bayes_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_class_marks_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/ARM-DSP/arm_class_marks_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_class_marks_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_convolution_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/ARM-DSP/arm_convolution_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_convolution_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_fir_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/ARM-DSP/arm_fir_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_fir_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_matrix_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/ARM-DSP/arm_matrix_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_matrix_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_svm_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/ARM-DSP/arm_svm_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_svm_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_variance_example/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/ARM-DSP/arm_variance_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_variance_example/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/CNN/cifar-100-effnet2/.vscode/README.md
+++ b/Examples/MAX78002/CNN/cifar-100-effnet2/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/CNN/cifar-100-effnet2/Makefile
+++ b/Examples/MAX78002/CNN/cifar-100-effnet2/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/CNN/cifar-100-effnet2/project.mk
+++ b/Examples/MAX78002/CNN/cifar-100-effnet2/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/CNN/cifar-100-mobilenet-v2-0.75/project.mk
+++ b/Examples/MAX78002/CNN/cifar-100-mobilenet-v2-0.75/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/CNN/facial_recognition/.vscode/README.md
+++ b/Examples/MAX78002/CNN/facial_recognition/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/CNN/facial_recognition/Makefile
+++ b/Examples/MAX78002/CNN/facial_recognition/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/CNN/imagenet-riscv/.vscode/README.md
+++ b/Examples/MAX78002/CNN/imagenet-riscv/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/CNN/imagenet/.vscode/README.md
+++ b/Examples/MAX78002/CNN/imagenet/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/CNN/imagenet/Makefile
+++ b/Examples/MAX78002/CNN/imagenet/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/CNN/imagenet/project.mk
+++ b/Examples/MAX78002/CNN/imagenet/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/CNN/kinetics/.vscode/README.md
+++ b/Examples/MAX78002/CNN/kinetics/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/CNN/kinetics/Makefile
+++ b/Examples/MAX78002/CNN/kinetics/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/CNN/kws20_demo/.vscode/README.md
+++ b/Examples/MAX78002/CNN/kws20_demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/CNN/kws20_demo/Makefile
+++ b/Examples/MAX78002/CNN/kws20_demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/CNN/kws20_demo/README.md
+++ b/Examples/MAX78002/CNN/kws20_demo/README.md
@@ -21,11 +21,11 @@ To improve the unknown detection, the model in version 3.2 is trained with an ad
 
 ### Project Usage
 
-Instructions on building, flashing, and debugging MSDK projects can be found in the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/).
+Instructions on building, flashing, and debugging MSDK projects can be found in the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/).
 
 ### Build Notes
 
-See ["Build System"](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system) in the MSDK User Guide for detailed documentation.  The section below contains additional notes on options that are specific to this project.
+See ["Build System"](https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system) in the MSDK User Guide for detailed documentation.  The section below contains additional notes on options that are specific to this project.
 
 This project offers the option to enable or disable the TFT display in [project.mk](project.mk) via the `ENABLE_TFT` build configuration variable.
 

--- a/Examples/MAX78002/CNN/kws20_demo/project.mk
+++ b/Examples/MAX78002/CNN/kws20_demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78002/CNN/kws20_demo/tft/bmp/README.md
+++ b/Examples/MAX78002/CNN/kws20_demo/tft/bmp/README.md
@@ -38,7 +38,7 @@ Examples:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/CNN/mobilefacenet-112/.vscode/README.md
+++ b/Examples/MAX78002/CNN/mobilefacenet-112/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/CNN/mobilefacenet-112/Makefile
+++ b/Examples/MAX78002/CNN/mobilefacenet-112/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/.vscode/README.md
+++ b/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/Makefile
+++ b/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/README.md
+++ b/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/README.md
@@ -8,7 +8,7 @@ After initialization, the demo program will continuously capture a 320x256 image
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/CRC/.vscode/README.md
+++ b/Examples/MAX78002/CRC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/CRC/Makefile
+++ b/Examples/MAX78002/CRC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/CRC/README.md
+++ b/Examples/MAX78002/CRC/README.md
@@ -6,7 +6,7 @@ This example demonstrates the use of the HW CRC calculator.  The example first g
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/CRC/project.mk
+++ b/Examples/MAX78002/CRC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/CSI2/.vscode/README.md
+++ b/Examples/MAX78002/CSI2/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/CSI2/Makefile
+++ b/Examples/MAX78002/CSI2/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/CSI2/README.md
+++ b/Examples/MAX78002/CSI2/README.md
@@ -8,7 +8,7 @@ Use the [utils/console.py](utils/console.py) script to grab the camera data and 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/CSI2/project.mk
+++ b/Examples/MAX78002/CSI2/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/CameraIF/.vscode/README.md
+++ b/Examples/MAX78002/CameraIF/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/CameraIF/Makefile
+++ b/Examples/MAX78002/CameraIF/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/CameraIF/README.md
+++ b/Examples/MAX78002/CameraIF/README.md
@@ -8,7 +8,7 @@ Use the pc_utility/grab_image.py script to grab the camera data and create a png
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/CameraIF/pc_utility/README.md
+++ b/Examples/MAX78002/CameraIF/pc_utility/README.md
@@ -17,7 +17,7 @@ The default baudrate is 921600 but if you would like to change it, do not forget
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/CameraIF/project.mk
+++ b/Examples/MAX78002/CameraIF/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/CameraIF_Debayer/.vscode/README.md
+++ b/Examples/MAX78002/CameraIF_Debayer/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/CameraIF_Debayer/Makefile
+++ b/Examples/MAX78002/CameraIF_Debayer/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/CameraIF_Debayer/README.md
+++ b/Examples/MAX78002/CameraIF_Debayer/README.md
@@ -10,7 +10,7 @@ It requires debayering/demosaicking and color correction post-processing algorit
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/CameraIF_Debayer/pc_utility/README.md
+++ b/Examples/MAX78002/CameraIF_Debayer/pc_utility/README.md
@@ -13,7 +13,7 @@ to update the board side too.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/CameraIF_Debayer/project.mk
+++ b/Examples/MAX78002/CameraIF_Debayer/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/Coremark/.vscode/README.md
+++ b/Examples/MAX78002/Coremark/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/Coremark/Makefile
+++ b/Examples/MAX78002/Coremark/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/Coremark/README.md
+++ b/Examples/MAX78002/Coremark/README.md
@@ -10,7 +10,7 @@ For more information, visit the [CoreMark webpage](https://www.eembc.org/coremar
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/Coremark/project.mk
+++ b/Examples/MAX78002/Coremark/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78002/DMA/.vscode/README.md
+++ b/Examples/MAX78002/DMA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/DMA/Makefile
+++ b/Examples/MAX78002/DMA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/DMA/README.md
+++ b/Examples/MAX78002/DMA/README.md
@@ -8,7 +8,7 @@ A second more complex memory-to-memory DMA transaction is then shown that chains
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/DMA/project.mk
+++ b/Examples/MAX78002/DMA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/ECC/.vscode/README.md
+++ b/Examples/MAX78002/ECC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/ECC/Makefile
+++ b/Examples/MAX78002/ECC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/ECC/README.md
+++ b/Examples/MAX78002/ECC/README.md
@@ -10,7 +10,7 @@ That same word is modified again to contain a double bit error.  The word is rea
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/ECC/project.mk
+++ b/Examples/MAX78002/ECC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX78002/EEPROM_Emulator/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/EEPROM_Emulator/Makefile
+++ b/Examples/MAX78002/EEPROM_Emulator/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/EEPROM_Emulator/README.md
+++ b/Examples/MAX78002/EEPROM_Emulator/README.md
@@ -48,7 +48,7 @@ To help with syncronization, a "Ready Signal" is set up as an output from a GPIO
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/EEPROM_Emulator/project.mk
+++ b/Examples/MAX78002/EEPROM_Emulator/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78002/Flash/.vscode/README.md
+++ b/Examples/MAX78002/Flash/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/Flash/Makefile
+++ b/Examples/MAX78002/Flash/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/Flash/README.md
+++ b/Examples/MAX78002/Flash/README.md
@@ -20,7 +20,7 @@ The _second_ time the example is run the application will see the "magic" 32-bit
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/Flash/project.mk
+++ b/Examples/MAX78002/Flash/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78002/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX78002/Flash_CLI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/Flash_CLI/Makefile
+++ b/Examples/MAX78002/Flash_CLI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/Flash_CLI/README.md
+++ b/Examples/MAX78002/Flash_CLI/README.md
@@ -8,7 +8,7 @@ This example demonstates the CLI commands feature of FreeRTOS, various features 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/Flash_CLI/project.mk
+++ b/Examples/MAX78002/Flash_CLI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX78002/FreeRTOSDemo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/FreeRTOSDemo/Makefile
+++ b/Examples/MAX78002/FreeRTOSDemo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/FreeRTOSDemo/README.md
+++ b/Examples/MAX78002/FreeRTOSDemo/README.md
@@ -6,7 +6,7 @@ A basic getting started application for FreeRTOS.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/FreeRTOSDemo/project.mk
+++ b/Examples/MAX78002/FreeRTOSDemo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/GPIO/.vscode/README.md
+++ b/Examples/MAX78002/GPIO/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/GPIO/Makefile
+++ b/Examples/MAX78002/GPIO/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/GPIO/README.md
+++ b/Examples/MAX78002/GPIO/README.md
@@ -8,7 +8,7 @@ P2.6 (PB1) is continuously scanned and whatever value is read on that pin is the
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/GPIO/project.mk
+++ b/Examples/MAX78002/GPIO/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/Hello_World/.vscode/README.md
+++ b/Examples/MAX78002/Hello_World/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/Hello_World/Makefile
+++ b/Examples/MAX78002/Hello_World/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/Hello_World/README.md
+++ b/Examples/MAX78002/Hello_World/README.md
@@ -8,7 +8,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/Hello_World/project.mk
+++ b/Examples/MAX78002/Hello_World/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX78002/Hello_World_Cpp/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/Hello_World_Cpp/Makefile
+++ b/Examples/MAX78002/Hello_World_Cpp/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/Hello_World_Cpp/README.md
+++ b/Examples/MAX78002/Hello_World_Cpp/README.md
@@ -8,7 +8,7 @@ This version of Hello_World prints an incrementing count to the console UART and
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/Hello_World_Cpp/project.mk
+++ b/Examples/MAX78002/Hello_World_Cpp/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/I2C/.vscode/README.md
+++ b/Examples/MAX78002/I2C/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/I2C/Makefile
+++ b/Examples/MAX78002/I2C/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/I2C/README.md
+++ b/Examples/MAX78002/I2C/README.md
@@ -6,7 +6,7 @@ This example uses the I2C Master to read/write from/to the I2C Slave.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/I2C/project.mk
+++ b/Examples/MAX78002/I2C/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX78002/I2C_MNGR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/I2C_MNGR/Makefile
+++ b/Examples/MAX78002/I2C_MNGR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/I2C_MNGR/README.md
+++ b/Examples/MAX78002/I2C_MNGR/README.md
@@ -10,7 +10,7 @@ You may change the configuration of each EEPROM's I2C transaction parameters (sl
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/I2C_MNGR/project.mk
+++ b/Examples/MAX78002/I2C_MNGR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX78002/I2C_SCAN/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/I2C_SCAN/Makefile
+++ b/Examples/MAX78002/I2C_SCAN/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/I2C_SCAN/README.md
+++ b/Examples/MAX78002/I2C_SCAN/README.md
@@ -6,7 +6,7 @@ This example uses the I2C Master to find the addresses of any I2C Slave devices 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/I2C_SCAN/project.mk
+++ b/Examples/MAX78002/I2C_SCAN/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX78002/I2C_Sensor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/I2C_Sensor/Makefile
+++ b/Examples/MAX78002/I2C_Sensor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/I2C_Sensor/README.md
+++ b/Examples/MAX78002/I2C_Sensor/README.md
@@ -8,7 +8,7 @@ After initialization, a new reading is printed to the terminal every second.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/I2C_Sensor/project.mk
+++ b/Examples/MAX78002/I2C_Sensor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/I2S/.vscode/README.md
+++ b/Examples/MAX78002/I2S/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/I2S/Makefile
+++ b/Examples/MAX78002/I2S/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/I2S/README.md
+++ b/Examples/MAX78002/I2S/README.md
@@ -6,7 +6,7 @@ This application demonstrates receiving data from the microphone on the MAX78002
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/I2S/project.mk
+++ b/Examples/MAX78002/I2S/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/I2S_DMA/.vscode/README.md
+++ b/Examples/MAX78002/I2S_DMA/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/I2S_DMA/Makefile
+++ b/Examples/MAX78002/I2S_DMA/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/I2S_DMA/README.md
+++ b/Examples/MAX78002/I2S_DMA/README.md
@@ -6,7 +6,7 @@ This application demonstrates receiving data from the microphone on the MAX78002
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/I2S_DMA/project.mk
+++ b/Examples/MAX78002/I2S_DMA/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/ICC/.vscode/README.md
+++ b/Examples/MAX78002/ICC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/ICC/Makefile
+++ b/Examples/MAX78002/ICC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/ICC/README.md
+++ b/Examples/MAX78002/ICC/README.md
@@ -11,7 +11,7 @@ This example demonstrates the time differences when running code with the instru
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/ICC/project.mk
+++ b/Examples/MAX78002/ICC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/ImgCapture/.vscode/README.md
+++ b/Examples/MAX78002/ImgCapture/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/ImgCapture/Makefile
+++ b/Examples/MAX78002/ImgCapture/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/ImgCapture/README.md
+++ b/Examples/MAX78002/ImgCapture/README.md
@@ -23,7 +23,7 @@ It supports the following output destinations:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Console Interface & Utilites
 

--- a/Examples/MAX78002/ImgCapture/project.mk
+++ b/Examples/MAX78002/ImgCapture/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/LP/.vscode/README.md
+++ b/Examples/MAX78002/LP/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/LP/Makefile
+++ b/Examples/MAX78002/LP/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/LP/README.md
+++ b/Examples/MAX78002/LP/README.md
@@ -17,7 +17,7 @@ Following modes can be tested:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/LP/project.mk
+++ b/Examples/MAX78002/LP/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/LPCMP/.vscode/README.md
+++ b/Examples/MAX78002/LPCMP/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/LPCMP/Makefile
+++ b/Examples/MAX78002/LPCMP/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/LPCMP/README.md
+++ b/Examples/MAX78002/LPCMP/README.md
@@ -8,7 +8,7 @@ The example is configured to use analog channels 0 (P2.0) and 1 (P2.1) as the ne
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/LPCMP/project.mk
+++ b/Examples/MAX78002/LPCMP/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/Library_Generate/.vscode/README.md
+++ b/Examples/MAX78002/Library_Generate/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
   * If it's not in the README, check the UG.
   * If it's not in the UG, open a ticket!
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
@@ -31,7 +31,7 @@ The following features are supported:
 
 The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.analog.com/en/education/education-library/videos/6313212752112.html).
 
-1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
     * [Windows](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0010820A)
     * [Linux (Ubuntu)](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018720A)
     * [MacOS](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018610A)

--- a/Examples/MAX78002/Library_Generate/Makefile
+++ b/Examples/MAX78002/Library_Generate/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/Library_Generate/README.md
+++ b/Examples/MAX78002/Library_Generate/README.md
@@ -9,7 +9,7 @@ Check the Library_Use demo to see how to link static libraries to an application
 
 ### Project Usage
 
-Universal instructions on building this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/Library_Generate/project.mk
+++ b/Examples/MAX78002/Library_Generate/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
  
 # **********************************************************
 

--- a/Examples/MAX78002/Library_Use/.vscode/README.md
+++ b/Examples/MAX78002/Library_Use/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/Library_Use/Makefile
+++ b/Examples/MAX78002/Library_Use/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/Library_Use/README.md
+++ b/Examples/MAX78002/Library_Use/README.md
@@ -9,7 +9,7 @@ to project.mk to see how to include ".a" static library files into your project.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/Library_Use/project.mk
+++ b/Examples/MAX78002/Library_Use/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78002/Pulse_Train/.vscode/README.md
+++ b/Examples/MAX78002/Pulse_Train/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/Pulse_Train/Makefile
+++ b/Examples/MAX78002/Pulse_Train/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/Pulse_Train/README.md
+++ b/Examples/MAX78002/Pulse_Train/README.md
@@ -10,7 +10,7 @@ The second, PT1, is set to generate a 10Hz square wave.  If you make the connect
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/Pulse_Train/project.mk
+++ b/Examples/MAX78002/Pulse_Train/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/QSPI/.vscode/README.md
+++ b/Examples/MAX78002/QSPI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/QSPI/Makefile
+++ b/Examples/MAX78002/QSPI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/QSPI/README.md
+++ b/Examples/MAX78002/QSPI/README.md
@@ -6,7 +6,7 @@ This example demonstrates QSPI communication in drivers written for the APS6404 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/QSPI/project.mk
+++ b/Examples/MAX78002/QSPI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78002/RTC/.vscode/README.md
+++ b/Examples/MAX78002/RTC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/RTC/Makefile
+++ b/Examples/MAX78002/RTC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/RTC/README.md
+++ b/Examples/MAX78002/RTC/README.md
@@ -11,7 +11,7 @@ The RTC is enabled and the sub-second alarm set to trigger every 250 ms.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/RTC/project.mk
+++ b/Examples/MAX78002/RTC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX78002/RTC_Backup/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/RTC_Backup/Makefile
+++ b/Examples/MAX78002/RTC_Backup/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/RTC_Backup/README.md
+++ b/Examples/MAX78002/RTC_Backup/README.md
@@ -8,7 +8,7 @@ The RTC time-of-day alarm is used to wake the device from backup mode every TIME
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/RTC_Backup/project.mk
+++ b/Examples/MAX78002/RTC_Backup/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/RV_ARM_Loader/.vscode/README.md
+++ b/Examples/MAX78002/RV_ARM_Loader/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/RV_ARM_Loader/Makefile
+++ b/Examples/MAX78002/RV_ARM_Loader/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/RV_ARM_Loader/README.md
+++ b/Examples/MAX78002/RV_ARM_Loader/README.md
@@ -8,7 +8,7 @@ RV_ARM_Loader runs on the ARM core to load the RISCV code space, setup the RISCV
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/RV_ARM_Loader/project.mk
+++ b/Examples/MAX78002/RV_ARM_Loader/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78002/SDHC_FAT/.vscode/README.md
+++ b/Examples/MAX78002/SDHC_FAT/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/SDHC_FAT/Makefile
+++ b/Examples/MAX78002/SDHC_FAT/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/SDHC_FAT/README.md
+++ b/Examples/MAX78002/SDHC_FAT/README.md
@@ -6,7 +6,7 @@ This example demonstrates the SDHC FAT Filesystem. The terminal prompts with a l
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/SDHC_FAT/project.mk
+++ b/Examples/MAX78002/SDHC_FAT/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/SDHC_Raw/.vscode/README.md
+++ b/Examples/MAX78002/SDHC_Raw/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/SDHC_Raw/Makefile
+++ b/Examples/MAX78002/SDHC_Raw/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/SDHC_Raw/README.md
+++ b/Examples/MAX78002/SDHC_Raw/README.md
@@ -6,7 +6,7 @@ This example demonstrates a series of blocking and non-blocking read/writes in 1
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/SDHC_Raw/project.mk
+++ b/Examples/MAX78002/SDHC_Raw/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/SPI/.vscode/README.md
+++ b/Examples/MAX78002/SPI/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/SPI/Makefile
+++ b/Examples/MAX78002/SPI/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/SPI/README.md
+++ b/Examples/MAX78002/SPI/README.md
@@ -10,11 +10,11 @@ This example uses the Hardware Target Select control scheme (application does no
 
 ## Software
 
-This project uses the SPI v2 library. More information on the SPI v2 library can be found in the **[MSDK User Guide Developer Notes](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#spi-v2-library)**.
+This project uses the SPI v2 library. More information on the SPI v2 library can be found in the **[MSDK User Guide Developer Notes](https://analogdevicesinc.github.io/msdk/USERGUIDE/#spi-v2-library)**.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/SPI/project.mk
+++ b/Examples/MAX78002/SPI/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/SPI_ControllerTarget/.vscode/README.md
+++ b/Examples/MAX78002/SPI_ControllerTarget/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/SPI_ControllerTarget/Makefile
+++ b/Examples/MAX78002/SPI_ControllerTarget/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/SPI_ControllerTarget/README.md
+++ b/Examples/MAX78002/SPI_ControllerTarget/README.md
@@ -15,11 +15,11 @@ Target Select (CS) Pin Connections
 
 ## Software
 
-This project uses the SPI v2 library. More information on the SPI v2 library can be found in the **[MSDK User Guide Developer Notes](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#spi-v2-library)**.
+This project uses the SPI v2 library. More information on the SPI v2 library can be found in the **[MSDK User Guide Developer Notes](https://analogdevicesinc.github.io/msdk/USERGUIDE/#spi-v2-library)**.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/SPI_ControllerTarget/project.mk
+++ b/Examples/MAX78002/SPI_ControllerTarget/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/SPI_MasterSlave/.vscode/README.md
+++ b/Examples/MAX78002/SPI_MasterSlave/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/SPI_MasterSlave/Makefile
+++ b/Examples/MAX78002/SPI_MasterSlave/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/SPI_MasterSlave/README.md
+++ b/Examples/MAX78002/SPI_MasterSlave/README.md
@@ -8,11 +8,11 @@ Once the master ends the transaction, the data received by the master and the sl
 
 ## Software
 
-This project uses the SPI v2 library. More information on the SPI v2 library can be found in the **[MSDK User Guide Developer Notes](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#spi-v2-library)**.
+This project uses the SPI v2 library. More information on the SPI v2 library can be found in the **[MSDK User Guide Developer Notes](https://analogdevicesinc.github.io/msdk/USERGUIDE/#spi-v2-library)**.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/SPI_MasterSlave/project.mk
+++ b/Examples/MAX78002/SPI_MasterSlave/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78002/TFT_Demo/.vscode/README.md
+++ b/Examples/MAX78002/TFT_Demo/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/TFT_Demo/Makefile
+++ b/Examples/MAX78002/TFT_Demo/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/TFT_Demo/README.md
+++ b/Examples/MAX78002/TFT_Demo/README.md
@@ -4,7 +4,7 @@
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/TFT_Demo/project.mk
+++ b/Examples/MAX78002/TFT_Demo/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/TFT_Demo/resources/tft/bmp/README.md
+++ b/Examples/MAX78002/TFT_Demo/resources/tft/bmp/README.md
@@ -38,7 +38,7 @@ Examples:
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/TMR/.vscode/README.md
+++ b/Examples/MAX78002/TMR/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/TMR/Makefile
+++ b/Examples/MAX78002/TMR/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/TMR/README.md
+++ b/Examples/MAX78002/TMR/README.md
@@ -12,7 +12,7 @@ Push PB1 to start the PWM and continuous timer and PB2 to start the oneshot time
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/TMR/project.mk
+++ b/Examples/MAX78002/TMR/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/TRNG/.vscode/README.md
+++ b/Examples/MAX78002/TRNG/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/TRNG/Makefile
+++ b/Examples/MAX78002/TRNG/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/TRNG/README.md
+++ b/Examples/MAX78002/TRNG/README.md
@@ -6,7 +6,7 @@ The true random number generator (TRNG) hardware is exercised in this example.  
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/TRNG/project.mk
+++ b/Examples/MAX78002/TRNG/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX78002/Temp_Monitor/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/Temp_Monitor/Makefile
+++ b/Examples/MAX78002/Temp_Monitor/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/Temp_Monitor/README.md
+++ b/Examples/MAX78002/Temp_Monitor/README.md
@@ -14,7 +14,7 @@ The temperature limits, flash storage page, and RTC time-of-day alarm period are
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/Temp_Monitor/project.mk
+++ b/Examples/MAX78002/Temp_Monitor/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 # **********************************************************
 

--- a/Examples/MAX78002/UART/.vscode/README.md
+++ b/Examples/MAX78002/UART/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/UART/Makefile
+++ b/Examples/MAX78002/UART/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/UART/README.md
+++ b/Examples/MAX78002/UART/README.md
@@ -6,7 +6,7 @@ This application uses two serial ports to send and receive data.  One serial por
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/UART/project.mk
+++ b/Examples/MAX78002/UART/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/USB/USB_CDCACM/.vscode/README.md
+++ b/Examples/MAX78002/USB/USB_CDCACM/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/USB/USB_CDCACM/Makefile
+++ b/Examples/MAX78002/USB/USB_CDCACM/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/USB/USB_CDCACM/README.md
+++ b/Examples/MAX78002/USB/USB_CDCACM/README.md
@@ -6,7 +6,7 @@ The example demonstartes the use of USB CDC-ACM driver class. After doing the re
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/USB/USB_CDCACM/project.mk
+++ b/Examples/MAX78002/USB/USB_CDCACM/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/USB/USB_CompositeDevice_MSC_CDC/.vscode/README.md
+++ b/Examples/MAX78002/USB/USB_CompositeDevice_MSC_CDC/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/USB/USB_CompositeDevice_MSC_CDC/Makefile
+++ b/Examples/MAX78002/USB/USB_CompositeDevice_MSC_CDC/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/USB/USB_CompositeDevice_MSC_CDC/README.md
+++ b/Examples/MAX78002/USB/USB_CompositeDevice_MSC_CDC/README.md
@@ -6,7 +6,7 @@ The example demonstartes the use of USB composite device with Mass Storage drive
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/USB/USB_CompositeDevice_MSC_CDC/project.mk
+++ b/Examples/MAX78002/USB/USB_CompositeDevice_MSC_CDC/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/USB/USB_CompositeDevice_MSC_HID/.vscode/README.md
+++ b/Examples/MAX78002/USB/USB_CompositeDevice_MSC_HID/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/USB/USB_CompositeDevice_MSC_HID/Makefile
+++ b/Examples/MAX78002/USB/USB_CompositeDevice_MSC_HID/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/USB/USB_CompositeDevice_MSC_HID/README.md
+++ b/Examples/MAX78002/USB/USB_CompositeDevice_MSC_HID/README.md
@@ -6,7 +6,7 @@ The example demonstartes the use of USB composite device with Mass Storage drive
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/USB/USB_CompositeDevice_MSC_HID/project.mk
+++ b/Examples/MAX78002/USB/USB_CompositeDevice_MSC_HID/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/USB/USB_HIDKeyboard/.vscode/README.md
+++ b/Examples/MAX78002/USB/USB_HIDKeyboard/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/USB/USB_HIDKeyboard/Makefile
+++ b/Examples/MAX78002/USB/USB_HIDKeyboard/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/USB/USB_HIDKeyboard/README.md
+++ b/Examples/MAX78002/USB/USB_HIDKeyboard/README.md
@@ -6,7 +6,7 @@ The example demonstartes the use of USB HID driver class. After doing the requir
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/USB/USB_HIDKeyboard/project.mk
+++ b/Examples/MAX78002/USB/USB_HIDKeyboard/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/USB/USB_MassStorage/.vscode/README.md
+++ b/Examples/MAX78002/USB/USB_MassStorage/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/USB/USB_MassStorage/Makefile
+++ b/Examples/MAX78002/USB/USB_MassStorage/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/USB/USB_MassStorage/README.md
+++ b/Examples/MAX78002/USB/USB_MassStorage/README.md
@@ -6,7 +6,7 @@ The example demonstartes the use of USB Mass Storage driver class. After doing t
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/USB/USB_MassStorage/project.mk
+++ b/Examples/MAX78002/USB/USB_MassStorage/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/USB/USB_MassStorage_ThroughPut/.vscode/README.md
+++ b/Examples/MAX78002/USB/USB_MassStorage_ThroughPut/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/USB/USB_MassStorage_ThroughPut/Makefile
+++ b/Examples/MAX78002/USB/USB_MassStorage_ThroughPut/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/USB/USB_MassStorage_ThroughPut/README.md
+++ b/Examples/MAX78002/USB/USB_MassStorage_ThroughPut/README.md
@@ -7,7 +7,7 @@ The device RAM is emulated as 1GB RAM for USB throughput testing purpose.
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/USB/USB_MassStorage_ThroughPut/project.mk
+++ b/Examples/MAX78002/USB/USB_MassStorage_ThroughPut/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/WUT/.vscode/README.md
+++ b/Examples/MAX78002/WUT/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/WUT/Makefile
+++ b/Examples/MAX78002/WUT/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/WUT/README.md
+++ b/Examples/MAX78002/WUT/README.md
@@ -6,7 +6,7 @@ This example shows how the wake up timer is used. Press SW4 to sleep or wake up 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/WUT/project.mk
+++ b/Examples/MAX78002/WUT/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/Watchdog/.vscode/README.md
+++ b/Examples/MAX78002/Watchdog/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/Watchdog/Makefile
+++ b/Examples/MAX78002/Watchdog/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/Watchdog/README.md
+++ b/Examples/MAX78002/Watchdog/README.md
@@ -11,7 +11,7 @@ When the application begins, it initializes and starts the watchdog timer.  The 
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 

--- a/Examples/MAX78002/Watchdog/project.mk
+++ b/Examples/MAX78002/Watchdog/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Examples/MAX78002/WearLeveling/.vscode/README.md
+++ b/Examples/MAX78002/WearLeveling/.vscode/README.md
@@ -4,7 +4,7 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 
 ## Quick Links
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 * [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
 
 ## Introduction
@@ -23,17 +23,17 @@ The following features are supported:
 * [Visual Studio Code](https://code.visualstudio.com/)
   * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
   * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
-* [Analog Devices MSDK](https://analog-devices-msdk.github.io/msdk/)
+* [Analog Devices MSDK](https://analogdevicesinc.github.io/msdk/)
 
 ## Installation
 
 Install the MSDK, then set `"MAXIM_PATH"` in your _user_ VS Code settings.
 
-See [Getting Started with Visual Studio Code](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
+See [Getting Started with Visual Studio Code](https://analogdevicesinc.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the MSDK User Guide for detailed instructions.
 
 ## Usage
 
-See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
+See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#visual-studio-code) for detailed usage info.
 
 ## Issue Tracker
 

--- a/Examples/MAX78002/WearLeveling/Makefile
+++ b/Examples/MAX78002/WearLeveling/Makefile
@@ -25,7 +25,7 @@
 # in "project.mk", on the command-line, or with system environment 
 # variables.
 
-# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# See https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 # for more detailed instructions on how to use this system.
 
 # The detailed instructions mentioned above are easier to read than 

--- a/Examples/MAX78002/WearLeveling/README.md
+++ b/Examples/MAX78002/WearLeveling/README.md
@@ -15,11 +15,11 @@ Enter "help" in the command line to see more details on the usage of each of the
 
 ### Project Usage
 
-Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.
 
 ### Project-Specific Build Notes
 
-* This project comes pre-configured for the MAX78002EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
+* This project comes pre-configured for the MAX78002EVKIT.  See [Board Support Packages](https://analogdevicesinc.github.io/msdk/USERGUIDE/#board-support-packages) in the UG for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX78002/WearLeveling/project.mk
+++ b/Examples/MAX78002/WearLeveling/project.mk
@@ -3,7 +3,7 @@
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
-# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #MXC_OPTIMIZE_CFLAGS = -Og
 # ^ For example, you can uncomment this line to 

--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
@@ -623,10 +623,10 @@ ifeq "$(SUPPRESS_HELP)" "0"
 ifneq "$(HELP_COMPLETE)" "1"
 $(info ****************************************************************************)
 $(info * Analog Devices MSDK)
-$(info * - User Guide: https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+$(info * - User Guide: https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 $(info * - Get Support: https://www.analog.com/support/technical-support.html)
 $(info * - Report Issues: https://github.com/Analog-Devices-MSDK/msdk/issues)
-$(info * - Contributing: https://analog-devices-msdk.github.io/msdk/CONTRIBUTING/)
+$(info * - Contributing: https://analogdevicesinc.github.io/msdk/CONTRIBUTING/)
 $(info ****************************************************************************)
 # export HELP_COMPLETE so that it's only printed once.
 HELP_COMPLETE = 1

--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
@@ -621,10 +621,10 @@ ifeq "$(SUPPRESS_HELP)" "0"
 ifneq "$(HELP_COMPLETE)" "1"
 $(info ****************************************************************************)
 $(info * Analog Devices MSDK)
-$(info * - User Guide: https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+$(info * - User Guide: https://analogdevicesinc.github.io/msdk/USERGUIDE/)
 $(info * - Get Support: https://www.analog.com/support/technical-support.html)
 $(info * - Report Issues: https://github.com/Analog-Devices-MSDK/msdk/issues)
-$(info * - Contributing: https://analog-devices-msdk.github.io/msdk/CONTRIBUTING/)
+$(info * - Contributing: https://analogdevicesinc.github.io/msdk/CONTRIBUTING/)
 $(info ****************************************************************************)
 # export HELP_COMPLETE so that it's only printed once.
 HELP_COMPLETE = 1

--- a/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
@@ -566,7 +566,7 @@ int MXC_SYS_LockDAP_Permanent(void)
     // Locking the DAP is not supported while in DEBUG.
     // To use this function, build for release ("make release")
     // or set DEBUG = 0
-    // (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-tables)
+    // (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-tables)
     return E_NOT_SUPPORTED;
 #else
     int err;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_ai87.c
@@ -566,7 +566,7 @@ int MXC_SYS_LockDAP_Permanent(void)
     // Locking the DAP is not supported while in DEBUG.
     // To use this function, build for release ("make release")
     // or set DEBUG = 0
-    // (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-tables)
+    // (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-tables)
     return E_NOT_SUPPORTED;
 #else
     int err;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_es17.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_es17.c
@@ -325,7 +325,7 @@ int MXC_SYS_LockDAP_Permanent(void)
     // Locking the DAP is not supported while in DEBUG.
     // To use this function, build for release ("make release")
     // or set DEBUG = 0
-    // (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-tables)
+    // (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-tables)
     return E_NOT_SUPPORTED;
 #else
     int err;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me10.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me10.c
@@ -600,7 +600,7 @@ int MXC_SYS_LockDAP_Permanent(void)
     // Locking the DAP is not supported while in DEBUG.
     // To use this function, build for release ("make release")
     // or set DEBUG = 0
-    // (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-tables)
+    // (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-tables)
     return E_NOT_SUPPORTED;
 #else
     int err;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me11.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me11.c
@@ -345,7 +345,7 @@ int MXC_SYS_LockDAP_Permanent(void)
     // Locking the DAP is not supported while in DEBUG.
     // To use this function, build for release ("make release")
     // or set DEBUG = 0
-    // (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-tables)
+    // (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-tables)
     return E_NOT_SUPPORTED;
 #else
     int err;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
@@ -470,7 +470,7 @@ int MXC_SYS_LockDAP_Permanent(void)
     // Locking the DAP is not supported while in DEBUG.
     // To use this function, build for release ("make release")
     // or set DEBUG = 0
-    // (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-tables)
+    // (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-tables)
     return E_NOT_SUPPORTED;
 #else
     int err;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me13.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me13.c
@@ -423,7 +423,7 @@ int MXC_SYS_LockDAP_Permanent(void)
     // Locking the DAP is not supported while in DEBUG.
     // To use this function, build for release ("make release")
     // or set DEBUG = 0
-    // (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-tables)
+    // (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-tables)
     return E_NOT_SUPPORTED;
 #else
     int err;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me14.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me14.c
@@ -409,7 +409,7 @@ int MXC_SYS_LockDAP_Permanent(void)
     // Locking the DAP is not supported while in DEBUG.
     // To use this function, build for release ("make release")
     // or set DEBUG = 0
-    // (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-tables)
+    // (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-tables)
     return E_NOT_SUPPORTED;
 #else
     int err;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
@@ -493,7 +493,7 @@ int MXC_SYS_LockDAP_Permanent(void)
     // Locking the DAP is not supported while in DEBUG.
     // To use this function, build for release ("make release")
     // or set DEBUG = 0
-    // (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-tables)
+    // (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-tables)
     return E_NOT_SUPPORTED;
 #else
     int err;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me16.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me16.c
@@ -404,7 +404,7 @@ int MXC_SYS_LockDAP_Permanent(void)
     // Locking the DAP is not supported while in DEBUG.
     // To use this function, build for release ("make release")
     // or set DEBUG = 0
-    // (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-tables)
+    // (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-tables)
     return E_NOT_SUPPORTED;
 #else
     int err;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
@@ -573,7 +573,7 @@ int MXC_SYS_LockDAP_Permanent(void)
     // Locking the DAP is not supported while in DEBUG.
     // To use this function, build for release ("make release")
     // or set DEBUG = 0
-    // (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-tables)
+    // (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-tables)
     return E_NOT_SUPPORTED;
 #else
     int err;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
@@ -504,7 +504,7 @@ int MXC_SYS_LockDAP_Permanent(void)
     // Locking the DAP is not supported while in DEBUG.
     // To use this function, build for release ("make release")
     // or set DEBUG = 0
-    // (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-tables)
+    // (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-tables)
     return E_NOT_SUPPORTED;
 #else
     int err;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
@@ -481,7 +481,7 @@ int MXC_SYS_LockDAP_Permanent(void)
     // Locking the DAP is not supported while in DEBUG.
     // To use this function, build for release ("make release")
     // or set DEBUG = 0
-    // (see https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-tables)
+    // (see https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-tables)
     return E_NOT_SUPPORTED;
 #else
     int err;

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 The Maxim Microcontrollers SDK (MSDK), now a part of [Analog Devices](https://www.analog.com/en/index.html), contains the necessary software and tools to develop firmware for the [MAX32xxx and MAX78xxx Microcontrollers](https://www.analog.com/en/parametricsearch/10984).  This includes register files, peripheral drivers, system startup files, documentation, various utilities, third-party libraries, IDE support files, and a toolchain.  Full documentation can be found in the User Guide:
 
-* [MSDK User Guide](https://analogdevicesinc.github.io/MAX32xxx-MSDK/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/msdk//USERGUIDE/)
 
 **This repository** contains the latest **_source code_** of the MSDK and is being used for _development_.  It does _not_ contain the MSDK _toolchain_, which is a separate collection of programs used for building, programming, and debugging.
 
 ## Installation
 
-The MSDK source code is bundled alongside its toolchain into releases that are available via an Automatic Installer.  See the ["Installation"](https://analogdevicesinc.github.io/MAX32xxx-MSDK/USERGUIDE/#installation) section in the MSDK User Guide for instructions.
+The MSDK source code is bundled alongside its toolchain into releases that are available via an Automatic Installer.  See the ["Installation"](https://analogdevicesinc.github.io/msdk//USERGUIDE/#installation) section in the MSDK User Guide for instructions.
 
 Users who would like to use the latest bleeding-edge _development_ resources can follow [Developing from the Repo](#developing-from-the-repo) below, but this should only be done **_after_** installing the release MSDK above.
 
@@ -52,7 +52,7 @@ This repo can be cloned using [Git](https://git-scm.com/) to obtain the latest d
 
 This repository contains the MSDK's *source code* only.  In order to develop on it directly the toolchain must be made available at the same file-paths as the full MSDK installation.  The easiest way to do this is to retrieve the toolchain with the automatic installer and then create symbolic links.  This section walks through the process.
 
-1. Install the MSDK via the [Automatic Installer](https://analogdevicesinc.github.io/MAX32xxx-MSDK/USERGUIDE/#installation).
+1. Install the MSDK via the [Automatic Installer](https://analogdevicesinc.github.io/msdk//USERGUIDE/#installation).
 
     At ***minimum***, install the following components:
     * GNU RISC-V Embedded GCC
@@ -150,7 +150,7 @@ This repository contains the MSDK's *source code* only.  In order to develop on 
 
 ### Environment Setup (Visual Studio Code)
 
-If you have not previously configured VS Code, see [Setup (VS Code)](https://analogdevicesinc.github.io/MAX32xxx-MSDK/USERGUIDE/#getting-started-with-visual-studio-code) in the User Guide.
+If you have not previously configured VS Code, see [Setup (VS Code)](https://analogdevicesinc.github.io/msdk//USERGUIDE/#getting-started-with-visual-studio-code) in the User Guide.
 
 To configure Visual Studio Code for the _development repository_ simply set `MAXIM_PATH` to the cloned location of the _development repo_ instead of the release MSDK in your user settings.json file.  After making the change, reload VS Code.  
 
@@ -225,13 +225,13 @@ This option can be used to configure _all_ Eclipse projects to use the developme
 
 ### Environment Setup (Command-Line)
 
-If you have not previously configured the command-line, see [Setup (Command-Line)](https://analogdevicesinc.github.io/MAX32xxx-MSDK/USERGUIDE/#getting-started-with-command-line-development) in the User Guide.
+If you have not previously configured the command-line, see [Setup (Command-Line)](https://analogdevicesinc.github.io/msdk//USERGUIDE/#getting-started-with-command-line-development) in the User Guide.
 
 To configure the command-line for use with the development repo:
 
 1. Set the `MAXIM_PATH` environment variable to the cloned location of the development repo instead of the release MSDK.
 
     - Windows:  Edit `setenv.bat` in the root directory of the MSDK.
-    - Linux/MacOS:  Edit your shell's profile/startup script.  Alternatively, edit `setenv.sh` in the root directory of the MSDK and `source` it from the shell's profile/startup script (see [here](https://analogdevicesinc.github.io/MAX32xxx-MSDK/USERGUIDE/#setup-command-line))
+    - Linux/MacOS:  Edit your shell's profile/startup script.  Alternatively, edit `setenv.sh` in the root directory of the MSDK and `source` it from the shell's profile/startup script (see [here](https://analogdevicesinc.github.io/msdk//USERGUIDE/#setup-command-line))
     
 2. Restart your shell

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 The Maxim Microcontrollers SDK (MSDK), now a part of [Analog Devices](https://www.analog.com/en/index.html), contains the necessary software and tools to develop firmware for the [MAX32xxx and MAX78xxx Microcontrollers](https://www.analog.com/en/parametricsearch/10984).  This includes register files, peripheral drivers, system startup files, documentation, various utilities, third-party libraries, IDE support files, and a toolchain.  Full documentation can be found in the User Guide:
 
-* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+* [MSDK User Guide](https://analogdevicesinc.github.io/MAX32xxx-MSDK/USERGUIDE/)
 
 **This repository** contains the latest **_source code_** of the MSDK and is being used for _development_.  It does _not_ contain the MSDK _toolchain_, which is a separate collection of programs used for building, programming, and debugging.
 
 ## Installation
 
-The MSDK source code is bundled alongside its toolchain into releases that are available via an Automatic Installer.  See the ["Installation"](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#installation) section in the MSDK User Guide for instructions.
+The MSDK source code is bundled alongside its toolchain into releases that are available via an Automatic Installer.  See the ["Installation"](https://analogdevicesinc.github.io/MAX32xxx-MSDK/USERGUIDE/#installation) section in the MSDK User Guide for instructions.
 
 Users who would like to use the latest bleeding-edge _development_ resources can follow [Developing from the Repo](#developing-from-the-repo) below, but this should only be done **_after_** installing the release MSDK above.
 
@@ -52,7 +52,7 @@ This repo can be cloned using [Git](https://git-scm.com/) to obtain the latest d
 
 This repository contains the MSDK's *source code* only.  In order to develop on it directly the toolchain must be made available at the same file-paths as the full MSDK installation.  The easiest way to do this is to retrieve the toolchain with the automatic installer and then create symbolic links.  This section walks through the process.
 
-1. Install the MSDK via the [Automatic Installer](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#installation).
+1. Install the MSDK via the [Automatic Installer](https://analogdevicesinc.github.io/MAX32xxx-MSDK/USERGUIDE/#installation).
 
     At ***minimum***, install the following components:
     * GNU RISC-V Embedded GCC
@@ -150,7 +150,7 @@ This repository contains the MSDK's *source code* only.  In order to develop on 
 
 ### Environment Setup (Visual Studio Code)
 
-If you have not previously configured VS Code, see [Setup (VS Code)](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-visual-studio-code) in the User Guide.
+If you have not previously configured VS Code, see [Setup (VS Code)](https://analogdevicesinc.github.io/MAX32xxx-MSDK/USERGUIDE/#getting-started-with-visual-studio-code) in the User Guide.
 
 To configure Visual Studio Code for the _development repository_ simply set `MAXIM_PATH` to the cloned location of the _development repo_ instead of the release MSDK in your user settings.json file.  After making the change, reload VS Code.  
 
@@ -225,13 +225,13 @@ This option can be used to configure _all_ Eclipse projects to use the developme
 
 ### Environment Setup (Command-Line)
 
-If you have not previously configured the command-line, see [Setup (Command-Line)](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#getting-started-with-command-line-development) in the User Guide.
+If you have not previously configured the command-line, see [Setup (Command-Line)](https://analogdevicesinc.github.io/MAX32xxx-MSDK/USERGUIDE/#getting-started-with-command-line-development) in the User Guide.
 
 To configure the command-line for use with the development repo:
 
 1. Set the `MAXIM_PATH` environment variable to the cloned location of the development repo instead of the release MSDK.
 
     - Windows:  Edit `setenv.bat` in the root directory of the MSDK.
-    - Linux/MacOS:  Edit your shell's profile/startup script.  Alternatively, edit `setenv.sh` in the root directory of the MSDK and `source` it from the shell's profile/startup script (see [here](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#setup-command-line))
+    - Linux/MacOS:  Edit your shell's profile/startup script.  Alternatively, edit `setenv.sh` in the root directory of the MSDK and `source` it from the shell's profile/startup script (see [here](https://analogdevicesinc.github.io/MAX32xxx-MSDK/USERGUIDE/#setup-command-line))
     
 2. Restart your shell

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -1455,7 +1455,7 @@ For setup/quick-start, see ["Getting Started with Command-Line Development"](#ge
         # "Makefile" that is located next to this one.
         
         # For instructions on how to use this system, see
-        # https://analog-devices-msdk.github.io/msdk/USERGUIDE/
+        # https://analogdevicesinc.github.io/msdk/USERGUIDE/
         
         # **********************************************************
         
@@ -1783,7 +1783,7 @@ For example, to enable hardware floating-point acceleration for a project, the *
     # "Makefile" that is located next to this one.
     
     # For instructions on how to use this system, see
-    # https://analog-devices-msdk.github.io/msdk/USERGUIDE/
+    # https://analogdevicesinc.github.io/msdk/USERGUIDE/
     
     # **********************************************************
     


### PR DESCRIPTION
### Description

After our migration to the analogdevicesinc organization, the old URL (https://analog-devices-msdk.github.io/msdk/) will no longer work.

The new URL is now https://analogdevicesinc.github.io/msdk/

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.