### PR TITLE
fix(ThirdParty): Remove IAR build errors for the MAX32675

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Source/IAR/startup_max32675.s
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Source/IAR/startup_max32675.s
@@ -1,8 +1,8 @@
-;------------------------------------------------------------------------------
+;-------------------------------------------------------------------------------
 ;
 ; Copyright (C) 2022-2023 Maxim Integrated Products, Inc. All Rights Reserved.
 ; (now owned by Analog Devices, Inc.),
-; Copyright (C) 2023 Analog Devices, Inc. All Rights Reserved. This software
+; Copyright (C) 2023-2024 Analog Devices, Inc. All Rights Reserved. This software
 ; is proprietary to Analog Devices, Inc. and its licensors.
 ;
 ; Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,14 +17,171 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 ;
-;------------------------------------------------------------------------------
+; Description        : MAX32675 device vector table for IAR EWARM toolchain.
+;                      - Sets the initial SP
+;                      - Sets the initial PC == _iar_program_start,
+;                      - Set the vector table entries with the exceptions ISR
+;                        address, all set as PUBWEAK. User may override any ISR
+;                        defined as PUBWEAK.
+;                      - Branches to main in the C library (which eventually
+;                        calls SystemInit() and main()).
+;                      After Reset the Cortex-M4 processor is in Thread mode,
+;                      priority is Privileged, and the Stack is set to Main.
+;
+;-------------------------------------------------------------------------------
 
+    MODULE  ?cstartup
+
+    ;; Forward declaration of sections.
+    SECTION CSTACK:DATA:NOROOT(3)
+
+    SECTION .intvec:CODE:NOROOT(2)
+
+    EXTERN  __iar_program_start
+    EXTERN  SysTick_Handler
+    EXTERN  __ICFEDIT_intvec_start__
+    PUBLIC  __vector_table
+    PUBLIC  __vector_table_modify
+    PUBLIC  __Vectors
+    PUBLIC  __Vectors_End
+    PUBLIC  __Vectors_Size
+    PUBLIC  __isr_vector
+
+    DATA
+__vector_table
+    DCD     sfe(CSTACK)
+    DCD    Reset_Handler         ; Reset Handler 
+    DCD    NMI_Handler           ; NMI Handler 
+    DCD    HardFault_Handler     ; Hard Fault Handler 
+    DCD    MemManage_Handler     ; MPU Fault Handler 
+    DCD    BusFault_Handler      ; Bus Fault Handler 
+    DCD    UsageFault_Handler    ; Usage Fault Handler 
+    DCD    0                     ; Reserved 
+    DCD    0                     ; Reserved 
+    DCD    0                     ; Reserved 
+    DCD    0                     ; Reserved 
+    DCD    SVC_Handler           ; SVCall Handler 
+    DCD    DebugMon_Handler      ; Debug Montor Handler
+    DCD    0                     ; Reserved 
+    DCD    PendSV_Handler        ; PendSV Handler 
+    DCD    SysTick_Handler       ; SysTick Handler 
+__vector_table_modify
+    ; Device-specific Interrupts 
+    DCD PF_IRQHandler                /* 0x10  0x0040  16: Power Fail */
+    DCD WDT0_IRQHandler              /* 0x11  0x0044  17: Watchdog 0 */
+    DCD RSV02_IRQHandler             /* 0x12  0x0048  18: Reserved */
+    DCD RTC_IRQHandler               /* 0x13  0x004C  19: RTC */
+    DCD TRNG_IRQHandler              /* 0x14  0x0050  20: True Random Number Generator */
+    DCD TMR0_IRQHandler              /* 0x15  0x0054  21: Timer 0 */
+    DCD TMR1_IRQHandler              /* 0x16  0x0058  22: Timer 1 */
+    DCD TMR2_IRQHandler              /* 0x17  0x005C  23: Timer 2 */
+    DCD TMR3_IRQHandler              /* 0x18  0x0060  24: Timer 3 */
+    DCD TMR4_IRQHandler              /* 0x19  0x0064  25: Timer 4 */
+    DCD TMR5_IRQHandler              /* 0x1A  0x0068  26: Timer 5 */
+    DCD RSV11_IRQHandler             /* 0x1B  0x006C  27: Reserved */
+    DCD RSV12_IRQHandler             /* 0x1C  0x0070  28: Reserved */
+    DCD I2C0_IRQHandler              /* 0x1D  0x0074  29: I2C0 */
+    DCD UART0_IRQHandler             /* 0x1E  0x0078  30: UART 0 */
+    DCD UART1_IRQHandler             /* 0x1F  0x007C  31: UART 1 */
+    DCD SPI0_IRQHandler              /* 0x20  0x0080  32: SPI0 */
+    DCD SPI1_IRQHandler              /* 0x21  0x0084  33: SPI1 */
+    DCD SPI2_IRQHandler              /* 0x22  0x0088  34: SPI2 */
+    DCD RSV19_IRQHandler             /* 0x23  0x008C  35: Reserved */
+    DCD RSV20_IRQHandler             /* 0x24  0x0090  36: Reserved */
+    DCD RSV21_IRQHandler             /* 0x25  0x0094  37: Reserved */
+    DCD RSV22_IRQHandler             /* 0x26  0x0098  38: Reserved */
+    DCD FLC0_IRQHandler              /* 0x27  0x009C  39: Flash Controller 0 */
+    DCD GPIO0_IRQHandler             /* 0x28  0x00A0  40: GPIO0 */
+    DCD GPIO1_IRQHandler             /* 0x29  0x00A4  41: GPIO1 */
+    DCD RSV26_IRQHandler             /* 0x2A  0x00A8  42: Reserved */
+    DCD RSV27_IRQHandler             /* 0x2B  0x00AC  43: Reserved */
+    DCD DMA0_IRQHandler              /* 0x2C  0x00B0  44: DMA0 */
+    DCD DMA1_IRQHandler              /* 0x2D  0x00B4  45: DMA1 */
+    DCD DMA2_IRQHandler              /* 0x2E  0x00B8  46: DMA2 */
+    DCD DMA3_IRQHandler              /* 0x2F  0x00BC  47: DMA3 */
+    DCD RSV32_IRQHandler             /* 0x30  0x00C0  48: Reserved */
+    DCD RSV33_IRQHandler             /* 0x31  0x00C4  49: Reserved */
+    DCD UART2_IRQHandler             /* 0x32  0x00C8  50: UART 2 */
+    DCD RSV35_IRQHandler             /* 0x33  0x00CC  51: Reserved */
+    DCD I2C1_IRQHandler              /* 0x34  0x00D0  52: I2C1 */
+    DCD RSV37_IRQHandler             /* 0x35  0x00D4  53: Reserved */
+    DCD RSV38_IRQHandler             /* 0x36  0x00D8  54: Reserved */
+    DCD RSV39_IRQHandler             /* 0x37  0x00DC  55: Reserved */
+    DCD RSV40_IRQHandler             /* 0x38  0x00E0  56: Reserved */
+    DCD RSV41_IRQHandler             /* 0x39  0x00E4  57: Reserved */
+    DCD RSV42_IRQHandler             /* 0x3A  0x00E8  58: Reserved */
+    DCD RSV43_IRQHandler             /* 0x3B  0x00EC  59: Reserved */
+    DCD RSV44_IRQHandler             /* 0x3C  0x00F0  60: Reserved */
+    DCD RSV45_IRQHandler             /* 0x3D  0x00F4  61: Reserved */
+    DCD RSV46_IRQHandler             /* 0x3E  0x00F8  62: Reserved */
+    DCD RSV47_IRQHandler             /* 0x3F  0x00FC  63: Reserved */
+    DCD RSV48_IRQHandler             /* 0x40  0x0100  64: Reserved */
+    DCD RSV49_IRQHandler             /* 0x41  0x0104  65: Reserved */
+    DCD RSV50_IRQHandler             /* 0x42  0x0108  66: Reserved */
+    DCD RSV51_IRQHandler             /* 0x43  0x010C  67: Reserved */
+    DCD RSV52_IRQHandler             /* 0x44  0x0110  68: Reserved */
+    DCD RSV53_IRQHandler             /* 0x45  0x0114  69: Reserved */
+    DCD RSV54_IRQHandler             /* 0x46  0x0118  70: Reserved */
+    DCD RSV55_IRQHandler             /* 0x47  0x011C  71: Reserved */
+    DCD RSV56_IRQHandler             /* 0x48  0x0120  72: Reserved */
+    DCD WDT1_IRQHandler              /* 0x49  0x0124  73: Watchdog 1 */
+    DCD RSV58_IRQHandler             /* 0x4A  0x0128  74: Reserved */
+    DCD RSV59_IRQHandler             /* 0x4B  0x012C  75: Reserved */
+    DCD RSV60_IRQHandler             /* 0x4C  0x0130  76: Reserved */
+    DCD RSV61_IRQHandler             /* 0x4D  0x0134  77: Reserved */
+    DCD I2C2_IRQHandler              /* 0x4E  0x0138  78: I2C 2 */
+    DCD RSV63_IRQHandler             /* 0x4F  0x013C  79: Reserved */
+    DCD RSV64_IRQHandler             /* 0x50  0x0140  80: Reserved */
+    DCD RSV65_IRQHandler             /* 0x51  0x0144  81: Reserved */
+    DCD RSV66_IRQHandler             /* 0x52  0x0148  82: Reserved*/
+    DCD RSV67_IRQHandler             /* 0x53  0x014C  83: Reserved*/
+    DCD DMA4_IRQHandler              /* 0x54  0x0150  84: DMA4 */
+    DCD DMA5_IRQHandler              /* 0x55  0x0154  85: DMA5 */
+    DCD DMA6_IRQHandler              /* 0x56  0x0158  86: DMA6 */
+    DCD DMA7_IRQHandler              /* 0x57  0x015C  87: DMA7 */
+    DCD DMA8_IRQHandler              /* 0x58  0x0160  88: DMA8 */
+    DCD DMA9_IRQHandler              /* 0x59  0x0164  89: DMA9 */
+    DCD DMA10_IRQHandler             /* 0x5A  0x0168  90: DMA10 */
+    DCD DMA11_IRQHandler             /* 0x5B  0x016C  91: DMA11 */
+    DCD DMA12_IRQHandler             /* 0x5C  0x0170  92: DMA12 */
+    DCD DMA13_IRQHandler             /* 0x5D  0x0174  93: DMA13 */
+    DCD DMA14_IRQHandler             /* 0x5E  0x0178  94: DMA14 */
+    DCD DMA15_IRQHandler             /* 0x5F  0x017C  95: DMA15 */
+    DCD RSV80_IRQHandler             /* 0x60  0x0180  96: Reserved */
+    DCD RSV81_IRQHandler             /* 0x61  0x0184  97: Reserved */
+    DCD ECC_IRQHandler               /* 0x62  0x0188  98: ECC */
+    DCD RSV83_IRQHandler             /* 0x63  0x018C  99: Reserved */
+    DCD RSV84_IRQHandler             /* 0x64  0x0190  100: Reserved */
+    DCD RSV85_IRQHandler             /* 0x65  0x0194  101: Reserved */
+    DCD RSV86_IRQHandler             /* 0x66  0x0198  102: Reserved */
+    DCD RSV87_IRQHandler             /* 0x67  0x019C  103: Reserved */
+    DCD UART3_IRQHandler             /* 0x68  0x01A0  104: UART 3 */
+    DCD RSV89_IRQHandler             /* 0x69  0x01A4  105: Reserved */
+    DCD RSV90_IRQHandler             /* 0x6A  0x01A8  106: Reserved */
+    DCD RSV91_IRQHandler             /* 0x6B  0x01AC  107: Reserved */
+    DCD RSV92_IRQHandler             /* 0x6C  0x01B0  108: Reserved */
+    DCD RSV93_IRQHandler             /* 0x6D  0x01B4  109: Reserved */
+    DCD RSV94_IRQHandler             /* 0x6E  0x01B8  110: Reserved */
+    DCD RSV95_IRQHandler             /* 0x6F  0x01BC  111: Reserved */
+    DCD RSV96_IRQHandler             /* 0x70  0x01C0  112: Reserved */
+    DCD AES_IRQHandler               /* 0x71  0x01C4  113: AES */
+    DCD CRC_IRQHandler               /* 0x72  0x01C8  114: CRC */
+    DCD I2S_IRQHandler               /* 0x73  0x01CC  115: I2S */    
+
+
+__Vectors_End
+__isr_vector    EQU   __vector_table
+__Vectors       EQU   __vector_table
+__Vectors_Size  EQU   __Vectors_End - __Vectors
+
+
+
+    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; Default interrupt handlers.
 ;;
     THUMB
     PUBWEAK Reset_Handler
-;;    SECTION .text:CODE:REORDER:NOROOT(2)
 Reset_Handler
 
 
@@ -34,7 +191,7 @@ Reset_Handler
 ; which occurs during the __iar_program_start definition.
 ; see project file cmain.s for the IAR specific startup flow and call to SystemInit
         ; Set the initial stack pointer
-        LDR        R0, =  __vector_table //0x10000200
+        LDR        R0, =__vector_table 
         LDR        R1, [R0]
         MOV        SP, R1
         ; jump into IAR program flow
@@ -115,9 +272,9 @@ handler_name
     def_irq_handler    RSV55_IRQHandler              ; 0x47  0x011C  71: Reserved 
     def_irq_handler    RSV56_IRQHandler              ; 0x48  0x0120  72: Reserved 
     def_irq_handler    WDT1_IRQHandler               ; 0x49  0x0124  73: Watchdog 1 
-    def_irq_handler    RSV57_IRQHandler              ; 0x4A  0x0128  74: Reserved 
-    def_irq_handler    RSV58_IRQHandler              ; 0x4B  0x012C  75: Reserved
-    def_irq_handler    RSV59_IRQHandler              ; 0x4C  0x0130  76: Reserved 
+    def_irq_handler    RSV58_IRQHandler              ; 0x4A  0x0128  74: Reserved 
+    def_irq_handler    RSV59_IRQHandler              ; 0x4B  0x012C  75: Reserved
+    def_irq_handler    RSV60_IRQHandler              ; 0x4C  0x0130  76: Reserved 
     def_irq_handler    RSV61_IRQHandler              ; 0x4D  0x0134  77: Reserved 
     def_irq_handler    I2C2_IRQHandler               ; 0x4E  0x0138  78: Reserved 
     def_irq_handler    RSV63_IRQHandler              ; 0x4F  0x013C  79: Reserved

--- a/Libraries/PeriphDrivers/Include/MAX32675/mxc_device.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/mxc_device.h
@@ -31,7 +31,7 @@
 #include "mxc_errors.h"
 #include "mxc_pins.h"
 
-#if defined(__ICCARM__) || (__CC_ARM)
+#if defined(__CC_ARM)
 #include "RTE_Components.h"
 #endif
 


### PR DESCRIPTION
### Description

- Added missing vector table information in cstartup file.
- Removed reference to the RTEComponents.h (this file is used when using CMSIS pack files).