### PR TITLE
feat(Build): Add Ability to Selectively Introspect Build Variables

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
@@ -620,6 +620,27 @@ $(BUILD_DIR)/project_defines.h: $(BUILD_DIR)/_empty_tmp_file.c $(PROJECTMK) | $(
 	@echo "// This is a generated file that's used to detect definitions that have been set by the compiler and build system." > $@
 	@$(CC) -E -P -dD $(BUILD_DIR)/_empty_tmp_file.c $(filter-out -MD,$(CFLAGS)) >> $@
 
+################################################################################
+# Add a rule for querying the value of any Makefile variable.  This is useful for
+# IDEs when they need to figure out include paths, value of the target, etc. for a
+# project
+# Set QUERY_VAR to the variable to inspect.
+# The output must be parsed, since other Makefiles may print additional info strings.
+# The relevant content will be on its own line, and separated by an '=' character.
+# Ex: make query QUERY_VAR=TARGET
+# will return
+# TARGET=MAXxxxxx
+ifeq "$(MAKECMDGOALS)" "query"
+SUPPRESS_HELP := 1
+endif
+.PHONY: query
+query:
+ifneq "$(QUERY_VAR)" ""
+	@echo $(QUERY_VAR)=$($(QUERY_VAR))
+else
+	$(MAKE) debug
+endif
+
 #################################################################################
 SUPPRESS_HELP ?= 0
 ifeq "$(SUPPRESS_HELP)" "0"
@@ -636,3 +657,4 @@ HELP_COMPLETE = 1
 export HELP_COMPLETE
 endif
 endif
+

--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
@@ -618,6 +618,27 @@ $(BUILD_DIR)/project_defines.h: $(BUILD_DIR)/_empty_tmp_file.c $(PROJECTMK) | $(
 	@echo "// This is a generated file that's used to detect definitions that have been set by the compiler and build system." > $@
 	@$(CC) -E -P -dD $(BUILD_DIR)/_empty_tmp_file.c $(filter-out -MD,$(CFLAGS)) >> $@
 
+################################################################################
+# Add a rule for querying the value of any Makefile variable.  This is useful for
+# IDEs when they need to figure out include paths, value of the target, etc. for a
+# project
+# Set QUERY_VAR to the variable to inspect.
+# The output must be parsed, since other Makefiles may print additional info strings.
+# The relevant content will be on its own line, and separated by an '=' character.
+# Ex: make query QUERY_VAR=TARGET
+# will return
+# TARGET=MAXxxxxx
+ifeq "$(MAKECMDGOALS)" "query"
+SUPPRESS_HELP := 1
+endif
+.PHONY: query
+query:
+ifneq "$(QUERY_VAR)" ""
+	@echo $(QUERY_VAR)=$($(QUERY_VAR))
+else
+	$(MAKE) debug
+endif
+
 #################################################################################
 SUPPRESS_HELP ?= 0
 ifeq "$(SUPPRESS_HELP)" "0"


### PR DESCRIPTION
## Pull Request Template

### Description

Add the `make query` target.  This allows IDEs and scripts to query the value of a specific build variable for a project by also setting `QUERY_VARIABLE`.

Useful for https://github.com/Analog-Devices-MSDK/MSDKGen/commit/17017774f9e7945a07e09f93f5ef0485287bc2e0

Ex:

```shell
~/repos/msdk/Examples/MAX78000/Hello_World (feat/query*) » make query QUERY_VAR=TARGET
Loaded project.mk
TARGET=MAX78000
```

The output must still be parsed, since other Makefiles might print extra `$(info)` statements.  This could be improved in a future PR that implements some sort of log-level mechanism for suppressing all `$(info)` output.