### PR TITLE
fix(BLE): PalTimer Calibration

### DIFF
--- a/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_timer.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_timer.c
@@ -317,7 +317,7 @@ void PalTimerDeInit(void)
 /*************************************************************************************************/
 /*!
  *  \brief      Return scheduler timer state.
- 
+
  */
 /*************************************************************************************************/
 void PalTimerExecCallback(void)
@@ -359,6 +359,9 @@ void PalTimerStart(uint32_t expUsec)
 
     /* Convert the time based on our calibration */
     expUsec += (expUsec / PAL_TMR_CALIB_TIME_US) * palTimerCb.usecDiff;
+    expUsec += ((((int32_t)expUsec % PAL_TMR_CALIB_TIME_US) * palTimerCb.usecDiff) /
+                PAL_TMR_CALIB_TIME_US);
+
 #if defined(USE_SHARED_WUT)
     PalSysSetBusy();
     uint64_t volatile compareValue;

--- a/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_timer.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_timer.c
@@ -266,7 +266,7 @@ void PalTimerDeInit(void)
 /*************************************************************************************************/
 /*!
  *  \brief      Return scheduler timer state.
- 
+
  */
 /*************************************************************************************************/
 void PalTimerExecCallback(void)
@@ -309,6 +309,8 @@ void PalTimerStart(uint32_t expUsec)
 
     /* Convert the time based on our calibration */
     expUsec += (expUsec / PAL_TMR_CALIB_TIME) * palTimerCb.usecDiff;
+    expUsec +=
+        ((((int32_t)expUsec % PAL_TMR_CALIB_TIME) * palTimerCb.usecDiff) / PAL_TMR_CALIB_TIME);
 
     /* Convert the start time to ticks */
     MXC_TMR_SetCount(PAL_TMR, 0);


### PR DESCRIPTION
Updated the code for calibrating the PalTimer against the 32MHz clock.  Original implementation only added adjustment on 100ms (PAL_TMR_CALIB_TIME) boundaries.  In cases where the timer time was in between 100ms intervals, the timer could be severely early or late depending on how large usecDiff is.
``
The math could be accomplished by simply running `(expUsec * palTimerCb.usecDiff) / PAL_TMR_CALIB_TIME;` however there is not enough objective evidence for the max values of expUsec and usecDiff to show the multiplication won't overflow 32-bits.  The math could be done in 64-bits, however the modulo method was used to keep this within a 32-bit scope.
