### PR TITLE
feat(PeriphDrivers): Add OTP Powerdown feature for MAX32572

### DIFF
--- a/Examples/MAX78000/CNN/facial_recognition/include/ffconf.h
+++ b/Examples/MAX78000/CNN/facial_recognition/include/ffconf.h
@@ -2,20 +2,19 @@
 /  Configurations of FatFs Module
 /---------------------------------------------------------------------------*/
 
-#define FFCONF_DEF	80286	/* Revision ID */
+#define FFCONF_DEF 80286 /* Revision ID */
 
 /*---------------------------------------------------------------------------/
 / Function Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_FS_READONLY	0
+#define FF_FS_READONLY 0
 /* This option switches read-only configuration. (0:Read/Write or 1:Read-only)
 /  Read-only configuration removes writing API functions, f_write(), f_sync(),
 /  f_unlink(), f_mkdir(), f_chmod(), f_rename(), f_truncate(), f_getfree()
 /  and optional writing functions as well. */
 
-
-#define FF_FS_MINIMIZE	0
+#define FF_FS_MINIMIZE 0
 /* This option defines minimization level to remove some basic API functions.
 /
 /   0: Basic functions are fully enabled.
@@ -24,42 +23,34 @@
 /   2: f_opendir(), f_readdir() and f_closedir() are removed in addition to 1.
 /   3: f_lseek() function is removed in addition to 2. */
 
-
-#define FF_USE_FIND		0
+#define FF_USE_FIND 0
 /* This option switches filtered directory read functions, f_findfirst() and
 /  f_findnext(). (0:Disable, 1:Enable 2:Enable with matching altname[] too) */
 
-
-#define FF_USE_MKFS		1
+#define FF_USE_MKFS 1
 /* This option switches f_mkfs() function. (0:Disable or 1:Enable) */
 
-
-#define FF_USE_FASTSEEK	0
+#define FF_USE_FASTSEEK 0
 /* This option switches fast seek function. (0:Disable or 1:Enable) */
 
-
-#define FF_USE_EXPAND	0
+#define FF_USE_EXPAND 0
 /* This option switches f_expand function. (0:Disable or 1:Enable) */
 
-
-#define FF_USE_CHMOD	1
+#define FF_USE_CHMOD 1
 /* This option switches attribute manipulation functions, f_chmod() and f_utime().
 /  (0:Disable or 1:Enable) Also FF_FS_READONLY needs to be 0 to enable this option. */
 
-
-#define FF_USE_LABEL	1
+#define FF_USE_LABEL 1
 /* This option switches volume label functions, f_getlabel() and f_setlabel().
 /  (0:Disable or 1:Enable) */
 
-
-#define FF_USE_FORWARD	1
+#define FF_USE_FORWARD 1
 /* This option switches f_forward() function. (0:Disable or 1:Enable) */
 
-
-#define FF_USE_STRFUNC	0
-#define FF_PRINT_LLI	1
-#define FF_PRINT_FLOAT	1
-#define FF_STRF_ENCODE	3
+#define FF_USE_STRFUNC 0
+#define FF_PRINT_LLI 1
+#define FF_PRINT_FLOAT 1
+#define FF_STRF_ENCODE 3
 /* FF_USE_STRFUNC switches string functions, f_gets(), f_putc(), f_puts() and
 /  f_printf().
 /
@@ -79,12 +70,11 @@
 /   3: Unicode in UTF-8
 */
 
-
 /*---------------------------------------------------------------------------/
 / Locale and Namespace Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_CODE_PAGE	932
+#define FF_CODE_PAGE 932
 /* This option specifies the OEM code page to be used on the target system.
 /  Incorrect code page setting can cause a file open failure.
 /
@@ -112,9 +102,8 @@
 /     0 - Include all code pages above and configured by f_setcp()
 */
 
-
-#define FF_USE_LFN		1
-#define FF_MAX_LFN		255
+#define FF_USE_LFN 1
+#define FF_MAX_LFN 255
 /* The FF_USE_LFN switches the support for LFN (long file name).
 /
 /   0: Disable LFN. FF_MAX_LFN has no effect.
@@ -132,8 +121,7 @@
 /  memory for the working buffer, memory management functions, ff_memalloc() and
 /  ff_memfree() exemplified in ffsystem.c, need to be added to the project. */
 
-
-#define FF_LFN_UNICODE	0
+#define FF_LFN_UNICODE 0
 /* This option switches the character encoding on the API when LFN is enabled.
 /
 /   0: ANSI/OEM in current CP (TCHAR = char)
@@ -144,16 +132,14 @@
 /  Also behavior of string I/O functions will be affected by this option.
 /  When LFN is not enabled, this option has no effect. */
 
-
-#define FF_LFN_BUF		255
-#define FF_SFN_BUF		12
+#define FF_LFN_BUF 255
+#define FF_SFN_BUF 12
 /* This set of options defines size of file name members in the FILINFO structure
 /  which is used to read out directory items. These values should be suffcient for
 /  the file names to read. The maximum possible length of the read file name depends
 /  on character encoding. When LFN is not enabled, these options have no effect. */
 
-
-#define FF_FS_RPATH		2
+#define FF_FS_RPATH 2
 /* This option configures support for relative path.
 /
 /   0: Disable relative path and remove related functions.
@@ -161,17 +147,15 @@
 /   2: f_getcwd() function is available in addition to 1.
 */
 
-
 /*---------------------------------------------------------------------------/
 / Drive/Volume Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_VOLUMES		1
+#define FF_VOLUMES 1
 /* Number of volumes (logical drives) to be used. (1-10) */
 
-
-#define FF_STR_VOLUME_ID	0
-#define FF_VOLUME_STRS		"RAM","NAND","CF","SD","SD2","USB","USB2","USB3"
+#define FF_STR_VOLUME_ID 0
+#define FF_VOLUME_STRS "RAM", "NAND", "CF", "SD", "SD2", "USB", "USB2", "USB3"
 /* FF_STR_VOLUME_ID switches support for volume ID in arbitrary strings.
 /  When FF_STR_VOLUME_ID is set to 1 or 2, arbitrary strings can be used as drive
 /  number in the path name. FF_VOLUME_STRS defines the volume ID strings for each
@@ -183,8 +167,7 @@
 /  const char* VolumeStr[FF_VOLUMES] = {"ram","flash","sd","usb",...
 */
 
-
-#define FF_MULTI_PARTITION	0
+#define FF_MULTI_PARTITION 0
 /* This option switches support for multiple volumes on the physical drive.
 /  By default (0), each logical drive number is bound to the same physical drive
 /  number and only an FAT volume found on the physical drive will be mounted.
@@ -192,9 +175,8 @@
 /  arbitrary physical drive and partition listed in the VolToPart[]. Also f_fdisk()
 /  function will be available. */
 
-
-#define FF_MIN_SS		512
-#define FF_MAX_SS		512
+#define FF_MIN_SS 512
+#define FF_MAX_SS 512
 /* This set of options configures the range of sector size to be supported. (512,
 /  1024, 2048 or 4096) Always set both 512 for most systems, generic memory card and
 /  harddisk, but a larger value may be required for on-board flash memory and some
@@ -202,45 +184,38 @@
 /  for variable sector size mode and disk_ioctl() function needs to implement
 /  GET_SECTOR_SIZE command. */
 
-
-#define FF_LBA64		0
+#define FF_LBA64 0
 /* This option switches support for 64-bit LBA. (0:Disable or 1:Enable)
 /  To enable the 64-bit LBA, also exFAT needs to be enabled. (FF_FS_EXFAT == 1) */
 
-
-#define FF_MIN_GPT		0x10000000
+#define FF_MIN_GPT 0x10000000
 /* Minimum number of sectors to switch GPT as partitioning format in f_mkfs and
 /  f_fdisk function. 0x100000000 max. This option has no effect when FF_LBA64 == 0. */
 
-
-#define FF_USE_TRIM		0
+#define FF_USE_TRIM 0
 /* This option switches support for ATA-TRIM. (0:Disable or 1:Enable)
 /  To enable Trim function, also CTRL_TRIM command should be implemented to the
 /  disk_ioctl() function. */
-
-
 
 /*---------------------------------------------------------------------------/
 / System Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_FS_TINY		0
+#define FF_FS_TINY 0
 /* This option switches tiny buffer configuration. (0:Normal or 1:Tiny)
 /  At the tiny configuration, size of file object (FIL) is shrinked FF_MAX_SS bytes.
 /  Instead of private sector buffer eliminated from the file object, common sector
 /  buffer in the filesystem object (FATFS) is used for the file data transfer. */
 
-
-#define FF_FS_EXFAT		0
+#define FF_FS_EXFAT 0
 /* This option switches support for exFAT filesystem. (0:Disable or 1:Enable)
 /  To enable exFAT, also LFN needs to be enabled. (FF_USE_LFN >= 1)
 /  Note that enabling exFAT discards ANSI C (C89) compatibility. */
 
-
-#define FF_FS_NORTC		1
-#define FF_NORTC_MON	1
-#define FF_NORTC_MDAY	1
-#define FF_NORTC_YEAR	2022
+#define FF_FS_NORTC 1
+#define FF_NORTC_MON 1
+#define FF_NORTC_MDAY 1
+#define FF_NORTC_YEAR 2022
 /* The option FF_FS_NORTC switches timestamp feature. If the system does not have
 /  an RTC or valid timestamp is not needed, set FF_FS_NORTC = 1 to disable the
 /  timestamp feature. Every object modified by FatFs will have a fixed timestamp
@@ -250,8 +225,7 @@
 /  FF_NORTC_MDAY and FF_NORTC_YEAR have no effect.
 /  These options have no effect in read-only configuration (FF_FS_READONLY = 1). */
 
-
-#define FF_FS_NOFSINFO	0
+#define FF_FS_NOFSINFO 0
 /* If you need to know correct free space on the FAT32 volume, set bit 0 of this
 /  option, and f_getfree() function at the first time after volume mount will force
 /  a full FAT scan. Bit 1 controls the use of last allocated cluster number.
@@ -262,8 +236,7 @@
 /  bit1=1: Do not trust last allocated cluster number in the FSINFO.
 */
 
-
-#define FF_FS_LOCK		0
+#define FF_FS_LOCK 0
 /* The option FF_FS_LOCK switches file lock function to control duplicated file open
 /  and illegal operation to open objects. This option must be 0 when FF_FS_READONLY
 /  is 1.
@@ -274,9 +247,8 @@
 /      can be opened simultaneously under file lock control. Note that the file
 /      lock control is independent of re-entrancy. */
 
-
-#define FF_FS_REENTRANT	0
-#define FF_FS_TIMEOUT	1000
+#define FF_FS_REENTRANT 0
+#define FF_FS_TIMEOUT 1000
 /* The option FF_FS_REENTRANT switches the re-entrancy (thread safe) of the FatFs
 /  module itself. Note that regardless of this option, file access to different
 /  volume is always re-entrant and volume control functions, f_mount(), f_mkfs()
@@ -290,7 +262,5 @@
 /
 /  The FF_FS_TIMEOUT defines timeout period in unit of O/S time tick.
 */
-
-
 
 /*--- End of configuration options ---*/

--- a/Examples/MAX78000/CNN/facial_recognition/include/ffconf.h
+++ b/Examples/MAX78000/CNN/facial_recognition/include/ffconf.h
@@ -2,19 +2,20 @@
 /  Configurations of FatFs Module
 /---------------------------------------------------------------------------*/
 
-#define FFCONF_DEF 80286 /* Revision ID */
+#define FFCONF_DEF	80286	/* Revision ID */
 
 /*---------------------------------------------------------------------------/
 / Function Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_FS_READONLY 0
+#define FF_FS_READONLY	0
 /* This option switches read-only configuration. (0:Read/Write or 1:Read-only)
 /  Read-only configuration removes writing API functions, f_write(), f_sync(),
 /  f_unlink(), f_mkdir(), f_chmod(), f_rename(), f_truncate(), f_getfree()
 /  and optional writing functions as well. */
 
-#define FF_FS_MINIMIZE 0
+
+#define FF_FS_MINIMIZE	0
 /* This option defines minimization level to remove some basic API functions.
 /
 /   0: Basic functions are fully enabled.
@@ -23,34 +24,42 @@
 /   2: f_opendir(), f_readdir() and f_closedir() are removed in addition to 1.
 /   3: f_lseek() function is removed in addition to 2. */
 
-#define FF_USE_FIND 0
+
+#define FF_USE_FIND		0
 /* This option switches filtered directory read functions, f_findfirst() and
 /  f_findnext(). (0:Disable, 1:Enable 2:Enable with matching altname[] too) */
 
-#define FF_USE_MKFS 1
+
+#define FF_USE_MKFS		1
 /* This option switches f_mkfs() function. (0:Disable or 1:Enable) */
 
-#define FF_USE_FASTSEEK 0
+
+#define FF_USE_FASTSEEK	0
 /* This option switches fast seek function. (0:Disable or 1:Enable) */
 
-#define FF_USE_EXPAND 0
+
+#define FF_USE_EXPAND	0
 /* This option switches f_expand function. (0:Disable or 1:Enable) */
 
-#define FF_USE_CHMOD 1
+
+#define FF_USE_CHMOD	1
 /* This option switches attribute manipulation functions, f_chmod() and f_utime().
 /  (0:Disable or 1:Enable) Also FF_FS_READONLY needs to be 0 to enable this option. */
 
-#define FF_USE_LABEL 1
+
+#define FF_USE_LABEL	1
 /* This option switches volume label functions, f_getlabel() and f_setlabel().
 /  (0:Disable or 1:Enable) */
 
-#define FF_USE_FORWARD 1
+
+#define FF_USE_FORWARD	1
 /* This option switches f_forward() function. (0:Disable or 1:Enable) */
 
-#define FF_USE_STRFUNC 0
-#define FF_PRINT_LLI 1
-#define FF_PRINT_FLOAT 1
-#define FF_STRF_ENCODE 3
+
+#define FF_USE_STRFUNC	0
+#define FF_PRINT_LLI	1
+#define FF_PRINT_FLOAT	1
+#define FF_STRF_ENCODE	3
 /* FF_USE_STRFUNC switches string functions, f_gets(), f_putc(), f_puts() and
 /  f_printf().
 /
@@ -70,11 +79,12 @@
 /   3: Unicode in UTF-8
 */
 
+
 /*---------------------------------------------------------------------------/
 / Locale and Namespace Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_CODE_PAGE 932
+#define FF_CODE_PAGE	932
 /* This option specifies the OEM code page to be used on the target system.
 /  Incorrect code page setting can cause a file open failure.
 /
@@ -102,8 +112,9 @@
 /     0 - Include all code pages above and configured by f_setcp()
 */
 
-#define FF_USE_LFN 1
-#define FF_MAX_LFN 255
+
+#define FF_USE_LFN		1
+#define FF_MAX_LFN		255
 /* The FF_USE_LFN switches the support for LFN (long file name).
 /
 /   0: Disable LFN. FF_MAX_LFN has no effect.
@@ -121,7 +132,8 @@
 /  memory for the working buffer, memory management functions, ff_memalloc() and
 /  ff_memfree() exemplified in ffsystem.c, need to be added to the project. */
 
-#define FF_LFN_UNICODE 0
+
+#define FF_LFN_UNICODE	0
 /* This option switches the character encoding on the API when LFN is enabled.
 /
 /   0: ANSI/OEM in current CP (TCHAR = char)
@@ -132,14 +144,16 @@
 /  Also behavior of string I/O functions will be affected by this option.
 /  When LFN is not enabled, this option has no effect. */
 
-#define FF_LFN_BUF 255
-#define FF_SFN_BUF 12
+
+#define FF_LFN_BUF		255
+#define FF_SFN_BUF		12
 /* This set of options defines size of file name members in the FILINFO structure
 /  which is used to read out directory items. These values should be suffcient for
 /  the file names to read. The maximum possible length of the read file name depends
 /  on character encoding. When LFN is not enabled, these options have no effect. */
 
-#define FF_FS_RPATH 2
+
+#define FF_FS_RPATH		2
 /* This option configures support for relative path.
 /
 /   0: Disable relative path and remove related functions.
@@ -147,15 +161,17 @@
 /   2: f_getcwd() function is available in addition to 1.
 */
 
+
 /*---------------------------------------------------------------------------/
 / Drive/Volume Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_VOLUMES 1
+#define FF_VOLUMES		1
 /* Number of volumes (logical drives) to be used. (1-10) */
 
-#define FF_STR_VOLUME_ID 0
-#define FF_VOLUME_STRS "RAM", "NAND", "CF", "SD", "SD2", "USB", "USB2", "USB3"
+
+#define FF_STR_VOLUME_ID	0
+#define FF_VOLUME_STRS		"RAM","NAND","CF","SD","SD2","USB","USB2","USB3"
 /* FF_STR_VOLUME_ID switches support for volume ID in arbitrary strings.
 /  When FF_STR_VOLUME_ID is set to 1 or 2, arbitrary strings can be used as drive
 /  number in the path name. FF_VOLUME_STRS defines the volume ID strings for each
@@ -167,7 +183,8 @@
 /  const char* VolumeStr[FF_VOLUMES] = {"ram","flash","sd","usb",...
 */
 
-#define FF_MULTI_PARTITION 0
+
+#define FF_MULTI_PARTITION	0
 /* This option switches support for multiple volumes on the physical drive.
 /  By default (0), each logical drive number is bound to the same physical drive
 /  number and only an FAT volume found on the physical drive will be mounted.
@@ -175,8 +192,9 @@
 /  arbitrary physical drive and partition listed in the VolToPart[]. Also f_fdisk()
 /  function will be available. */
 
-#define FF_MIN_SS 512
-#define FF_MAX_SS 512
+
+#define FF_MIN_SS		512
+#define FF_MAX_SS		512
 /* This set of options configures the range of sector size to be supported. (512,
 /  1024, 2048 or 4096) Always set both 512 for most systems, generic memory card and
 /  harddisk, but a larger value may be required for on-board flash memory and some
@@ -184,38 +202,45 @@
 /  for variable sector size mode and disk_ioctl() function needs to implement
 /  GET_SECTOR_SIZE command. */
 
-#define FF_LBA64 0
+
+#define FF_LBA64		0
 /* This option switches support for 64-bit LBA. (0:Disable or 1:Enable)
 /  To enable the 64-bit LBA, also exFAT needs to be enabled. (FF_FS_EXFAT == 1) */
 
-#define FF_MIN_GPT 0x10000000
+
+#define FF_MIN_GPT		0x10000000
 /* Minimum number of sectors to switch GPT as partitioning format in f_mkfs and
 /  f_fdisk function. 0x100000000 max. This option has no effect when FF_LBA64 == 0. */
 
-#define FF_USE_TRIM 0
+
+#define FF_USE_TRIM		0
 /* This option switches support for ATA-TRIM. (0:Disable or 1:Enable)
 /  To enable Trim function, also CTRL_TRIM command should be implemented to the
 /  disk_ioctl() function. */
+
+
 
 /*---------------------------------------------------------------------------/
 / System Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_FS_TINY 0
+#define FF_FS_TINY		0
 /* This option switches tiny buffer configuration. (0:Normal or 1:Tiny)
 /  At the tiny configuration, size of file object (FIL) is shrinked FF_MAX_SS bytes.
 /  Instead of private sector buffer eliminated from the file object, common sector
 /  buffer in the filesystem object (FATFS) is used for the file data transfer. */
 
-#define FF_FS_EXFAT 0
+
+#define FF_FS_EXFAT		0
 /* This option switches support for exFAT filesystem. (0:Disable or 1:Enable)
 /  To enable exFAT, also LFN needs to be enabled. (FF_USE_LFN >= 1)
 /  Note that enabling exFAT discards ANSI C (C89) compatibility. */
 
-#define FF_FS_NORTC 1
-#define FF_NORTC_MON 1
-#define FF_NORTC_MDAY 1
-#define FF_NORTC_YEAR 2022
+
+#define FF_FS_NORTC		1
+#define FF_NORTC_MON	1
+#define FF_NORTC_MDAY	1
+#define FF_NORTC_YEAR	2022
 /* The option FF_FS_NORTC switches timestamp feature. If the system does not have
 /  an RTC or valid timestamp is not needed, set FF_FS_NORTC = 1 to disable the
 /  timestamp feature. Every object modified by FatFs will have a fixed timestamp
@@ -225,7 +250,8 @@
 /  FF_NORTC_MDAY and FF_NORTC_YEAR have no effect.
 /  These options have no effect in read-only configuration (FF_FS_READONLY = 1). */
 
-#define FF_FS_NOFSINFO 0
+
+#define FF_FS_NOFSINFO	0
 /* If you need to know correct free space on the FAT32 volume, set bit 0 of this
 /  option, and f_getfree() function at the first time after volume mount will force
 /  a full FAT scan. Bit 1 controls the use of last allocated cluster number.
@@ -236,7 +262,8 @@
 /  bit1=1: Do not trust last allocated cluster number in the FSINFO.
 */
 
-#define FF_FS_LOCK 0
+
+#define FF_FS_LOCK		0
 /* The option FF_FS_LOCK switches file lock function to control duplicated file open
 /  and illegal operation to open objects. This option must be 0 when FF_FS_READONLY
 /  is 1.
@@ -247,8 +274,9 @@
 /      can be opened simultaneously under file lock control. Note that the file
 /      lock control is independent of re-entrancy. */
 
-#define FF_FS_REENTRANT 0
-#define FF_FS_TIMEOUT 1000
+
+#define FF_FS_REENTRANT	0
+#define FF_FS_TIMEOUT	1000
 /* The option FF_FS_REENTRANT switches the re-entrancy (thread safe) of the FatFs
 /  module itself. Note that regardless of this option, file access to different
 /  volume is always re-entrant and volume control functions, f_mount(), f_mkfs()
@@ -262,5 +290,7 @@
 /
 /  The FF_FS_TIMEOUT defines timeout period in unit of O/S time tick.
 */
+
+
 
 /*--- End of configuration options ---*/

--- a/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_max32572.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_max32572.c
@@ -21,10 +21,11 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "max32572.h"
+#include "mxc_device.h"
 #include "gcr_regs.h"
 #include "mxc_sys.h"
 #include "usbhs_regs.h"
+#include "sfcc.h"
 
 extern void (*const __isr_vector[])(void);
 

--- a/Libraries/PeriphDrivers/Include/MAX32572/otp.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/otp.h
@@ -73,6 +73,13 @@ typedef enum { MXC_OTP_READ_OP, MXC_OTP_WRITE_OP } mxc_otp_op_t;
 int MXC_OTP_Init(mxc_otp_clkdiv_t pclkdiv);
 
 /**
+ * @brief      Power down the OTP Controller.
+ * 
+ * @return     #E_NO_ERROR if everything is successful, \ref MXC_Error_Codes "error" if unsuccessful.
+ */
+int MXC_OTP_PowerDown(void);
+
+/**
  * @brief      Checks whether the OTP user block is locked/unlocked.
  * 
  * @return     (0) for Unlocked, (1) for Locked.

--- a/Libraries/PeriphDrivers/Source/OTP/otp_me55.c
+++ b/Libraries/PeriphDrivers/Source/OTP/otp_me55.c
@@ -66,6 +66,11 @@ int MXC_OTP_Init(mxc_otp_clkdiv_t pclkdiv)
     return MXC_OTP_RevA_Init((mxc_otp_reva_regs_t *)MXC_OTP, pclkdiv);
 }
 
+int MXC_OTP_PowerDown(void)
+{
+    return MXC_OTP_RevA_PowerDown((mxc_otp_reva_regs_t *)MXC_OTP);
+}
+
 int MXC_OTP_IsLocked(void)
 {
     return MXC_OTP_RevA_IsLocked((mxc_otp_reva_regs_t *)MXC_OTP);

--- a/Libraries/PeriphDrivers/Source/OTP/otp_reva.c
+++ b/Libraries/PeriphDrivers/Source/OTP/otp_reva.c
@@ -20,6 +20,7 @@
 
 /* **** Includes **** */
 #include <stddef.h>
+#include "mxc_delay.h"
 #include "mxc_device.h"
 #include "mxc_assert.h"
 #include "mxc_errors.h"
@@ -33,6 +34,23 @@ int MXC_OTP_RevA_Init(mxc_otp_reva_regs_t *otp, mxc_otp_clkdiv_t pclkdiv)
 {
     MXC_SETFIELD(otp->clkdiv, MXC_F_OTP_REVA_CLKDIV_PCLKDIV,
                  (pclkdiv << MXC_F_OTP_CLKDIV_PCLKDIV_POS));
+
+    return E_NO_ERROR;
+}
+
+int MXC_OTP_RevA_PowerDown(mxc_otp_reva_regs_t *otp)
+{
+    otp->clkdiv |= MXC_F_OTP_REVA_CLKDIV_PD;
+
+    // Must wait 20HCLK cycles after powering down OTP before 
+    //  disabling the OTP clock and OTP_STATUS.pwr_rdy
+    //  is properly updated.
+    MXC_Delay(10);
+
+    MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_OTP);
+
+    // Poll status bit until OTP is powered off.
+    while(otp->status & MXC_F_OTP_REVA_STATUS_PWR_RDY) {}
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/OTP/otp_reva.c
+++ b/Libraries/PeriphDrivers/Source/OTP/otp_reva.c
@@ -42,8 +42,8 @@ int MXC_OTP_RevA_PowerDown(mxc_otp_reva_regs_t *otp)
 {
     otp->clkdiv |= MXC_F_OTP_REVA_CLKDIV_PD;
 
-    // Must wait 20HCLK cycles after powering down OTP before
-    //  disabling the OTP clock and OTP_STATUS.pwr_rdy
+    // Must wait 20HCLK cycles after powering down OTP and before
+    //  disabling the OTP clock, so the OTP_STATUS.pwr_rdy
     //  is properly updated.
     MXC_Delay(10);
 

--- a/Libraries/PeriphDrivers/Source/OTP/otp_reva.c
+++ b/Libraries/PeriphDrivers/Source/OTP/otp_reva.c
@@ -42,7 +42,7 @@ int MXC_OTP_RevA_PowerDown(mxc_otp_reva_regs_t *otp)
 {
     otp->clkdiv |= MXC_F_OTP_REVA_CLKDIV_PD;
 
-    // Must wait 20HCLK cycles after powering down OTP before
+    // Must wait 20HCLK cycles after powering down OTP before 
     //  disabling the OTP clock and OTP_STATUS.pwr_rdy
     //  is properly updated.
     MXC_Delay(10);
@@ -50,7 +50,7 @@ int MXC_OTP_RevA_PowerDown(mxc_otp_reva_regs_t *otp)
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_OTP);
 
     // Poll status bit until OTP is powered off.
-    while (otp->status & MXC_F_OTP_REVA_STATUS_PWR_RDY) {}
+    while(otp->status & MXC_F_OTP_REVA_STATUS_PWR_RDY) {}
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/OTP/otp_reva.c
+++ b/Libraries/PeriphDrivers/Source/OTP/otp_reva.c
@@ -42,7 +42,7 @@ int MXC_OTP_RevA_PowerDown(mxc_otp_reva_regs_t *otp)
 {
     otp->clkdiv |= MXC_F_OTP_REVA_CLKDIV_PD;
 
-    // Must wait 20HCLK cycles after powering down OTP before 
+    // Must wait 20HCLK cycles after powering down OTP before
     //  disabling the OTP clock and OTP_STATUS.pwr_rdy
     //  is properly updated.
     MXC_Delay(10);
@@ -50,7 +50,7 @@ int MXC_OTP_RevA_PowerDown(mxc_otp_reva_regs_t *otp)
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_OTP);
 
     // Poll status bit until OTP is powered off.
-    while(otp->status & MXC_F_OTP_REVA_STATUS_PWR_RDY) {}
+    while (otp->status & MXC_F_OTP_REVA_STATUS_PWR_RDY) {}
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/OTP/otp_reva.h
+++ b/Libraries/PeriphDrivers/Source/OTP/otp_reva.h
@@ -33,6 +33,8 @@ extern "C" {
 
 int MXC_OTP_RevA_Init(mxc_otp_reva_regs_t *otp, mxc_otp_clkdiv_t pclkdiv);
 
+int MXC_OTP_RevA_PowerDown(mxc_otp_reva_regs_t *otp);
+
 int MXC_OTP_RevA_IsLocked(mxc_otp_reva_regs_t *otp);
 
 void MXC_OTP_RevA_Unlock(mxc_otp_reva_regs_t *otp);


### PR DESCRIPTION
### Description

To disable the OTP for low power applications, there needs to be a 20HCLK cycle delay after the OTP controller powers down (`OTP_CLKDIV.pd`) and before the OTP peripheral clock is disabled.

Needs to be tested for ME55A2 LP measurements.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.