### PR TITLE
feat(CMSIS): Enable SPIXF cache controller (SFCC) in SystemInit for MAX32572

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_max32572.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_max32572.c
@@ -122,6 +122,9 @@ __weak void SystemInit(void)
     /* Make sure interrupts are enabled. */
     __enable_irq();
 
+    /* Enable SPIXF cache */
+    MXC_SFCC_Enable();
+
     /* Enable FPU on Cortex-M4, which occupies coprocessor slots 10 & 11 */
     /* Grant full access, per "Table B3-24 CPACR bit assignments". */
     /* DDI0403D "ARMv7-M Architecture Reference Manual" */


### PR DESCRIPTION
### Description

The performance of the ME55 is greatly diminished with the SPIXF cache controller disabled when using the external flash. This change will enable the SFCC by default in SystemInit.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.