### PR TITLE
fix(PeriphDrivers): Update INRO clock Enum name for MAX32662.

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32662/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/tmr.h
@@ -149,8 +149,8 @@ typedef enum {
     MXC_TMR_8M_CLK,
     /*32K clock can be used for Timers 0,1,2,3 and 4*/
     MXC_TMR_32K_CLK,
-    /*8K and EXT clocks can only be used for Timers 4 and 5*/
-    MXC_TMR_8K_CLK,
+    /*80K and EXT clocks can only be used for Timers 4 and 5*/
+    MXC_TMR_80K_CLK
 } mxc_tmr_clock_t;
 
 /**

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me12.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me12.c
@@ -66,7 +66,7 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins, sys_ma
         MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, ERTCO_FREQ);
         break;
 
-    case MXC_TMR_8K_CLK:
+    case MXC_TMR_80K_CLK:
         if (tmr_id < 3) { // Timers 0-2 do not support this clock source
             return E_NOT_SUPPORTED;
         }
@@ -242,7 +242,7 @@ uint32_t MXC_TMR_GetPeriod(mxc_tmr_regs_t *tmr, mxc_tmr_clock_t clock, uint32_t 
             clockFrequency = ERTCO_FREQ;
             break;
 
-        case MXC_TMR_8K_CLK:
+        case MXC_TMR_80K_CLK:
             clockFrequency = INRO_FREQ;
             break;
 


### PR DESCRIPTION
Rename INRO clock Enum definition for MAX32662. See #895 