### PR TITLE
fix(Build): Fix Broken macOS PATH in VS Code, Fix Broken README Links

### DIFF
--- a/Examples/MAX32520/AES/.vscode/README.md
+++ b/Examples/MAX32520/AES/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/AES/.vscode/settings.json
+++ b/Examples/MAX32520/AES/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32520/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/CRC/.vscode/README.md
+++ b/Examples/MAX32520/CRC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/CRC/.vscode/settings.json
+++ b/Examples/MAX32520/CRC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/Coremark/.vscode/README.md
+++ b/Examples/MAX32520/Coremark/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/Coremark/.vscode/settings.json
+++ b/Examples/MAX32520/Coremark/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/DMA/.vscode/README.md
+++ b/Examples/MAX32520/DMA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/DMA/.vscode/settings.json
+++ b/Examples/MAX32520/DMA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/ECDSA/.vscode/README.md
+++ b/Examples/MAX32520/ECDSA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/ECDSA/.vscode/settings.json
+++ b/Examples/MAX32520/ECDSA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32520/EEPROM_Emulator/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32520/EEPROM_Emulator/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/Flash/.vscode/README.md
+++ b/Examples/MAX32520/Flash/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/Flash/.vscode/settings.json
+++ b/Examples/MAX32520/Flash/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32520/Flash_CLI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32520/Flash_CLI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32520/FreeRTOSDemo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32520/FreeRTOSDemo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/GPIO/.vscode/README.md
+++ b/Examples/MAX32520/GPIO/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/GPIO/.vscode/settings.json
+++ b/Examples/MAX32520/GPIO/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/Hello_World/.vscode/README.md
+++ b/Examples/MAX32520/Hello_World/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32520/Hello_World/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32520/Hello_World_Cpp/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32520/Hello_World_Cpp/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32520/I2C_MNGR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32520/I2C_MNGR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32520/I2C_SCAN/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32520/I2C_SCAN/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32520/I2C_Sensor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32520/I2C_Sensor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/ICC/.vscode/README.md
+++ b/Examples/MAX32520/ICC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/ICC/.vscode/settings.json
+++ b/Examples/MAX32520/ICC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/LP/.vscode/README.md
+++ b/Examples/MAX32520/LP/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/LP/.vscode/settings.json
+++ b/Examples/MAX32520/LP/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/Library_Use/.vscode/README.md
+++ b/Examples/MAX32520/Library_Use/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32520/Library_Use/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/LockDebug/.vscode/README.md
+++ b/Examples/MAX32520/LockDebug/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/LockDebug/.vscode/settings.json
+++ b/Examples/MAX32520/LockDebug/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32520/OTP_Dump/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32520/OTP_Dump/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/SCPA_OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32520/SCPA_OTP_Dump/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/SCPA_OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32520/SCPA_OTP_Dump/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/SFE/.vscode/README.md
+++ b/Examples/MAX32520/SFE/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/SFE/.vscode/settings.json
+++ b/Examples/MAX32520/SFE/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/SFE_Host/.vscode/README.md
+++ b/Examples/MAX32520/SFE_Host/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/SFE_Host/.vscode/settings.json
+++ b/Examples/MAX32520/SFE_Host/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/SMON/.vscode/README.md
+++ b/Examples/MAX32520/SMON/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/SMON/.vscode/settings.json
+++ b/Examples/MAX32520/SMON/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/SPI/.vscode/README.md
+++ b/Examples/MAX32520/SPI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/SPI/.vscode/settings.json
+++ b/Examples/MAX32520/SPI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/SPI_MasterSlave/.vscode/README.md
+++ b/Examples/MAX32520/SPI_MasterSlave/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/SPI_MasterSlave/.vscode/settings.json
+++ b/Examples/MAX32520/SPI_MasterSlave/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/TMR/.vscode/README.md
+++ b/Examples/MAX32520/TMR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/TMR/.vscode/settings.json
+++ b/Examples/MAX32520/TMR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/TRNG/.vscode/README.md
+++ b/Examples/MAX32520/TRNG/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/TRNG/.vscode/settings.json
+++ b/Examples/MAX32520/TRNG/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32520/Watchdog/.vscode/README.md
+++ b/Examples/MAX32520/Watchdog/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32520/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32520/Watchdog/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/ADC/.vscode/README.md
+++ b/Examples/MAX32650/ADC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/ADC/.vscode/settings.json
+++ b/Examples/MAX32650/ADC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/ADC_MAX11261/.vscode/README.md
+++ b/Examples/MAX32650/ADC_MAX11261/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/ADC_MAX11261/.vscode/settings.json
+++ b/Examples/MAX32650/ADC_MAX11261/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/AES/.vscode/README.md
+++ b/Examples/MAX32650/AES/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/AES/.vscode/settings.json
+++ b/Examples/MAX32650/AES/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32650/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/CLCD/.vscode/README.md
+++ b/Examples/MAX32650/CLCD/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/CLCD/.vscode/settings.json
+++ b/Examples/MAX32650/CLCD/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/CRC/.vscode/README.md
+++ b/Examples/MAX32650/CRC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/CRC/.vscode/settings.json
+++ b/Examples/MAX32650/CRC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/Coremark/.vscode/README.md
+++ b/Examples/MAX32650/Coremark/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/Coremark/.vscode/settings.json
+++ b/Examples/MAX32650/Coremark/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/DES/.vscode/README.md
+++ b/Examples/MAX32650/DES/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/DES/.vscode/settings.json
+++ b/Examples/MAX32650/DES/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/DMA/.vscode/README.md
+++ b/Examples/MAX32650/DMA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/DMA/.vscode/settings.json
+++ b/Examples/MAX32650/DMA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32650/EEPROM_Emulator/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32650/EEPROM_Emulator/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/EMCC/.vscode/README.md
+++ b/Examples/MAX32650/EMCC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/EMCC/.vscode/settings.json
+++ b/Examples/MAX32650/EMCC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/Flash/.vscode/README.md
+++ b/Examples/MAX32650/Flash/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/Flash/.vscode/settings.json
+++ b/Examples/MAX32650/Flash/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32650/Flash_CLI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32650/Flash_CLI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32650/FreeRTOSDemo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32650/FreeRTOSDemo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/GPIO/.vscode/README.md
+++ b/Examples/MAX32650/GPIO/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/GPIO/.vscode/settings.json
+++ b/Examples/MAX32650/GPIO/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/HBMC/.vscode/README.md
+++ b/Examples/MAX32650/HBMC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/HBMC/.vscode/settings.json
+++ b/Examples/MAX32650/HBMC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/Hello_World/.vscode/README.md
+++ b/Examples/MAX32650/Hello_World/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32650/Hello_World/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32650/Hello_World_Cpp/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32650/Hello_World_Cpp/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/I2C/.vscode/README.md
+++ b/Examples/MAX32650/I2C/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/I2C/.vscode/settings.json
+++ b/Examples/MAX32650/I2C/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32650/I2C_MNGR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32650/I2C_MNGR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32650/I2C_SCAN/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32650/I2C_SCAN/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32650/I2C_Sensor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32650/I2C_Sensor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/I2S/.vscode/README.md
+++ b/Examples/MAX32650/I2S/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/I2S/.vscode/settings.json
+++ b/Examples/MAX32650/I2S/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/ICC/.vscode/README.md
+++ b/Examples/MAX32650/ICC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/ICC/.vscode/settings.json
+++ b/Examples/MAX32650/ICC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/LP/.vscode/README.md
+++ b/Examples/MAX32650/LP/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/LP/.vscode/settings.json
+++ b/Examples/MAX32650/LP/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/Library_Use/.vscode/README.md
+++ b/Examples/MAX32650/Library_Use/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32650/Library_Use/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/MAA/.vscode/README.md
+++ b/Examples/MAX32650/MAA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/MAA/.vscode/settings.json
+++ b/Examples/MAX32650/MAA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32650/OTP_Dump/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32650/OTP_Dump/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/OWM/.vscode/README.md
+++ b/Examples/MAX32650/OWM/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/OWM/.vscode/settings.json
+++ b/Examples/MAX32650/OWM/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/Pulse_Train/.vscode/README.md
+++ b/Examples/MAX32650/Pulse_Train/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/Pulse_Train/.vscode/settings.json
+++ b/Examples/MAX32650/Pulse_Train/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/RTC/.vscode/README.md
+++ b/Examples/MAX32650/RTC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/RTC/.vscode/settings.json
+++ b/Examples/MAX32650/RTC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX32650/RTC_Backup/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX32650/RTC_Backup/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/SCPA_OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32650/SCPA_OTP_Dump/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/SCPA_OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32650/SCPA_OTP_Dump/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/SDHC_FAT/.vscode/README.md
+++ b/Examples/MAX32650/SDHC_FAT/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/SDHC_FAT/.vscode/settings.json
+++ b/Examples/MAX32650/SDHC_FAT/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/SDHC_Raw/.vscode/README.md
+++ b/Examples/MAX32650/SDHC_Raw/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/SDHC_Raw/.vscode/settings.json
+++ b/Examples/MAX32650/SDHC_Raw/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/SPI/.vscode/README.md
+++ b/Examples/MAX32650/SPI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/SPI/.vscode/settings.json
+++ b/Examples/MAX32650/SPI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/SPIMSS/.vscode/README.md
+++ b/Examples/MAX32650/SPIMSS/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/SPIMSS/.vscode/settings.json
+++ b/Examples/MAX32650/SPIMSS/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/SPIXF/.vscode/README.md
+++ b/Examples/MAX32650/SPIXF/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/SPIXF/.vscode/settings.json
+++ b/Examples/MAX32650/SPIXF/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/SPIXF_ICC/.vscode/README.md
+++ b/Examples/MAX32650/SPIXF_ICC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/SPIXF_ICC/.vscode/settings.json
+++ b/Examples/MAX32650/SPIXF_ICC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/SPIXR/.vscode/README.md
+++ b/Examples/MAX32650/SPIXR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/SPIXR/.vscode/settings.json
+++ b/Examples/MAX32650/SPIXR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/SPI_MasterSlave/.vscode/README.md
+++ b/Examples/MAX32650/SPI_MasterSlave/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/SPI_MasterSlave/.vscode/settings.json
+++ b/Examples/MAX32650/SPI_MasterSlave/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/Semaphore/.vscode/README.md
+++ b/Examples/MAX32650/Semaphore/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/Semaphore/.vscode/settings.json
+++ b/Examples/MAX32650/Semaphore/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/SysTick/.vscode/README.md
+++ b/Examples/MAX32650/SysTick/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/SysTick/.vscode/settings.json
+++ b/Examples/MAX32650/SysTick/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/TMR/.vscode/README.md
+++ b/Examples/MAX32650/TMR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/TMR/.vscode/settings.json
+++ b/Examples/MAX32650/TMR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/TRNG/.vscode/README.md
+++ b/Examples/MAX32650/TRNG/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/TRNG/.vscode/settings.json
+++ b/Examples/MAX32650/TRNG/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32650/Temp_Monitor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32650/Temp_Monitor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/UART/.vscode/README.md
+++ b/Examples/MAX32650/UART/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/UART/.vscode/settings.json
+++ b/Examples/MAX32650/UART/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/USB/USB_CDCACM/.vscode/README.md
+++ b/Examples/MAX32650/USB/USB_CDCACM/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/USB/USB_CDCACM/.vscode/settings.json
+++ b/Examples/MAX32650/USB/USB_CDCACM/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/USB/USB_CompositeDevice_MSC_CDC/.vscode/README.md
+++ b/Examples/MAX32650/USB/USB_CompositeDevice_MSC_CDC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/USB/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
+++ b/Examples/MAX32650/USB/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/USB/USB_CompositeDevice_MSC_HID/.vscode/README.md
+++ b/Examples/MAX32650/USB/USB_CompositeDevice_MSC_HID/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/USB/USB_CompositeDevice_MSC_HID/.vscode/settings.json
+++ b/Examples/MAX32650/USB/USB_CompositeDevice_MSC_HID/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/USB/USB_HIDKeyboard/.vscode/README.md
+++ b/Examples/MAX32650/USB/USB_HIDKeyboard/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/USB/USB_HIDKeyboard/.vscode/settings.json
+++ b/Examples/MAX32650/USB/USB_HIDKeyboard/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/USB/USB_MassStorage/.vscode/README.md
+++ b/Examples/MAX32650/USB/USB_MassStorage/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/USB/USB_MassStorage/.vscode/settings.json
+++ b/Examples/MAX32650/USB/USB_MassStorage/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/Watchdog/.vscode/README.md
+++ b/Examples/MAX32650/Watchdog/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32650/Watchdog/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32650/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32650/WearLeveling/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32650/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32650/WearLeveling/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/ADC/.vscode/README.md
+++ b/Examples/MAX32655/ADC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/ADC/.vscode/settings.json
+++ b/Examples/MAX32655/ADC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/AES/.vscode/README.md
+++ b/Examples/MAX32655/AES/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/AES/.vscode/settings.json
+++ b/Examples/MAX32655/AES/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32655/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Bluetooth/BLE4_ctr/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE4_ctr/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Bluetooth/BLE4_ctr/.vscode/settings.json
+++ b/Examples/MAX32655/Bluetooth/BLE4_ctr/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Bluetooth/BLE5_ctr/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE5_ctr/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Bluetooth/BLE5_ctr/.vscode/settings.json
+++ b/Examples/MAX32655/Bluetooth/BLE5_ctr/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Bluetooth/BLE_FreeRTOS/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_FreeRTOS/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Bluetooth/BLE_FreeRTOS/.vscode/settings.json
+++ b/Examples/MAX32655/Bluetooth/BLE_FreeRTOS/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Bluetooth/BLE_datc/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_datc/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Bluetooth/BLE_datc/.vscode/settings.json
+++ b/Examples/MAX32655/Bluetooth/BLE_datc/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Bluetooth/BLE_dats/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_dats/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Bluetooth/BLE_dats/.vscode/settings.json
+++ b/Examples/MAX32655/Bluetooth/BLE_dats/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Bluetooth/BLE_fcc/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_fcc/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Bluetooth/BLE_fcc/.vscode/settings.json
+++ b/Examples/MAX32655/Bluetooth/BLE_fcc/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Bluetooth/BLE_fit/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_fit/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Bluetooth/BLE_fit/.vscode/settings.json
+++ b/Examples/MAX32655/Bluetooth/BLE_fit/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Bluetooth/BLE_fit_FreeRTOS/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_fit_FreeRTOS/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Bluetooth/BLE_fit_FreeRTOS/.vscode/settings.json
+++ b/Examples/MAX32655/Bluetooth/BLE_fit_FreeRTOS/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Bluetooth/BLE_mcs/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_mcs/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Bluetooth/BLE_mcs/.vscode/settings.json
+++ b/Examples/MAX32655/Bluetooth/BLE_mcs/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Bluetooth/BLE_otac/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_otac/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Bluetooth/BLE_otac/.vscode/settings.json
+++ b/Examples/MAX32655/Bluetooth/BLE_otac/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Bluetooth/BLE_otas/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_otas/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Bluetooth/BLE_otas/.vscode/settings.json
+++ b/Examples/MAX32655/Bluetooth/BLE_otas/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Bluetooth/BLE_periph/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/BLE_periph/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Bluetooth/BLE_periph/.vscode/settings.json
+++ b/Examples/MAX32655/Bluetooth/BLE_periph/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Bluetooth/Bootloader/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/Bootloader/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Bluetooth/Bootloader/.vscode/settings.json
+++ b/Examples/MAX32655/Bluetooth/Bootloader/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Bluetooth/RF_Test/.vscode/README.md
+++ b/Examples/MAX32655/Bluetooth/RF_Test/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Bluetooth/RF_Test/.vscode/settings.json
+++ b/Examples/MAX32655/Bluetooth/RF_Test/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/CRC/.vscode/README.md
+++ b/Examples/MAX32655/CRC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/CRC/.vscode/settings.json
+++ b/Examples/MAX32655/CRC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Coremark/.vscode/README.md
+++ b/Examples/MAX32655/Coremark/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Coremark/.vscode/settings.json
+++ b/Examples/MAX32655/Coremark/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/DMA/.vscode/README.md
+++ b/Examples/MAX32655/DMA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/DMA/.vscode/settings.json
+++ b/Examples/MAX32655/DMA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/.vscode/README.md
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/.vscode/settings.json
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/.vscode/README.md
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/.vscode/settings.json
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32655/EEPROM_Emulator/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32655/EEPROM_Emulator/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/External_Flash/.vscode/README.md
+++ b/Examples/MAX32655/External_Flash/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/External_Flash/.vscode/settings.json
+++ b/Examples/MAX32655/External_Flash/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/FTHR_I2C/.vscode/README.md
+++ b/Examples/MAX32655/FTHR_I2C/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/FTHR_I2C/.vscode/settings.json
+++ b/Examples/MAX32655/FTHR_I2C/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Flash/.vscode/README.md
+++ b/Examples/MAX32655/Flash/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Flash/.vscode/settings.json
+++ b/Examples/MAX32655/Flash/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32655/Flash_CLI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32655/Flash_CLI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32655/FreeRTOSDemo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32655/FreeRTOSDemo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/GPIO/.vscode/README.md
+++ b/Examples/MAX32655/GPIO/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/GPIO/.vscode/settings.json
+++ b/Examples/MAX32655/GPIO/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Hello_World-riscv/.vscode/README.md
+++ b/Examples/MAX32655/Hello_World-riscv/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Hello_World-riscv/.vscode/settings.json
+++ b/Examples/MAX32655/Hello_World-riscv/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Hello_World/.vscode/README.md
+++ b/Examples/MAX32655/Hello_World/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32655/Hello_World/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32655/Hello_World_Cpp/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32655/Hello_World_Cpp/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/I2C/.vscode/README.md
+++ b/Examples/MAX32655/I2C/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/I2C/.vscode/settings.json
+++ b/Examples/MAX32655/I2C/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/I2C_EEPROM/.vscode/README.md
+++ b/Examples/MAX32655/I2C_EEPROM/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/I2C_EEPROM/.vscode/settings.json
+++ b/Examples/MAX32655/I2C_EEPROM/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32655/I2C_MNGR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32655/I2C_MNGR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32655/I2C_SCAN/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32655/I2C_SCAN/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32655/I2C_Sensor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32655/I2C_Sensor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/I2C_Sensor_ADT7420/.vscode/README.md
+++ b/Examples/MAX32655/I2C_Sensor_ADT7420/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/I2C_Sensor_ADT7420/.vscode/settings.json
+++ b/Examples/MAX32655/I2C_Sensor_ADT7420/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/I2S/.vscode/README.md
+++ b/Examples/MAX32655/I2S/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/I2S/.vscode/settings.json
+++ b/Examples/MAX32655/I2S/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/ICC/.vscode/README.md
+++ b/Examples/MAX32655/ICC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/ICC/.vscode/settings.json
+++ b/Examples/MAX32655/ICC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/LP/.vscode/README.md
+++ b/Examples/MAX32655/LP/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/LP/.vscode/settings.json
+++ b/Examples/MAX32655/LP/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/LPCMP/.vscode/README.md
+++ b/Examples/MAX32655/LPCMP/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/LPCMP/.vscode/settings.json
+++ b/Examples/MAX32655/LPCMP/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Library_Use/.vscode/README.md
+++ b/Examples/MAX32655/Library_Use/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32655/Library_Use/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Pulse_Train/.vscode/README.md
+++ b/Examples/MAX32655/Pulse_Train/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Pulse_Train/.vscode/settings.json
+++ b/Examples/MAX32655/Pulse_Train/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/RTC/.vscode/README.md
+++ b/Examples/MAX32655/RTC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/RTC/.vscode/settings.json
+++ b/Examples/MAX32655/RTC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX32655/RTC_Backup/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX32655/RTC_Backup/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/RV_ARM_Loader/.vscode/README.md
+++ b/Examples/MAX32655/RV_ARM_Loader/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/RV_ARM_Loader/.vscode/settings.json
+++ b/Examples/MAX32655/RV_ARM_Loader/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/SPI/.vscode/README.md
+++ b/Examples/MAX32655/SPI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/SPI/.vscode/settings.json
+++ b/Examples/MAX32655/SPI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/TFT_Demo/.vscode/README.md
+++ b/Examples/MAX32655/TFT_Demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/TFT_Demo/.vscode/settings.json
+++ b/Examples/MAX32655/TFT_Demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/TMR/.vscode/README.md
+++ b/Examples/MAX32655/TMR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/TMR/.vscode/settings.json
+++ b/Examples/MAX32655/TMR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/TRNG/.vscode/README.md
+++ b/Examples/MAX32655/TRNG/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/TRNG/.vscode/settings.json
+++ b/Examples/MAX32655/TRNG/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32655/Temp_Monitor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32655/Temp_Monitor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/UART/.vscode/README.md
+++ b/Examples/MAX32655/UART/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/UART/.vscode/settings.json
+++ b/Examples/MAX32655/UART/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/WUT/.vscode/README.md
+++ b/Examples/MAX32655/WUT/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/WUT/.vscode/settings.json
+++ b/Examples/MAX32655/WUT/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/Watchdog/.vscode/README.md
+++ b/Examples/MAX32655/Watchdog/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32655/Watchdog/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32655/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32655/WearLeveling/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32655/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32655/WearLeveling/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32660/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/Bootloader_Host/.vscode/README.md
+++ b/Examples/MAX32660/Bootloader_Host/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/Bootloader_Host/.vscode/settings.json
+++ b/Examples/MAX32660/Bootloader_Host/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/Coremark/.vscode/README.md
+++ b/Examples/MAX32660/Coremark/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/Coremark/.vscode/settings.json
+++ b/Examples/MAX32660/Coremark/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/DMA/.vscode/README.md
+++ b/Examples/MAX32660/DMA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/DMA/.vscode/settings.json
+++ b/Examples/MAX32660/DMA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32660/EEPROM_Emulator/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32660/EEPROM_Emulator/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/Flash/.vscode/README.md
+++ b/Examples/MAX32660/Flash/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/Flash/.vscode/settings.json
+++ b/Examples/MAX32660/Flash/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32660/Flash_CLI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32660/Flash_CLI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32660/FreeRTOSDemo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32660/FreeRTOSDemo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/GPIO/.vscode/README.md
+++ b/Examples/MAX32660/GPIO/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/GPIO/.vscode/settings.json
+++ b/Examples/MAX32660/GPIO/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/Hello_World/.vscode/README.md
+++ b/Examples/MAX32660/Hello_World/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32660/Hello_World/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32660/Hello_World_Cpp/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32660/Hello_World_Cpp/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/I2C/.vscode/README.md
+++ b/Examples/MAX32660/I2C/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/I2C/.vscode/settings.json
+++ b/Examples/MAX32660/I2C/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32660/I2C_MNGR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32660/I2C_MNGR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32660/I2C_SCAN/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32660/I2C_SCAN/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32660/I2C_Sensor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32660/I2C_Sensor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/I2S/.vscode/README.md
+++ b/Examples/MAX32660/I2S/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/I2S/.vscode/settings.json
+++ b/Examples/MAX32660/I2S/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/ICC/.vscode/README.md
+++ b/Examples/MAX32660/ICC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/ICC/.vscode/settings.json
+++ b/Examples/MAX32660/ICC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/Info_Block_Usecase/.vscode/README.md
+++ b/Examples/MAX32660/Info_Block_Usecase/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/Info_Block_Usecase/.vscode/settings.json
+++ b/Examples/MAX32660/Info_Block_Usecase/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/LP/.vscode/README.md
+++ b/Examples/MAX32660/LP/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/LP/.vscode/settings.json
+++ b/Examples/MAX32660/LP/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/Library_Use/.vscode/README.md
+++ b/Examples/MAX32660/Library_Use/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32660/Library_Use/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/RTC/.vscode/README.md
+++ b/Examples/MAX32660/RTC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/RTC/.vscode/settings.json
+++ b/Examples/MAX32660/RTC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX32660/RTC_Backup/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX32660/RTC_Backup/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/SPI/.vscode/README.md
+++ b/Examples/MAX32660/SPI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/SPI/.vscode/settings.json
+++ b/Examples/MAX32660/SPI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/SPIMSS/.vscode/README.md
+++ b/Examples/MAX32660/SPIMSS/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/SPIMSS/.vscode/settings.json
+++ b/Examples/MAX32660/SPIMSS/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/SPIMSS_DMA/.vscode/README.md
+++ b/Examples/MAX32660/SPIMSS_DMA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/SPIMSS_DMA/.vscode/settings.json
+++ b/Examples/MAX32660/SPIMSS_DMA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/SPI_MasterSlave/.vscode/README.md
+++ b/Examples/MAX32660/SPI_MasterSlave/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/SPI_MasterSlave/.vscode/settings.json
+++ b/Examples/MAX32660/SPI_MasterSlave/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/SecureROM_BL_Host/.vscode/README.md
+++ b/Examples/MAX32660/SecureROM_BL_Host/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/SecureROM_BL_Host/.vscode/settings.json
+++ b/Examples/MAX32660/SecureROM_BL_Host/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/TMR/.vscode/README.md
+++ b/Examples/MAX32660/TMR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/TMR/.vscode/settings.json
+++ b/Examples/MAX32660/TMR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32660/Temp_Monitor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32660/Temp_Monitor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/UART/.vscode/README.md
+++ b/Examples/MAX32660/UART/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/UART/.vscode/settings.json
+++ b/Examples/MAX32660/UART/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/UART_Wakeup/.vscode/README.md
+++ b/Examples/MAX32660/UART_Wakeup/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/UART_Wakeup/.vscode/settings.json
+++ b/Examples/MAX32660/UART_Wakeup/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/Watchdog/.vscode/README.md
+++ b/Examples/MAX32660/Watchdog/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32660/Watchdog/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32660/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32660/WearLeveling/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32660/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32660/WearLeveling/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/ADC/.vscode/README.md
+++ b/Examples/MAX32662/ADC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/ADC/.vscode/settings.json
+++ b/Examples/MAX32662/ADC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32662/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/Bootloader_Host/.vscode/README.md
+++ b/Examples/MAX32662/Bootloader_Host/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/Bootloader_Host/.vscode/settings.json
+++ b/Examples/MAX32662/Bootloader_Host/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/CAN/.vscode/README.md
+++ b/Examples/MAX32662/CAN/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/CAN/.vscode/settings.json
+++ b/Examples/MAX32662/CAN/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/Coremark/.vscode/README.md
+++ b/Examples/MAX32662/Coremark/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/Coremark/.vscode/settings.json
+++ b/Examples/MAX32662/Coremark/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/DMA/.vscode/README.md
+++ b/Examples/MAX32662/DMA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/DMA/.vscode/settings.json
+++ b/Examples/MAX32662/DMA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/Demo/.vscode/README.md
+++ b/Examples/MAX32662/Demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/Demo/.vscode/settings.json
+++ b/Examples/MAX32662/Demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32662/EEPROM_Emulator/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32662/EEPROM_Emulator/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/Flash/.vscode/README.md
+++ b/Examples/MAX32662/Flash/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/Flash/.vscode/settings.json
+++ b/Examples/MAX32662/Flash/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32662/Flash_CLI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32662/Flash_CLI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/GPIO/.vscode/README.md
+++ b/Examples/MAX32662/GPIO/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/GPIO/.vscode/settings.json
+++ b/Examples/MAX32662/GPIO/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/Hello_World/.vscode/README.md
+++ b/Examples/MAX32662/Hello_World/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32662/Hello_World/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32662/Hello_World_Cpp/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32662/Hello_World_Cpp/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/I2C/.vscode/README.md
+++ b/Examples/MAX32662/I2C/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/I2C/.vscode/settings.json
+++ b/Examples/MAX32662/I2C/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32662/I2C_MNGR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32662/I2C_MNGR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32662/I2C_SCAN/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32662/I2C_SCAN/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32662/I2C_Sensor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32662/I2C_Sensor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/I2S/.vscode/README.md
+++ b/Examples/MAX32662/I2S/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/I2S/.vscode/settings.json
+++ b/Examples/MAX32662/I2S/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/ICC/.vscode/README.md
+++ b/Examples/MAX32662/ICC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/ICC/.vscode/settings.json
+++ b/Examples/MAX32662/ICC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/Info_Block_Usecase/.vscode/README.md
+++ b/Examples/MAX32662/Info_Block_Usecase/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/Info_Block_Usecase/.vscode/settings.json
+++ b/Examples/MAX32662/Info_Block_Usecase/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/LP/.vscode/README.md
+++ b/Examples/MAX32662/LP/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/LP/.vscode/settings.json
+++ b/Examples/MAX32662/LP/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/Library_Use/.vscode/README.md
+++ b/Examples/MAX32662/Library_Use/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32662/Library_Use/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/RTC/.vscode/README.md
+++ b/Examples/MAX32662/RTC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/RTC/.vscode/settings.json
+++ b/Examples/MAX32662/RTC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX32662/RTC_Backup/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX32662/RTC_Backup/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/SCPA_OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32662/SCPA_OTP_Dump/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/SCPA_OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32662/SCPA_OTP_Dump/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/SPI/.vscode/README.md
+++ b/Examples/MAX32662/SPI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/SPI/.vscode/settings.json
+++ b/Examples/MAX32662/SPI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/SPI_MasterSlave/.vscode/README.md
+++ b/Examples/MAX32662/SPI_MasterSlave/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/SPI_MasterSlave/.vscode/settings.json
+++ b/Examples/MAX32662/SPI_MasterSlave/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/TMR/.vscode/README.md
+++ b/Examples/MAX32662/TMR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/TMR/.vscode/settings.json
+++ b/Examples/MAX32662/TMR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32662/Temp_Monitor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32662/Temp_Monitor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/UART/.vscode/README.md
+++ b/Examples/MAX32662/UART/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/UART/.vscode/settings.json
+++ b/Examples/MAX32662/UART/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/UART_Wakeup/.vscode/README.md
+++ b/Examples/MAX32662/UART_Wakeup/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/UART_Wakeup/.vscode/settings.json
+++ b/Examples/MAX32662/UART_Wakeup/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/Watchdog/.vscode/README.md
+++ b/Examples/MAX32662/Watchdog/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32662/Watchdog/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32662/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32662/WearLeveling/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32662/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32662/WearLeveling/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/ADC/.vscode/README.md
+++ b/Examples/MAX32665/ADC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/ADC/.vscode/settings.json
+++ b/Examples/MAX32665/ADC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/ADT7320_TempMonitor/.vscode/README.md
+++ b/Examples/MAX32665/ADT7320_TempMonitor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/ADT7320_TempMonitor/.vscode/settings.json
+++ b/Examples/MAX32665/ADT7320_TempMonitor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/AES/.vscode/README.md
+++ b/Examples/MAX32665/AES/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/AES/.vscode/settings.json
+++ b/Examples/MAX32665/AES/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32665/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/AUDIO_Playback/.vscode/README.md
+++ b/Examples/MAX32665/AUDIO_Playback/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/AUDIO_Playback/.vscode/settings.json
+++ b/Examples/MAX32665/AUDIO_Playback/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Bluetooth/BLE4_ctr/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE4_ctr/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Bluetooth/BLE4_ctr/.vscode/settings.json
+++ b/Examples/MAX32665/Bluetooth/BLE4_ctr/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Bluetooth/BLE5_ctr/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE5_ctr/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Bluetooth/BLE5_ctr/.vscode/settings.json
+++ b/Examples/MAX32665/Bluetooth/BLE5_ctr/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Bluetooth/BLE_FreeRTOS/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_FreeRTOS/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Bluetooth/BLE_FreeRTOS/.vscode/settings.json
+++ b/Examples/MAX32665/Bluetooth/BLE_FreeRTOS/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Bluetooth/BLE_LR_Central/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_LR_Central/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Bluetooth/BLE_LR_Central/.vscode/settings.json
+++ b/Examples/MAX32665/Bluetooth/BLE_LR_Central/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Bluetooth/BLE_LR_Peripheral/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_LR_Peripheral/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Bluetooth/BLE_LR_Peripheral/.vscode/settings.json
+++ b/Examples/MAX32665/Bluetooth/BLE_LR_Peripheral/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Bluetooth/BLE_datc/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_datc/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Bluetooth/BLE_datc/.vscode/settings.json
+++ b/Examples/MAX32665/Bluetooth/BLE_datc/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Bluetooth/BLE_dats/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_dats/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Bluetooth/BLE_dats/.vscode/settings.json
+++ b/Examples/MAX32665/Bluetooth/BLE_dats/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Bluetooth/BLE_fcc/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_fcc/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Bluetooth/BLE_fcc/.vscode/settings.json
+++ b/Examples/MAX32665/Bluetooth/BLE_fcc/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Bluetooth/BLE_fit/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_fit/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Bluetooth/BLE_fit/.vscode/settings.json
+++ b/Examples/MAX32665/Bluetooth/BLE_fit/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Bluetooth/BLE_mcs/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_mcs/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Bluetooth/BLE_mcs/.vscode/settings.json
+++ b/Examples/MAX32665/Bluetooth/BLE_mcs/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Bluetooth/BLE_otac/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_otac/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Bluetooth/BLE_otac/.vscode/settings.json
+++ b/Examples/MAX32665/Bluetooth/BLE_otac/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Bluetooth/BLE_otas/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_otas/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Bluetooth/BLE_otas/.vscode/settings.json
+++ b/Examples/MAX32665/Bluetooth/BLE_otas/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Bluetooth/BLE_periph/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/BLE_periph/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Bluetooth/BLE_periph/.vscode/settings.json
+++ b/Examples/MAX32665/Bluetooth/BLE_periph/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Bluetooth/Bootloader/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/Bootloader/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Bluetooth/Bootloader/.vscode/settings.json
+++ b/Examples/MAX32665/Bluetooth/Bootloader/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Bluetooth/Bootloader_Host/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/Bootloader_Host/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Bluetooth/Bootloader_Host/.vscode/settings.json
+++ b/Examples/MAX32665/Bluetooth/Bootloader_Host/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Bluetooth/RF_Test/.vscode/README.md
+++ b/Examples/MAX32665/Bluetooth/RF_Test/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Bluetooth/RF_Test/.vscode/settings.json
+++ b/Examples/MAX32665/Bluetooth/RF_Test/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/CRC/.vscode/README.md
+++ b/Examples/MAX32665/CRC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/CRC/.vscode/settings.json
+++ b/Examples/MAX32665/CRC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Coremark/.vscode/README.md
+++ b/Examples/MAX32665/Coremark/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Coremark/.vscode/settings.json
+++ b/Examples/MAX32665/Coremark/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/DES/.vscode/README.md
+++ b/Examples/MAX32665/DES/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/DES/.vscode/settings.json
+++ b/Examples/MAX32665/DES/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/DMA/.vscode/README.md
+++ b/Examples/MAX32665/DMA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/DMA/.vscode/settings.json
+++ b/Examples/MAX32665/DMA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Demo/.vscode/README.md
+++ b/Examples/MAX32665/Demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Demo/.vscode/settings.json
+++ b/Examples/MAX32665/Demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Display/.vscode/README.md
+++ b/Examples/MAX32665/Display/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Display/.vscode/settings.json
+++ b/Examples/MAX32665/Display/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/ECC/.vscode/README.md
+++ b/Examples/MAX32665/ECC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/ECC/.vscode/settings.json
+++ b/Examples/MAX32665/ECC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32665/EEPROM_Emulator/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32665/EEPROM_Emulator/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Flash/.vscode/README.md
+++ b/Examples/MAX32665/Flash/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Flash/.vscode/settings.json
+++ b/Examples/MAX32665/Flash/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32665/Flash_CLI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32665/Flash_CLI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32665/FreeRTOSDemo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32665/FreeRTOSDemo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/GPIO/.vscode/README.md
+++ b/Examples/MAX32665/GPIO/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/GPIO/.vscode/settings.json
+++ b/Examples/MAX32665/GPIO/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/HTMR/.vscode/README.md
+++ b/Examples/MAX32665/HTMR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/HTMR/.vscode/settings.json
+++ b/Examples/MAX32665/HTMR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Hash/.vscode/README.md
+++ b/Examples/MAX32665/Hash/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Hash/.vscode/settings.json
+++ b/Examples/MAX32665/Hash/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Hello_World/.vscode/README.md
+++ b/Examples/MAX32665/Hello_World/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32665/Hello_World/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32665/Hello_World_Cpp/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32665/Hello_World_Cpp/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/I2C/.vscode/README.md
+++ b/Examples/MAX32665/I2C/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/I2C/.vscode/settings.json
+++ b/Examples/MAX32665/I2C/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32665/I2C_MNGR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32665/I2C_MNGR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32665/I2C_SCAN/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32665/I2C_SCAN/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32665/I2C_Sensor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32665/I2C_Sensor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/ICC/.vscode/README.md
+++ b/Examples/MAX32665/ICC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/ICC/.vscode/settings.json
+++ b/Examples/MAX32665/ICC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/LP/.vscode/README.md
+++ b/Examples/MAX32665/LP/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/LP/.vscode/settings.json
+++ b/Examples/MAX32665/LP/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Library_Use/.vscode/README.md
+++ b/Examples/MAX32665/Library_Use/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32665/Library_Use/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/MAA/.vscode/README.md
+++ b/Examples/MAX32665/MAA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/MAA/.vscode/settings.json
+++ b/Examples/MAX32665/MAA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32665/OTP_Dump/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32665/OTP_Dump/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/OWM/.vscode/README.md
+++ b/Examples/MAX32665/OWM/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/OWM/.vscode/settings.json
+++ b/Examples/MAX32665/OWM/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Pulse_Train/.vscode/README.md
+++ b/Examples/MAX32665/Pulse_Train/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Pulse_Train/.vscode/settings.json
+++ b/Examples/MAX32665/Pulse_Train/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/RPU/.vscode/README.md
+++ b/Examples/MAX32665/RPU/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/RPU/.vscode/settings.json
+++ b/Examples/MAX32665/RPU/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/RTC/.vscode/README.md
+++ b/Examples/MAX32665/RTC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/RTC/.vscode/settings.json
+++ b/Examples/MAX32665/RTC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX32665/RTC_Backup/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX32665/RTC_Backup/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/SCPA_OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32665/SCPA_OTP_Dump/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/SCPA_OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32665/SCPA_OTP_Dump/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/SDHC_FAT/.vscode/README.md
+++ b/Examples/MAX32665/SDHC_FAT/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/SDHC_FAT/.vscode/settings.json
+++ b/Examples/MAX32665/SDHC_FAT/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/SDHC_Raw/.vscode/README.md
+++ b/Examples/MAX32665/SDHC_Raw/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/SDHC_Raw/.vscode/settings.json
+++ b/Examples/MAX32665/SDHC_Raw/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/SPI/.vscode/README.md
+++ b/Examples/MAX32665/SPI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/SPI/.vscode/settings.json
+++ b/Examples/MAX32665/SPI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/SPIXF/.vscode/README.md
+++ b/Examples/MAX32665/SPIXF/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/SPIXF/.vscode/settings.json
+++ b/Examples/MAX32665/SPIXF/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/SPIXF_SFCC/.vscode/README.md
+++ b/Examples/MAX32665/SPIXF_SFCC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/SPIXF_SFCC/.vscode/settings.json
+++ b/Examples/MAX32665/SPIXF_SFCC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/SPIXR/.vscode/README.md
+++ b/Examples/MAX32665/SPIXR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/SPIXR/.vscode/settings.json
+++ b/Examples/MAX32665/SPIXR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/SPI_3Wire/.vscode/README.md
+++ b/Examples/MAX32665/SPI_3Wire/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/SPI_3Wire/.vscode/settings.json
+++ b/Examples/MAX32665/SPI_3Wire/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/SRCC/.vscode/README.md
+++ b/Examples/MAX32665/SRCC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/SRCC/.vscode/settings.json
+++ b/Examples/MAX32665/SRCC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Semaphore/.vscode/README.md
+++ b/Examples/MAX32665/Semaphore/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Semaphore/.vscode/settings.json
+++ b/Examples/MAX32665/Semaphore/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/TMR/.vscode/README.md
+++ b/Examples/MAX32665/TMR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/TMR/.vscode/settings.json
+++ b/Examples/MAX32665/TMR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/TRNG/.vscode/README.md
+++ b/Examples/MAX32665/TRNG/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/TRNG/.vscode/settings.json
+++ b/Examples/MAX32665/TRNG/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32665/Temp_Monitor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32665/Temp_Monitor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/UART/.vscode/README.md
+++ b/Examples/MAX32665/UART/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/UART/.vscode/settings.json
+++ b/Examples/MAX32665/UART/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/USB/USB_CDCACM/.vscode/README.md
+++ b/Examples/MAX32665/USB/USB_CDCACM/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/USB/USB_CDCACM/.vscode/settings.json
+++ b/Examples/MAX32665/USB/USB_CDCACM/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/USB/USB_CompositeDevice_MSC_CDC/.vscode/README.md
+++ b/Examples/MAX32665/USB/USB_CompositeDevice_MSC_CDC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/USB/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
+++ b/Examples/MAX32665/USB/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/USB/USB_CompositeDevice_MSC_HID/.vscode/README.md
+++ b/Examples/MAX32665/USB/USB_CompositeDevice_MSC_HID/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/USB/USB_CompositeDevice_MSC_HID/.vscode/settings.json
+++ b/Examples/MAX32665/USB/USB_CompositeDevice_MSC_HID/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/USB/USB_HIDKeyboard/.vscode/README.md
+++ b/Examples/MAX32665/USB/USB_HIDKeyboard/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/USB/USB_HIDKeyboard/.vscode/settings.json
+++ b/Examples/MAX32665/USB/USB_HIDKeyboard/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/USB/USB_MassStorage/.vscode/README.md
+++ b/Examples/MAX32665/USB/USB_MassStorage/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/USB/USB_MassStorage/.vscode/settings.json
+++ b/Examples/MAX32665/USB/USB_MassStorage/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/WUT/.vscode/README.md
+++ b/Examples/MAX32665/WUT/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/WUT/.vscode/settings.json
+++ b/Examples/MAX32665/WUT/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/Watchdog/.vscode/README.md
+++ b/Examples/MAX32665/Watchdog/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32665/Watchdog/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32665/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32665/WearLeveling/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32665/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32665/WearLeveling/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/AES/.vscode/README.md
+++ b/Examples/MAX32670/AES/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/AES/.vscode/settings.json
+++ b/Examples/MAX32670/AES/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32670/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/CRC/.vscode/README.md
+++ b/Examples/MAX32670/CRC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/CRC/.vscode/settings.json
+++ b/Examples/MAX32670/CRC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/Coremark/.vscode/README.md
+++ b/Examples/MAX32670/Coremark/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/Coremark/.vscode/settings.json
+++ b/Examples/MAX32670/Coremark/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/DMA/.vscode/README.md
+++ b/Examples/MAX32670/DMA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/DMA/.vscode/settings.json
+++ b/Examples/MAX32670/DMA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32670/EEPROM_Emulator/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32670/EEPROM_Emulator/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/EXT_CLK/.vscode/README.md
+++ b/Examples/MAX32670/EXT_CLK/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/EXT_CLK/.vscode/settings.json
+++ b/Examples/MAX32670/EXT_CLK/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/Flash/.vscode/README.md
+++ b/Examples/MAX32670/Flash/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/Flash/.vscode/settings.json
+++ b/Examples/MAX32670/Flash/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32670/Flash_CLI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32670/Flash_CLI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32670/FreeRTOSDemo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32670/FreeRTOSDemo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/GPIO/.vscode/README.md
+++ b/Examples/MAX32670/GPIO/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/GPIO/.vscode/settings.json
+++ b/Examples/MAX32670/GPIO/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/Hello_World/.vscode/README.md
+++ b/Examples/MAX32670/Hello_World/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32670/Hello_World/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32670/Hello_World_Cpp/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32670/Hello_World_Cpp/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/I2C/.vscode/README.md
+++ b/Examples/MAX32670/I2C/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/I2C/.vscode/settings.json
+++ b/Examples/MAX32670/I2C/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32670/I2C_MNGR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32670/I2C_MNGR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32670/I2C_SCAN/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32670/I2C_SCAN/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32670/I2C_Sensor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32670/I2C_Sensor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/I2S/.vscode/README.md
+++ b/Examples/MAX32670/I2S/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/I2S/.vscode/settings.json
+++ b/Examples/MAX32670/I2S/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/ICC/.vscode/README.md
+++ b/Examples/MAX32670/ICC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/ICC/.vscode/settings.json
+++ b/Examples/MAX32670/ICC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/LP/.vscode/README.md
+++ b/Examples/MAX32670/LP/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/LP/.vscode/settings.json
+++ b/Examples/MAX32670/LP/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/Library_Use/.vscode/README.md
+++ b/Examples/MAX32670/Library_Use/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32670/Library_Use/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/RTC/.vscode/README.md
+++ b/Examples/MAX32670/RTC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/RTC/.vscode/settings.json
+++ b/Examples/MAX32670/RTC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX32670/RTC_Backup/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX32670/RTC_Backup/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/SPI/.vscode/README.md
+++ b/Examples/MAX32670/SPI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/SPI/.vscode/settings.json
+++ b/Examples/MAX32670/SPI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/SPI_MasterSlave/.vscode/README.md
+++ b/Examples/MAX32670/SPI_MasterSlave/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/SPI_MasterSlave/.vscode/settings.json
+++ b/Examples/MAX32670/SPI_MasterSlave/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/SPI_Usecase/.vscode/README.md
+++ b/Examples/MAX32670/SPI_Usecase/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/SPI_Usecase/.vscode/settings.json
+++ b/Examples/MAX32670/SPI_Usecase/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/SecureROM_BL_Host/.vscode/README.md
+++ b/Examples/MAX32670/SecureROM_BL_Host/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/SecureROM_BL_Host/.vscode/settings.json
+++ b/Examples/MAX32670/SecureROM_BL_Host/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/TMR/.vscode/README.md
+++ b/Examples/MAX32670/TMR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/TMR/.vscode/settings.json
+++ b/Examples/MAX32670/TMR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/TRNG/.vscode/README.md
+++ b/Examples/MAX32670/TRNG/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/TRNG/.vscode/settings.json
+++ b/Examples/MAX32670/TRNG/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32670/Temp_Monitor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32670/Temp_Monitor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/UART/.vscode/README.md
+++ b/Examples/MAX32670/UART/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/UART/.vscode/settings.json
+++ b/Examples/MAX32670/UART/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/Watchdog/.vscode/README.md
+++ b/Examples/MAX32670/Watchdog/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32670/Watchdog/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32670/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32670/WearLeveling/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32670/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32670/WearLeveling/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/ADC/.vscode/README.md
+++ b/Examples/MAX32672/ADC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/ADC/.vscode/settings.json
+++ b/Examples/MAX32672/ADC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/AES/.vscode/README.md
+++ b/Examples/MAX32672/AES/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/AES/.vscode/settings.json
+++ b/Examples/MAX32672/AES/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32672/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/CRC/.vscode/README.md
+++ b/Examples/MAX32672/CRC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/CRC/.vscode/settings.json
+++ b/Examples/MAX32672/CRC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/CTB_AES/.vscode/README.md
+++ b/Examples/MAX32672/CTB_AES/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/CTB_AES/.vscode/settings.json
+++ b/Examples/MAX32672/CTB_AES/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/Comparator/.vscode/README.md
+++ b/Examples/MAX32672/Comparator/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/Comparator/.vscode/settings.json
+++ b/Examples/MAX32672/Comparator/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/Coremark/.vscode/README.md
+++ b/Examples/MAX32672/Coremark/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/Coremark/.vscode/settings.json
+++ b/Examples/MAX32672/Coremark/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/DMA/.vscode/README.md
+++ b/Examples/MAX32672/DMA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/DMA/.vscode/settings.json
+++ b/Examples/MAX32672/DMA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/Demo/.vscode/README.md
+++ b/Examples/MAX32672/Demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/Demo/.vscode/settings.json
+++ b/Examples/MAX32672/Demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/Display/.vscode/README.md
+++ b/Examples/MAX32672/Display/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/Display/.vscode/settings.json
+++ b/Examples/MAX32672/Display/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32672/EEPROM_Emulator/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32672/EEPROM_Emulator/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/Flash/.vscode/README.md
+++ b/Examples/MAX32672/Flash/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/Flash/.vscode/settings.json
+++ b/Examples/MAX32672/Flash/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32672/Flash_CLI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32672/Flash_CLI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32672/FreeRTOSDemo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32672/FreeRTOSDemo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/GPIO/.vscode/README.md
+++ b/Examples/MAX32672/GPIO/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/GPIO/.vscode/settings.json
+++ b/Examples/MAX32672/GPIO/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/Hello_World/.vscode/README.md
+++ b/Examples/MAX32672/Hello_World/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32672/Hello_World/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32672/Hello_World_Cpp/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32672/Hello_World_Cpp/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/I2C/.vscode/README.md
+++ b/Examples/MAX32672/I2C/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/I2C/.vscode/settings.json
+++ b/Examples/MAX32672/I2C/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32672/I2C_MNGR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32672/I2C_MNGR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32672/I2C_SCAN/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32672/I2C_SCAN/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32672/I2C_Sensor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32672/I2C_Sensor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/I2S/.vscode/README.md
+++ b/Examples/MAX32672/I2S/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/I2S/.vscode/settings.json
+++ b/Examples/MAX32672/I2S/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/ICC/.vscode/README.md
+++ b/Examples/MAX32672/ICC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/ICC/.vscode/settings.json
+++ b/Examples/MAX32672/ICC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/LP/.vscode/README.md
+++ b/Examples/MAX32672/LP/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/LP/.vscode/settings.json
+++ b/Examples/MAX32672/LP/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/Library_Use/.vscode/README.md
+++ b/Examples/MAX32672/Library_Use/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32672/Library_Use/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/OLED_Demo/.vscode/README.md
+++ b/Examples/MAX32672/OLED_Demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/OLED_Demo/.vscode/settings.json
+++ b/Examples/MAX32672/OLED_Demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/QDEC/.vscode/README.md
+++ b/Examples/MAX32672/QDEC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/QDEC/.vscode/settings.json
+++ b/Examples/MAX32672/QDEC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/RTC/.vscode/README.md
+++ b/Examples/MAX32672/RTC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/RTC/.vscode/settings.json
+++ b/Examples/MAX32672/RTC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX32672/RTC_Backup/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX32672/RTC_Backup/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/SCPA_OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32672/SCPA_OTP_Dump/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/SCPA_OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32672/SCPA_OTP_Dump/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/SPI/.vscode/README.md
+++ b/Examples/MAX32672/SPI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/SPI/.vscode/settings.json
+++ b/Examples/MAX32672/SPI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/SPI_MasterSlave/.vscode/README.md
+++ b/Examples/MAX32672/SPI_MasterSlave/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/SPI_MasterSlave/.vscode/settings.json
+++ b/Examples/MAX32672/SPI_MasterSlave/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/TMR/.vscode/README.md
+++ b/Examples/MAX32672/TMR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/TMR/.vscode/settings.json
+++ b/Examples/MAX32672/TMR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/TRNG/.vscode/README.md
+++ b/Examples/MAX32672/TRNG/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/TRNG/.vscode/settings.json
+++ b/Examples/MAX32672/TRNG/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32672/Temp_Monitor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32672/Temp_Monitor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/UART/.vscode/README.md
+++ b/Examples/MAX32672/UART/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/UART/.vscode/settings.json
+++ b/Examples/MAX32672/UART/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/Watchdog/.vscode/README.md
+++ b/Examples/MAX32672/Watchdog/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32672/Watchdog/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32672/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32672/WearLeveling/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32672/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32672/WearLeveling/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/ADC/.vscode/README.md
+++ b/Examples/MAX32675/ADC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/ADC/.vscode/settings.json
+++ b/Examples/MAX32675/ADC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/AES/.vscode/README.md
+++ b/Examples/MAX32675/AES/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/AES/.vscode/settings.json
+++ b/Examples/MAX32675/AES/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/AFE_DAC/.vscode/README.md
+++ b/Examples/MAX32675/AFE_DAC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/AFE_DAC/.vscode/settings.json
+++ b/Examples/MAX32675/AFE_DAC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32675/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/CRC/.vscode/README.md
+++ b/Examples/MAX32675/CRC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/CRC/.vscode/settings.json
+++ b/Examples/MAX32675/CRC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/Coremark/.vscode/README.md
+++ b/Examples/MAX32675/Coremark/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/Coremark/.vscode/settings.json
+++ b/Examples/MAX32675/Coremark/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/DMA/.vscode/README.md
+++ b/Examples/MAX32675/DMA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/DMA/.vscode/settings.json
+++ b/Examples/MAX32675/DMA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32675/EEPROM_Emulator/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32675/EEPROM_Emulator/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/Flash/.vscode/README.md
+++ b/Examples/MAX32675/Flash/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/Flash/.vscode/settings.json
+++ b/Examples/MAX32675/Flash/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32675/Flash_CLI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32675/Flash_CLI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32675/FreeRTOSDemo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32675/FreeRTOSDemo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/GPIO/.vscode/README.md
+++ b/Examples/MAX32675/GPIO/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/GPIO/.vscode/settings.json
+++ b/Examples/MAX32675/GPIO/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/HART_UART/.vscode/README.md
+++ b/Examples/MAX32675/HART_UART/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/HART_UART/.vscode/settings.json
+++ b/Examples/MAX32675/HART_UART/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/Hello_World/.vscode/README.md
+++ b/Examples/MAX32675/Hello_World/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32675/Hello_World/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32675/Hello_World_Cpp/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32675/Hello_World_Cpp/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/I2C/.vscode/README.md
+++ b/Examples/MAX32675/I2C/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/I2C/.vscode/settings.json
+++ b/Examples/MAX32675/I2C/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32675/I2C_MNGR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32675/I2C_MNGR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32675/I2C_SCAN/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32675/I2C_SCAN/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32675/I2C_Sensor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32675/I2C_Sensor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/I2S/.vscode/README.md
+++ b/Examples/MAX32675/I2S/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/I2S/.vscode/settings.json
+++ b/Examples/MAX32675/I2S/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/ICC/.vscode/README.md
+++ b/Examples/MAX32675/ICC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/ICC/.vscode/settings.json
+++ b/Examples/MAX32675/ICC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/LP/.vscode/README.md
+++ b/Examples/MAX32675/LP/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/LP/.vscode/settings.json
+++ b/Examples/MAX32675/LP/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/Library_Use/.vscode/README.md
+++ b/Examples/MAX32675/Library_Use/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32675/Library_Use/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/SPI/.vscode/README.md
+++ b/Examples/MAX32675/SPI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/SPI/.vscode/settings.json
+++ b/Examples/MAX32675/SPI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/TMR/.vscode/README.md
+++ b/Examples/MAX32675/TMR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/TMR/.vscode/settings.json
+++ b/Examples/MAX32675/TMR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/TRNG/.vscode/README.md
+++ b/Examples/MAX32675/TRNG/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/TRNG/.vscode/settings.json
+++ b/Examples/MAX32675/TRNG/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/UART/.vscode/README.md
+++ b/Examples/MAX32675/UART/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/UART/.vscode/settings.json
+++ b/Examples/MAX32675/UART/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/Watchdog/.vscode/README.md
+++ b/Examples/MAX32675/Watchdog/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32675/Watchdog/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32675/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32675/WearLeveling/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32675/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32675/WearLeveling/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/ADC/.vscode/README.md
+++ b/Examples/MAX32680/ADC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/ADC/.vscode/settings.json
+++ b/Examples/MAX32680/ADC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/AES/.vscode/README.md
+++ b/Examples/MAX32680/AES/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/AES/.vscode/settings.json
+++ b/Examples/MAX32680/AES/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/AFE_ADC/.vscode/README.md
+++ b/Examples/MAX32680/AFE_ADC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/AFE_ADC/.vscode/settings.json
+++ b/Examples/MAX32680/AFE_ADC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32680/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/Bluetooth/BLE4_ctr/.vscode/README.md
+++ b/Examples/MAX32680/Bluetooth/BLE4_ctr/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/Bluetooth/BLE4_ctr/.vscode/settings.json
+++ b/Examples/MAX32680/Bluetooth/BLE4_ctr/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/Bluetooth/BLE_dats/.vscode/README.md
+++ b/Examples/MAX32680/Bluetooth/BLE_dats/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/Bluetooth/BLE_dats/.vscode/settings.json
+++ b/Examples/MAX32680/Bluetooth/BLE_dats/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/CRC/.vscode/README.md
+++ b/Examples/MAX32680/CRC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/CRC/.vscode/settings.json
+++ b/Examples/MAX32680/CRC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/Coremark/.vscode/README.md
+++ b/Examples/MAX32680/Coremark/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/Coremark/.vscode/settings.json
+++ b/Examples/MAX32680/Coremark/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/DMA/.vscode/README.md
+++ b/Examples/MAX32680/DMA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/DMA/.vscode/settings.json
+++ b/Examples/MAX32680/DMA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32680/EEPROM_Emulator/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32680/EEPROM_Emulator/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/Flash/.vscode/README.md
+++ b/Examples/MAX32680/Flash/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/Flash/.vscode/settings.json
+++ b/Examples/MAX32680/Flash/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32680/Flash_CLI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32680/Flash_CLI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32680/FreeRTOSDemo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32680/FreeRTOSDemo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/GPIO/.vscode/README.md
+++ b/Examples/MAX32680/GPIO/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/GPIO/.vscode/settings.json
+++ b/Examples/MAX32680/GPIO/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/HART_UART/.vscode/README.md
+++ b/Examples/MAX32680/HART_UART/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/HART_UART/.vscode/settings.json
+++ b/Examples/MAX32680/HART_UART/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/Hello_World-riscv/.vscode/README.md
+++ b/Examples/MAX32680/Hello_World-riscv/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/Hello_World-riscv/.vscode/settings.json
+++ b/Examples/MAX32680/Hello_World-riscv/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/Hello_World/.vscode/README.md
+++ b/Examples/MAX32680/Hello_World/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32680/Hello_World/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32680/Hello_World_Cpp/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32680/Hello_World_Cpp/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/I2C/.vscode/README.md
+++ b/Examples/MAX32680/I2C/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/I2C/.vscode/settings.json
+++ b/Examples/MAX32680/I2C/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32680/I2C_MNGR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32680/I2C_MNGR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32680/I2C_SCAN/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32680/I2C_SCAN/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32680/I2C_Sensor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32680/I2C_Sensor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/I2S/.vscode/README.md
+++ b/Examples/MAX32680/I2S/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/I2S/.vscode/settings.json
+++ b/Examples/MAX32680/I2S/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/ICC/.vscode/README.md
+++ b/Examples/MAX32680/ICC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/ICC/.vscode/settings.json
+++ b/Examples/MAX32680/ICC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/LP/.vscode/README.md
+++ b/Examples/MAX32680/LP/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/LP/.vscode/settings.json
+++ b/Examples/MAX32680/LP/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/Library_Use/.vscode/README.md
+++ b/Examples/MAX32680/Library_Use/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32680/Library_Use/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/Pulse_Train/.vscode/README.md
+++ b/Examples/MAX32680/Pulse_Train/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/Pulse_Train/.vscode/settings.json
+++ b/Examples/MAX32680/Pulse_Train/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/RV_ARM_Loader/.vscode/README.md
+++ b/Examples/MAX32680/RV_ARM_Loader/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/RV_ARM_Loader/.vscode/settings.json
+++ b/Examples/MAX32680/RV_ARM_Loader/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/SPI/.vscode/README.md
+++ b/Examples/MAX32680/SPI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/SPI/.vscode/settings.json
+++ b/Examples/MAX32680/SPI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/TMR/.vscode/README.md
+++ b/Examples/MAX32680/TMR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/TMR/.vscode/settings.json
+++ b/Examples/MAX32680/TMR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/TRNG/.vscode/README.md
+++ b/Examples/MAX32680/TRNG/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/TRNG/.vscode/settings.json
+++ b/Examples/MAX32680/TRNG/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32680/Temp_Monitor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32680/Temp_Monitor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/UART/.vscode/README.md
+++ b/Examples/MAX32680/UART/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/UART/.vscode/settings.json
+++ b/Examples/MAX32680/UART/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/WUT/.vscode/README.md
+++ b/Examples/MAX32680/WUT/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/WUT/.vscode/settings.json
+++ b/Examples/MAX32680/WUT/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/Watchdog/.vscode/README.md
+++ b/Examples/MAX32680/Watchdog/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32680/Watchdog/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32680/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32680/WearLeveling/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32680/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32680/WearLeveling/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/ADC/.vscode/README.md
+++ b/Examples/MAX32690/ADC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/ADC/.vscode/settings.json
+++ b/Examples/MAX32690/ADC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX32690/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Bluetooth/BLE4_ctr/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE4_ctr/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Bluetooth/BLE4_ctr/.vscode/settings.json
+++ b/Examples/MAX32690/Bluetooth/BLE4_ctr/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Bluetooth/BLE5_ctr/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE5_ctr/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Bluetooth/BLE5_ctr/.vscode/settings.json
+++ b/Examples/MAX32690/Bluetooth/BLE5_ctr/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/.vscode/settings.json
+++ b/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Bluetooth/BLE_datc/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_datc/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Bluetooth/BLE_datc/.vscode/settings.json
+++ b/Examples/MAX32690/Bluetooth/BLE_datc/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Bluetooth/BLE_dats/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_dats/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Bluetooth/BLE_dats/.vscode/settings.json
+++ b/Examples/MAX32690/Bluetooth/BLE_dats/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Bluetooth/BLE_fcc/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_fcc/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Bluetooth/BLE_fcc/.vscode/settings.json
+++ b/Examples/MAX32690/Bluetooth/BLE_fcc/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Bluetooth/BLE_fit/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_fit/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Bluetooth/BLE_fit/.vscode/settings.json
+++ b/Examples/MAX32690/Bluetooth/BLE_fit/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Bluetooth/BLE_mcs/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_mcs/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Bluetooth/BLE_mcs/.vscode/settings.json
+++ b/Examples/MAX32690/Bluetooth/BLE_mcs/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Bluetooth/BLE_otac/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_otac/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Bluetooth/BLE_otac/.vscode/settings.json
+++ b/Examples/MAX32690/Bluetooth/BLE_otac/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Bluetooth/BLE_otas/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_otas/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Bluetooth/BLE_otas/.vscode/settings.json
+++ b/Examples/MAX32690/Bluetooth/BLE_otas/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Bluetooth/BLE_periph/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/BLE_periph/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Bluetooth/BLE_periph/.vscode/settings.json
+++ b/Examples/MAX32690/Bluetooth/BLE_periph/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Bluetooth/Bootloader/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/Bootloader/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Bluetooth/Bootloader/.vscode/settings.json
+++ b/Examples/MAX32690/Bluetooth/Bootloader/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Bluetooth/RF_Test/.vscode/README.md
+++ b/Examples/MAX32690/Bluetooth/RF_Test/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Bluetooth/RF_Test/.vscode/settings.json
+++ b/Examples/MAX32690/Bluetooth/RF_Test/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/CAN/.vscode/README.md
+++ b/Examples/MAX32690/CAN/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/CAN/.vscode/settings.json
+++ b/Examples/MAX32690/CAN/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/CRC/.vscode/README.md
+++ b/Examples/MAX32690/CRC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/CRC/.vscode/settings.json
+++ b/Examples/MAX32690/CRC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/CTB_AES/.vscode/README.md
+++ b/Examples/MAX32690/CTB_AES/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/CTB_AES/.vscode/settings.json
+++ b/Examples/MAX32690/CTB_AES/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Coremark/.vscode/README.md
+++ b/Examples/MAX32690/Coremark/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Coremark/.vscode/settings.json
+++ b/Examples/MAX32690/Coremark/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/DMA/.vscode/README.md
+++ b/Examples/MAX32690/DMA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/DMA/.vscode/settings.json
+++ b/Examples/MAX32690/DMA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX32690/EEPROM_Emulator/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32690/EEPROM_Emulator/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Flash/.vscode/README.md
+++ b/Examples/MAX32690/Flash/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Flash/.vscode/settings.json
+++ b/Examples/MAX32690/Flash/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX32690/Flash_CLI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32690/Flash_CLI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX32690/FreeRTOSDemo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32690/FreeRTOSDemo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/GPIO/.vscode/README.md
+++ b/Examples/MAX32690/GPIO/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/GPIO/.vscode/settings.json
+++ b/Examples/MAX32690/GPIO/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/HBMC/.vscode/README.md
+++ b/Examples/MAX32690/HBMC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/HBMC/.vscode/settings.json
+++ b/Examples/MAX32690/HBMC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Hash/.vscode/README.md
+++ b/Examples/MAX32690/Hash/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Hash/.vscode/settings.json
+++ b/Examples/MAX32690/Hash/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Hello_World/.vscode/README.md
+++ b/Examples/MAX32690/Hello_World/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32690/Hello_World/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX32690/Hello_World_Cpp/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32690/Hello_World_Cpp/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/I2C/.vscode/README.md
+++ b/Examples/MAX32690/I2C/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/I2C/.vscode/settings.json
+++ b/Examples/MAX32690/I2C/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX32690/I2C_MNGR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32690/I2C_MNGR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX32690/I2C_SCAN/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32690/I2C_SCAN/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX32690/I2C_Sensor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32690/I2C_Sensor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/I2S/.vscode/README.md
+++ b/Examples/MAX32690/I2S/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/I2S/.vscode/settings.json
+++ b/Examples/MAX32690/I2S/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/ICC/.vscode/README.md
+++ b/Examples/MAX32690/ICC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/ICC/.vscode/settings.json
+++ b/Examples/MAX32690/ICC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/LP/.vscode/README.md
+++ b/Examples/MAX32690/LP/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/LP/.vscode/settings.json
+++ b/Examples/MAX32690/LP/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/LPCMP/.vscode/README.md
+++ b/Examples/MAX32690/LPCMP/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/LPCMP/.vscode/settings.json
+++ b/Examples/MAX32690/LPCMP/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Library_Use/.vscode/README.md
+++ b/Examples/MAX32690/Library_Use/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32690/Library_Use/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Pulse_Train/.vscode/README.md
+++ b/Examples/MAX32690/Pulse_Train/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Pulse_Train/.vscode/settings.json
+++ b/Examples/MAX32690/Pulse_Train/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/RTC/.vscode/README.md
+++ b/Examples/MAX32690/RTC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/RTC/.vscode/settings.json
+++ b/Examples/MAX32690/RTC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX32690/RTC_Backup/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX32690/RTC_Backup/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/RV_ARM_Loader/.vscode/README.md
+++ b/Examples/MAX32690/RV_ARM_Loader/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/RV_ARM_Loader/.vscode/settings.json
+++ b/Examples/MAX32690/RV_ARM_Loader/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/SCPA_OTP_Dump/.vscode/README.md
+++ b/Examples/MAX32690/SCPA_OTP_Dump/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/SCPA_OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32690/SCPA_OTP_Dump/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/SPI/.vscode/README.md
+++ b/Examples/MAX32690/SPI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/SPI/.vscode/settings.json
+++ b/Examples/MAX32690/SPI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/TFT_Demo/.vscode/README.md
+++ b/Examples/MAX32690/TFT_Demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/TFT_Demo/.vscode/settings.json
+++ b/Examples/MAX32690/TFT_Demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/TMR/.vscode/README.md
+++ b/Examples/MAX32690/TMR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/TMR/.vscode/settings.json
+++ b/Examples/MAX32690/TMR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/TRNG/.vscode/README.md
+++ b/Examples/MAX32690/TRNG/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/TRNG/.vscode/settings.json
+++ b/Examples/MAX32690/TRNG/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32690/Temp_Monitor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32690/Temp_Monitor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/UART/.vscode/README.md
+++ b/Examples/MAX32690/UART/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/UART/.vscode/settings.json
+++ b/Examples/MAX32690/UART/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/USB/USB_CDCACM/.vscode/README.md
+++ b/Examples/MAX32690/USB/USB_CDCACM/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/USB/USB_CDCACM/.vscode/settings.json
+++ b/Examples/MAX32690/USB/USB_CDCACM/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/USB/USB_CompositeDevice_MSC_CDC/.vscode/README.md
+++ b/Examples/MAX32690/USB/USB_CompositeDevice_MSC_CDC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/USB/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
+++ b/Examples/MAX32690/USB/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/USB/USB_CompositeDevice_MSC_HID/.vscode/README.md
+++ b/Examples/MAX32690/USB/USB_CompositeDevice_MSC_HID/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/USB/USB_CompositeDevice_MSC_HID/.vscode/settings.json
+++ b/Examples/MAX32690/USB/USB_CompositeDevice_MSC_HID/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/USB/USB_HIDKeyboard/.vscode/README.md
+++ b/Examples/MAX32690/USB/USB_HIDKeyboard/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/USB/USB_HIDKeyboard/.vscode/settings.json
+++ b/Examples/MAX32690/USB/USB_HIDKeyboard/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/USB/USB_MassStorage/.vscode/README.md
+++ b/Examples/MAX32690/USB/USB_MassStorage/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/USB/USB_MassStorage/.vscode/settings.json
+++ b/Examples/MAX32690/USB/USB_MassStorage/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/WUT/.vscode/README.md
+++ b/Examples/MAX32690/WUT/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/WUT/.vscode/settings.json
+++ b/Examples/MAX32690/WUT/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/Watchdog/.vscode/README.md
+++ b/Examples/MAX32690/Watchdog/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32690/Watchdog/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX32690/WearLeveling/.vscode/README.md
+++ b/Examples/MAX32690/WearLeveling/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX32690/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32690/WearLeveling/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/ADC/.vscode/README.md
+++ b/Examples/MAX78000/ADC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/ADC/.vscode/settings.json
+++ b/Examples/MAX78000/ADC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/AES/.vscode/README.md
+++ b/Examples/MAX78000/AES/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/AES/.vscode/settings.json
+++ b/Examples/MAX78000/AES/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX78000/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/UNet-demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/UNet-demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/UNet-demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/UNet-demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/UNet-highres-demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/UNet-highres-demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/UNet-highres-demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/UNet-highres-demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/actionrecognition-demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/actionrecognition-demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/actionrecognition-demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/actionrecognition-demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/aisegment_unet-demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/aisegment_unet-demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/aisegment_unet-demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/aisegment_unet-demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/aisegment_unet/.vscode/README.md
+++ b/Examples/MAX78000/CNN/aisegment_unet/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/aisegment_unet/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/aisegment_unet/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/asl/.vscode/README.md
+++ b/Examples/MAX78000/CNN/asl/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/asl/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/asl/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/asl_demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/asl_demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/asl_demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/asl_demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/cam01_facedetect_demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cam01_facedetect_demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/cam01_facedetect_demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cam01_facedetect_demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/cam02_facedetect_demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cam02_facedetect_demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/cam02_facedetect_demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cam02_facedetect_demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/camvid_unet/.vscode/README.md
+++ b/Examples/MAX78000/CNN/camvid_unet/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/camvid_unet/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/camvid_unet/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/cats-dogs/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cats-dogs/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/cats-dogs/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cats-dogs/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/cats-dogs_demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cats-dogs_demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/cats-dogs_demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cats-dogs_demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/cifar-10-auto-test/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cifar-10-auto-test/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/cifar-10-auto-test/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cifar-10-auto-test/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/cifar-10/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cifar-10/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/cifar-10/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cifar-10/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/cifar-100-mixed/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cifar-100-mixed/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/cifar-100-mixed/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cifar-100-mixed/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/cifar-100-residual/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cifar-100-residual/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/cifar-100-residual/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cifar-100-residual/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/cifar-100/.vscode/README.md
+++ b/Examples/MAX78000/CNN/cifar-100/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/cifar-100/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cifar-100/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/digit-detection-demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/digit-detection-demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/digit-detection-demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/digit-detection-demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/faceid_112/.vscode/README.md
+++ b/Examples/MAX78000/CNN/faceid_112/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/faceid_112/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/faceid_112/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/facial_recognition/.vscode/README.md
+++ b/Examples/MAX78000/CNN/facial_recognition/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/facial_recognition/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/facial_recognition/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/facial_recognition/SDHC_weights/.vscode/README.md
+++ b/Examples/MAX78000/CNN/facial_recognition/SDHC_weights/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/facial_recognition/SDHC_weights/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/facial_recognition/SDHC_weights/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/kws20_demo-riscv/.vscode/README.md
+++ b/Examples/MAX78000/CNN/kws20_demo-riscv/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/kws20_demo-riscv/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/kws20_demo-riscv/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/kws20_demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/kws20_demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/kws20_demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/kws20_demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/kws20_v3/.vscode/README.md
+++ b/Examples/MAX78000/CNN/kws20_v3/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/kws20_v3/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/kws20_v3/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/mnist-riscv/.vscode/README.md
+++ b/Examples/MAX78000/CNN/mnist-riscv/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/mnist-riscv/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/mnist-riscv/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/mnist/.vscode/README.md
+++ b/Examples/MAX78000/CNN/mnist/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/mnist/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/mnist/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/rps-demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/rps-demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/rps-demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/rps-demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/rps/.vscode/README.md
+++ b/Examples/MAX78000/CNN/rps/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/rps/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/rps/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/snake_game_demo/.vscode/README.md
+++ b/Examples/MAX78000/CNN/snake_game_demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/snake_game_demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/snake_game_demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CNN/svhn_tinierssd/.vscode/README.md
+++ b/Examples/MAX78000/CNN/svhn_tinierssd/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CNN/svhn_tinierssd/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/svhn_tinierssd/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CRC/.vscode/README.md
+++ b/Examples/MAX78000/CRC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CRC/.vscode/settings.json
+++ b/Examples/MAX78000/CRC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CameraIF/.vscode/README.md
+++ b/Examples/MAX78000/CameraIF/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CameraIF/.vscode/settings.json
+++ b/Examples/MAX78000/CameraIF/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/CameraIF_Debayer/.vscode/README.md
+++ b/Examples/MAX78000/CameraIF_Debayer/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/CameraIF_Debayer/.vscode/settings.json
+++ b/Examples/MAX78000/CameraIF_Debayer/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/Coremark/.vscode/README.md
+++ b/Examples/MAX78000/Coremark/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/Coremark/.vscode/settings.json
+++ b/Examples/MAX78000/Coremark/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/DMA/.vscode/README.md
+++ b/Examples/MAX78000/DMA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/DMA/.vscode/settings.json
+++ b/Examples/MAX78000/DMA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/ECC/.vscode/README.md
+++ b/Examples/MAX78000/ECC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/ECC/.vscode/settings.json
+++ b/Examples/MAX78000/ECC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX78000/EEPROM_Emulator/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX78000/EEPROM_Emulator/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/FTHR_I2C/.vscode/README.md
+++ b/Examples/MAX78000/FTHR_I2C/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/FTHR_I2C/.vscode/settings.json
+++ b/Examples/MAX78000/FTHR_I2C/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/FTHR_SRAM/.vscode/README.md
+++ b/Examples/MAX78000/FTHR_SRAM/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/FTHR_SRAM/.vscode/settings.json
+++ b/Examples/MAX78000/FTHR_SRAM/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/Flash/.vscode/README.md
+++ b/Examples/MAX78000/Flash/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/Flash/.vscode/settings.json
+++ b/Examples/MAX78000/Flash/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX78000/Flash_CLI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX78000/Flash_CLI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX78000/FreeRTOSDemo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX78000/FreeRTOSDemo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/GPIO/.vscode/README.md
+++ b/Examples/MAX78000/GPIO/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/GPIO/.vscode/settings.json
+++ b/Examples/MAX78000/GPIO/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/Hello_World/.vscode/README.md
+++ b/Examples/MAX78000/Hello_World/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/Hello_World/.vscode/settings.json
+++ b/Examples/MAX78000/Hello_World/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX78000/Hello_World_Cpp/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX78000/Hello_World_Cpp/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/I2C_ADXL343/.vscode/README.md
+++ b/Examples/MAX78000/I2C_ADXL343/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/I2C_ADXL343/.vscode/settings.json
+++ b/Examples/MAX78000/I2C_ADXL343/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX78000/I2C_MNGR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX78000/I2C_MNGR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX78000/I2C_SCAN/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX78000/I2C_SCAN/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX78000/I2C_Sensor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX78000/I2C_Sensor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/I2S/.vscode/README.md
+++ b/Examples/MAX78000/I2S/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/I2S/.vscode/settings.json
+++ b/Examples/MAX78000/I2S/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/I2S_DMA/.vscode/README.md
+++ b/Examples/MAX78000/I2S_DMA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/I2S_DMA/.vscode/settings.json
+++ b/Examples/MAX78000/I2S_DMA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/I2S_DMA_Target/.vscode/README.md
+++ b/Examples/MAX78000/I2S_DMA_Target/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/I2S_DMA_Target/.vscode/settings.json
+++ b/Examples/MAX78000/I2S_DMA_Target/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/ICC/.vscode/README.md
+++ b/Examples/MAX78000/ICC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/ICC/.vscode/settings.json
+++ b/Examples/MAX78000/ICC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/ImgCapture/.vscode/README.md
+++ b/Examples/MAX78000/ImgCapture/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/ImgCapture/.vscode/settings.json
+++ b/Examples/MAX78000/ImgCapture/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/LP/.vscode/README.md
+++ b/Examples/MAX78000/LP/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/LP/.vscode/settings.json
+++ b/Examples/MAX78000/LP/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/LPCMP/.vscode/README.md
+++ b/Examples/MAX78000/LPCMP/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/LPCMP/.vscode/settings.json
+++ b/Examples/MAX78000/LPCMP/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/Library_Use/.vscode/README.md
+++ b/Examples/MAX78000/Library_Use/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/Library_Use/.vscode/settings.json
+++ b/Examples/MAX78000/Library_Use/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/Pulse_Train/.vscode/README.md
+++ b/Examples/MAX78000/Pulse_Train/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/Pulse_Train/.vscode/settings.json
+++ b/Examples/MAX78000/Pulse_Train/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/RTC/.vscode/README.md
+++ b/Examples/MAX78000/RTC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/RTC/.vscode/settings.json
+++ b/Examples/MAX78000/RTC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX78000/RTC_Backup/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX78000/RTC_Backup/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/RV_ARM_Loader/.vscode/README.md
+++ b/Examples/MAX78000/RV_ARM_Loader/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/RV_ARM_Loader/.vscode/settings.json
+++ b/Examples/MAX78000/RV_ARM_Loader/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/SDHC_FTHR/.vscode/README.md
+++ b/Examples/MAX78000/SDHC_FTHR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/SDHC_FTHR/.vscode/settings.json
+++ b/Examples/MAX78000/SDHC_FTHR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/SPI/.vscode/README.md
+++ b/Examples/MAX78000/SPI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/SPI/.vscode/settings.json
+++ b/Examples/MAX78000/SPI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/TFT_Demo/.vscode/README.md
+++ b/Examples/MAX78000/TFT_Demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/TFT_Demo/.vscode/settings.json
+++ b/Examples/MAX78000/TFT_Demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/TMR/.vscode/README.md
+++ b/Examples/MAX78000/TMR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/TMR/.vscode/settings.json
+++ b/Examples/MAX78000/TMR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/TRNG/.vscode/README.md
+++ b/Examples/MAX78000/TRNG/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/TRNG/.vscode/settings.json
+++ b/Examples/MAX78000/TRNG/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX78000/Temp_Monitor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX78000/Temp_Monitor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/UART/.vscode/README.md
+++ b/Examples/MAX78000/UART/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/UART/.vscode/settings.json
+++ b/Examples/MAX78000/UART/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/WUT/.vscode/README.md
+++ b/Examples/MAX78000/WUT/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/WUT/.vscode/settings.json
+++ b/Examples/MAX78000/WUT/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/Watchdog/.vscode/README.md
+++ b/Examples/MAX78000/Watchdog/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/Watchdog/.vscode/settings.json
+++ b/Examples/MAX78000/Watchdog/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78000/WearLeveling/.vscode/README.md
+++ b/Examples/MAX78000/WearLeveling/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78000/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX78000/WearLeveling/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/ADC/.vscode/README.md
+++ b/Examples/MAX78002/ADC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/ADC/.vscode/settings.json
+++ b/Examples/MAX78002/ADC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/AES/.vscode/README.md
+++ b/Examples/MAX78002/AES/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/AES/.vscode/settings.json
+++ b/Examples/MAX78002/AES/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/ARM-DSP/arm_bayes_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_bayes_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/ARM-DSP/arm_class_marks_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_class_marks_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/ARM-DSP/arm_convolution_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_convolution_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/ARM-DSP/arm_fir_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_fir_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/ARM-DSP/arm_matrix_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_matrix_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/ARM-DSP/arm_svm_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_svm_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/ARM-DSP/arm_variance_example/.vscode/README.md
+++ b/Examples/MAX78002/ARM-DSP/arm_variance_example/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/CNN/cifar-100-effnet2/.vscode/README.md
+++ b/Examples/MAX78002/CNN/cifar-100-effnet2/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/CNN/cifar-100-effnet2/.vscode/settings.json
+++ b/Examples/MAX78002/CNN/cifar-100-effnet2/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/CNN/facial_recognition/.vscode/README.md
+++ b/Examples/MAX78002/CNN/facial_recognition/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/CNN/facial_recognition/.vscode/settings.json
+++ b/Examples/MAX78002/CNN/facial_recognition/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/CNN/imagenet-riscv/.vscode/README.md
+++ b/Examples/MAX78002/CNN/imagenet-riscv/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/CNN/imagenet-riscv/.vscode/settings.json
+++ b/Examples/MAX78002/CNN/imagenet-riscv/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/CNN/imagenet/.vscode/README.md
+++ b/Examples/MAX78002/CNN/imagenet/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/CNN/imagenet/.vscode/settings.json
+++ b/Examples/MAX78002/CNN/imagenet/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/CNN/kinetics/.vscode/README.md
+++ b/Examples/MAX78002/CNN/kinetics/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/CNN/kinetics/.vscode/settings.json
+++ b/Examples/MAX78002/CNN/kinetics/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/CNN/kws20_demo/.vscode/README.md
+++ b/Examples/MAX78002/CNN/kws20_demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/CNN/kws20_demo/.vscode/settings.json
+++ b/Examples/MAX78002/CNN/kws20_demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/CNN/mobilefacenet-112/.vscode/README.md
+++ b/Examples/MAX78002/CNN/mobilefacenet-112/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/CNN/mobilefacenet-112/.vscode/settings.json
+++ b/Examples/MAX78002/CNN/mobilefacenet-112/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/.vscode/README.md
+++ b/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/.vscode/settings.json
+++ b/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/CRC/.vscode/README.md
+++ b/Examples/MAX78002/CRC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/CRC/.vscode/settings.json
+++ b/Examples/MAX78002/CRC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/CSI2/.vscode/README.md
+++ b/Examples/MAX78002/CSI2/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/CSI2/.vscode/settings.json
+++ b/Examples/MAX78002/CSI2/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/CameraIF/.vscode/README.md
+++ b/Examples/MAX78002/CameraIF/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/CameraIF/.vscode/settings.json
+++ b/Examples/MAX78002/CameraIF/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/CameraIF_Debayer/.vscode/README.md
+++ b/Examples/MAX78002/CameraIF_Debayer/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/CameraIF_Debayer/.vscode/settings.json
+++ b/Examples/MAX78002/CameraIF_Debayer/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/Coremark/.vscode/README.md
+++ b/Examples/MAX78002/Coremark/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/Coremark/.vscode/settings.json
+++ b/Examples/MAX78002/Coremark/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/DMA/.vscode/README.md
+++ b/Examples/MAX78002/DMA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/DMA/.vscode/settings.json
+++ b/Examples/MAX78002/DMA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/ECC/.vscode/README.md
+++ b/Examples/MAX78002/ECC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/ECC/.vscode/settings.json
+++ b/Examples/MAX78002/ECC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/EEPROM_Emulator/.vscode/README.md
+++ b/Examples/MAX78002/EEPROM_Emulator/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX78002/EEPROM_Emulator/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/Flash/.vscode/README.md
+++ b/Examples/MAX78002/Flash/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/Flash/.vscode/settings.json
+++ b/Examples/MAX78002/Flash/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/Flash_CLI/.vscode/README.md
+++ b/Examples/MAX78002/Flash_CLI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX78002/Flash_CLI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/FreeRTOSDemo/.vscode/README.md
+++ b/Examples/MAX78002/FreeRTOSDemo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX78002/FreeRTOSDemo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/GPIO/.vscode/README.md
+++ b/Examples/MAX78002/GPIO/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/GPIO/.vscode/settings.json
+++ b/Examples/MAX78002/GPIO/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/Hello_World/.vscode/README.md
+++ b/Examples/MAX78002/Hello_World/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/Hello_World/.vscode/settings.json
+++ b/Examples/MAX78002/Hello_World/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/Hello_World_Cpp/.vscode/README.md
+++ b/Examples/MAX78002/Hello_World_Cpp/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX78002/Hello_World_Cpp/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/I2C/.vscode/README.md
+++ b/Examples/MAX78002/I2C/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/I2C/.vscode/settings.json
+++ b/Examples/MAX78002/I2C/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/I2C_MNGR/.vscode/README.md
+++ b/Examples/MAX78002/I2C_MNGR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX78002/I2C_MNGR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/I2C_SCAN/.vscode/README.md
+++ b/Examples/MAX78002/I2C_SCAN/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX78002/I2C_SCAN/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/I2C_Sensor/.vscode/README.md
+++ b/Examples/MAX78002/I2C_Sensor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX78002/I2C_Sensor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/I2S/.vscode/README.md
+++ b/Examples/MAX78002/I2S/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/I2S/.vscode/settings.json
+++ b/Examples/MAX78002/I2S/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/I2S_DMA/.vscode/README.md
+++ b/Examples/MAX78002/I2S_DMA/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/I2S_DMA/.vscode/settings.json
+++ b/Examples/MAX78002/I2S_DMA/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/ICC/.vscode/README.md
+++ b/Examples/MAX78002/ICC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/ICC/.vscode/settings.json
+++ b/Examples/MAX78002/ICC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/ImgCapture/.vscode/README.md
+++ b/Examples/MAX78002/ImgCapture/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/ImgCapture/.vscode/settings.json
+++ b/Examples/MAX78002/ImgCapture/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/LP/.vscode/README.md
+++ b/Examples/MAX78002/LP/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/LP/.vscode/settings.json
+++ b/Examples/MAX78002/LP/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/LPCMP/.vscode/README.md
+++ b/Examples/MAX78002/LPCMP/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/LPCMP/.vscode/settings.json
+++ b/Examples/MAX78002/LPCMP/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/Library_Use/.vscode/README.md
+++ b/Examples/MAX78002/Library_Use/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/Library_Use/.vscode/settings.json
+++ b/Examples/MAX78002/Library_Use/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/Pulse_Train/.vscode/README.md
+++ b/Examples/MAX78002/Pulse_Train/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/Pulse_Train/.vscode/settings.json
+++ b/Examples/MAX78002/Pulse_Train/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/QSPI/.vscode/README.md
+++ b/Examples/MAX78002/QSPI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/QSPI/.vscode/settings.json
+++ b/Examples/MAX78002/QSPI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/RTC/.vscode/README.md
+++ b/Examples/MAX78002/RTC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/RTC/.vscode/settings.json
+++ b/Examples/MAX78002/RTC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/RTC_Backup/.vscode/README.md
+++ b/Examples/MAX78002/RTC_Backup/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX78002/RTC_Backup/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/RV_ARM_Loader/.vscode/README.md
+++ b/Examples/MAX78002/RV_ARM_Loader/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/RV_ARM_Loader/.vscode/settings.json
+++ b/Examples/MAX78002/RV_ARM_Loader/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/SDHC_FAT/.vscode/README.md
+++ b/Examples/MAX78002/SDHC_FAT/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/SDHC_FAT/.vscode/settings.json
+++ b/Examples/MAX78002/SDHC_FAT/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/SDHC_Raw/.vscode/README.md
+++ b/Examples/MAX78002/SDHC_Raw/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/SDHC_Raw/.vscode/settings.json
+++ b/Examples/MAX78002/SDHC_Raw/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/SPI/.vscode/README.md
+++ b/Examples/MAX78002/SPI/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/SPI/.vscode/settings.json
+++ b/Examples/MAX78002/SPI/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/SPI_ControllerTarget/.vscode/README.md
+++ b/Examples/MAX78002/SPI_ControllerTarget/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/SPI_ControllerTarget/.vscode/settings.json
+++ b/Examples/MAX78002/SPI_ControllerTarget/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/SPI_MasterSlave/.vscode/README.md
+++ b/Examples/MAX78002/SPI_MasterSlave/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/SPI_MasterSlave/.vscode/settings.json
+++ b/Examples/MAX78002/SPI_MasterSlave/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/TFT_Demo/.vscode/README.md
+++ b/Examples/MAX78002/TFT_Demo/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/TFT_Demo/.vscode/settings.json
+++ b/Examples/MAX78002/TFT_Demo/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/TMR/.vscode/README.md
+++ b/Examples/MAX78002/TMR/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/TMR/.vscode/settings.json
+++ b/Examples/MAX78002/TMR/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/TRNG/.vscode/README.md
+++ b/Examples/MAX78002/TRNG/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/TRNG/.vscode/settings.json
+++ b/Examples/MAX78002/TRNG/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX78002/Temp_Monitor/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX78002/Temp_Monitor/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/UART/.vscode/README.md
+++ b/Examples/MAX78002/UART/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/UART/.vscode/settings.json
+++ b/Examples/MAX78002/UART/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/USB/USB_CDCACM/.vscode/README.md
+++ b/Examples/MAX78002/USB/USB_CDCACM/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/USB/USB_CDCACM/.vscode/settings.json
+++ b/Examples/MAX78002/USB/USB_CDCACM/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/USB/USB_CompositeDevice_MSC_CDC/.vscode/README.md
+++ b/Examples/MAX78002/USB/USB_CompositeDevice_MSC_CDC/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/USB/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
+++ b/Examples/MAX78002/USB/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/USB/USB_CompositeDevice_MSC_HID/.vscode/README.md
+++ b/Examples/MAX78002/USB/USB_CompositeDevice_MSC_HID/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/USB/USB_CompositeDevice_MSC_HID/.vscode/settings.json
+++ b/Examples/MAX78002/USB/USB_CompositeDevice_MSC_HID/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/USB/USB_HIDKeyboard/.vscode/README.md
+++ b/Examples/MAX78002/USB/USB_HIDKeyboard/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/USB/USB_HIDKeyboard/.vscode/settings.json
+++ b/Examples/MAX78002/USB/USB_HIDKeyboard/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/USB/USB_MassStorage/.vscode/README.md
+++ b/Examples/MAX78002/USB/USB_MassStorage/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/USB/USB_MassStorage/.vscode/settings.json
+++ b/Examples/MAX78002/USB/USB_MassStorage/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/USB/USB_MassStorage_ThroughPut/.vscode/README.md
+++ b/Examples/MAX78002/USB/USB_MassStorage_ThroughPut/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/USB/USB_MassStorage_ThroughPut/.vscode/settings.json
+++ b/Examples/MAX78002/USB/USB_MassStorage_ThroughPut/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/WUT/.vscode/README.md
+++ b/Examples/MAX78002/WUT/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/WUT/.vscode/settings.json
+++ b/Examples/MAX78002/WUT/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/Watchdog/.vscode/README.md
+++ b/Examples/MAX78002/Watchdog/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/Watchdog/.vscode/settings.json
+++ b/Examples/MAX78002/Watchdog/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     

--- a/Examples/MAX78002/WearLeveling/.vscode/README.md
+++ b/Examples/MAX78002/WearLeveling/.vscode/README.md
@@ -5,11 +5,11 @@ _(If you're viewing this document from within Visual Studio Code you can press `
 ## Quick Links
 
 * [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)
-* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [VSCode-Maxim Github](https://github.com/analogdevicesinc/VSCode-Maxim)
 
 ## Introduction
 
-VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/analogdevicesinc/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
 
 The following features are supported:
 
@@ -37,7 +37,7 @@ See the [MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/#vis
 
 ## Issue Tracker
 
-Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/analogdevicesinc/VSCode-Maxim/issues) tracker on Github.
 
 New issues should contain _at minimum_ the following information:
 

--- a/Examples/MAX78002/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX78002/WearLeveling/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:{env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     


### PR DESCRIPTION
## Pull Request Template

### Description

As caught by https://github.com/analogdevicesinc/msdk/commit/a89a913960e8daf869f6236873d2e33fcd7eed5d#r139009506, PR #918 introduced a critical typo that broke the entire PATH on MacOS for the VSCode-Maxim projects...

This PR regenerates the example files and further fixes some broken URLs in the README.  

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.


