### PR TITLE
fix(PeriphDrivers): Resolve compiler warnings for the MAX32690 libraries when building with IAR's Embedded Workbench

### DIFF
--- a/Examples/MAX78000/CNN/facial_recognition/include/ffconf.h
+++ b/Examples/MAX78000/CNN/facial_recognition/include/ffconf.h
@@ -2,20 +2,19 @@
 /  Configurations of FatFs Module
 /---------------------------------------------------------------------------*/
 
-#define FFCONF_DEF	80286	/* Revision ID */
+#define FFCONF_DEF 80286 /* Revision ID */
 
 /*---------------------------------------------------------------------------/
 / Function Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_FS_READONLY	0
+#define FF_FS_READONLY 0
 /* This option switches read-only configuration. (0:Read/Write or 1:Read-only)
 /  Read-only configuration removes writing API functions, f_write(), f_sync(),
 /  f_unlink(), f_mkdir(), f_chmod(), f_rename(), f_truncate(), f_getfree()
 /  and optional writing functions as well. */
 
-
-#define FF_FS_MINIMIZE	0
+#define FF_FS_MINIMIZE 0
 /* This option defines minimization level to remove some basic API functions.
 /
 /   0: Basic functions are fully enabled.
@@ -24,42 +23,34 @@
 /   2: f_opendir(), f_readdir() and f_closedir() are removed in addition to 1.
 /   3: f_lseek() function is removed in addition to 2. */
 
-
-#define FF_USE_FIND		0
+#define FF_USE_FIND 0
 /* This option switches filtered directory read functions, f_findfirst() and
 /  f_findnext(). (0:Disable, 1:Enable 2:Enable with matching altname[] too) */
 
-
-#define FF_USE_MKFS		1
+#define FF_USE_MKFS 1
 /* This option switches f_mkfs() function. (0:Disable or 1:Enable) */
 
-
-#define FF_USE_FASTSEEK	0
+#define FF_USE_FASTSEEK 0
 /* This option switches fast seek function. (0:Disable or 1:Enable) */
 
-
-#define FF_USE_EXPAND	0
+#define FF_USE_EXPAND 0
 /* This option switches f_expand function. (0:Disable or 1:Enable) */
 
-
-#define FF_USE_CHMOD	1
+#define FF_USE_CHMOD 1
 /* This option switches attribute manipulation functions, f_chmod() and f_utime().
 /  (0:Disable or 1:Enable) Also FF_FS_READONLY needs to be 0 to enable this option. */
 
-
-#define FF_USE_LABEL	1
+#define FF_USE_LABEL 1
 /* This option switches volume label functions, f_getlabel() and f_setlabel().
 /  (0:Disable or 1:Enable) */
 
-
-#define FF_USE_FORWARD	1
+#define FF_USE_FORWARD 1
 /* This option switches f_forward() function. (0:Disable or 1:Enable) */
 
-
-#define FF_USE_STRFUNC	0
-#define FF_PRINT_LLI	1
-#define FF_PRINT_FLOAT	1
-#define FF_STRF_ENCODE	3
+#define FF_USE_STRFUNC 0
+#define FF_PRINT_LLI 1
+#define FF_PRINT_FLOAT 1
+#define FF_STRF_ENCODE 3
 /* FF_USE_STRFUNC switches string functions, f_gets(), f_putc(), f_puts() and
 /  f_printf().
 /
@@ -79,12 +70,11 @@
 /   3: Unicode in UTF-8
 */
 
-
 /*---------------------------------------------------------------------------/
 / Locale and Namespace Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_CODE_PAGE	932
+#define FF_CODE_PAGE 932
 /* This option specifies the OEM code page to be used on the target system.
 /  Incorrect code page setting can cause a file open failure.
 /
@@ -112,9 +102,8 @@
 /     0 - Include all code pages above and configured by f_setcp()
 */
 
-
-#define FF_USE_LFN		1
-#define FF_MAX_LFN		255
+#define FF_USE_LFN 1
+#define FF_MAX_LFN 255
 /* The FF_USE_LFN switches the support for LFN (long file name).
 /
 /   0: Disable LFN. FF_MAX_LFN has no effect.
@@ -132,8 +121,7 @@
 /  memory for the working buffer, memory management functions, ff_memalloc() and
 /  ff_memfree() exemplified in ffsystem.c, need to be added to the project. */
 
-
-#define FF_LFN_UNICODE	0
+#define FF_LFN_UNICODE 0
 /* This option switches the character encoding on the API when LFN is enabled.
 /
 /   0: ANSI/OEM in current CP (TCHAR = char)
@@ -144,16 +132,14 @@
 /  Also behavior of string I/O functions will be affected by this option.
 /  When LFN is not enabled, this option has no effect. */
 
-
-#define FF_LFN_BUF		255
-#define FF_SFN_BUF		12
+#define FF_LFN_BUF 255
+#define FF_SFN_BUF 12
 /* This set of options defines size of file name members in the FILINFO structure
 /  which is used to read out directory items. These values should be suffcient for
 /  the file names to read. The maximum possible length of the read file name depends
 /  on character encoding. When LFN is not enabled, these options have no effect. */
 
-
-#define FF_FS_RPATH		2
+#define FF_FS_RPATH 2
 /* This option configures support for relative path.
 /
 /   0: Disable relative path and remove related functions.
@@ -161,17 +147,15 @@
 /   2: f_getcwd() function is available in addition to 1.
 */
 
-
 /*---------------------------------------------------------------------------/
 / Drive/Volume Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_VOLUMES		1
+#define FF_VOLUMES 1
 /* Number of volumes (logical drives) to be used. (1-10) */
 
-
-#define FF_STR_VOLUME_ID	0
-#define FF_VOLUME_STRS		"RAM","NAND","CF","SD","SD2","USB","USB2","USB3"
+#define FF_STR_VOLUME_ID 0
+#define FF_VOLUME_STRS "RAM", "NAND", "CF", "SD", "SD2", "USB", "USB2", "USB3"
 /* FF_STR_VOLUME_ID switches support for volume ID in arbitrary strings.
 /  When FF_STR_VOLUME_ID is set to 1 or 2, arbitrary strings can be used as drive
 /  number in the path name. FF_VOLUME_STRS defines the volume ID strings for each
@@ -183,8 +167,7 @@
 /  const char* VolumeStr[FF_VOLUMES] = {"ram","flash","sd","usb",...
 */
 
-
-#define FF_MULTI_PARTITION	0
+#define FF_MULTI_PARTITION 0
 /* This option switches support for multiple volumes on the physical drive.
 /  By default (0), each logical drive number is bound to the same physical drive
 /  number and only an FAT volume found on the physical drive will be mounted.
@@ -192,9 +175,8 @@
 /  arbitrary physical drive and partition listed in the VolToPart[]. Also f_fdisk()
 /  function will be available. */
 
-
-#define FF_MIN_SS		512
-#define FF_MAX_SS		512
+#define FF_MIN_SS 512
+#define FF_MAX_SS 512
 /* This set of options configures the range of sector size to be supported. (512,
 /  1024, 2048 or 4096) Always set both 512 for most systems, generic memory card and
 /  harddisk, but a larger value may be required for on-board flash memory and some
@@ -202,45 +184,38 @@
 /  for variable sector size mode and disk_ioctl() function needs to implement
 /  GET_SECTOR_SIZE command. */
 
-
-#define FF_LBA64		0
+#define FF_LBA64 0
 /* This option switches support for 64-bit LBA. (0:Disable or 1:Enable)
 /  To enable the 64-bit LBA, also exFAT needs to be enabled. (FF_FS_EXFAT == 1) */
 
-
-#define FF_MIN_GPT		0x10000000
+#define FF_MIN_GPT 0x10000000
 /* Minimum number of sectors to switch GPT as partitioning format in f_mkfs and
 /  f_fdisk function. 0x100000000 max. This option has no effect when FF_LBA64 == 0. */
 
-
-#define FF_USE_TRIM		0
+#define FF_USE_TRIM 0
 /* This option switches support for ATA-TRIM. (0:Disable or 1:Enable)
 /  To enable Trim function, also CTRL_TRIM command should be implemented to the
 /  disk_ioctl() function. */
-
-
 
 /*---------------------------------------------------------------------------/
 / System Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_FS_TINY		0
+#define FF_FS_TINY 0
 /* This option switches tiny buffer configuration. (0:Normal or 1:Tiny)
 /  At the tiny configuration, size of file object (FIL) is shrinked FF_MAX_SS bytes.
 /  Instead of private sector buffer eliminated from the file object, common sector
 /  buffer in the filesystem object (FATFS) is used for the file data transfer. */
 
-
-#define FF_FS_EXFAT		0
+#define FF_FS_EXFAT 0
 /* This option switches support for exFAT filesystem. (0:Disable or 1:Enable)
 /  To enable exFAT, also LFN needs to be enabled. (FF_USE_LFN >= 1)
 /  Note that enabling exFAT discards ANSI C (C89) compatibility. */
 
-
-#define FF_FS_NORTC		1
-#define FF_NORTC_MON	1
-#define FF_NORTC_MDAY	1
-#define FF_NORTC_YEAR	2022
+#define FF_FS_NORTC 1
+#define FF_NORTC_MON 1
+#define FF_NORTC_MDAY 1
+#define FF_NORTC_YEAR 2022
 /* The option FF_FS_NORTC switches timestamp feature. If the system does not have
 /  an RTC or valid timestamp is not needed, set FF_FS_NORTC = 1 to disable the
 /  timestamp feature. Every object modified by FatFs will have a fixed timestamp
@@ -250,8 +225,7 @@
 /  FF_NORTC_MDAY and FF_NORTC_YEAR have no effect.
 /  These options have no effect in read-only configuration (FF_FS_READONLY = 1). */
 
-
-#define FF_FS_NOFSINFO	0
+#define FF_FS_NOFSINFO 0
 /* If you need to know correct free space on the FAT32 volume, set bit 0 of this
 /  option, and f_getfree() function at the first time after volume mount will force
 /  a full FAT scan. Bit 1 controls the use of last allocated cluster number.
@@ -262,8 +236,7 @@
 /  bit1=1: Do not trust last allocated cluster number in the FSINFO.
 */
 
-
-#define FF_FS_LOCK		0
+#define FF_FS_LOCK 0
 /* The option FF_FS_LOCK switches file lock function to control duplicated file open
 /  and illegal operation to open objects. This option must be 0 when FF_FS_READONLY
 /  is 1.
@@ -274,9 +247,8 @@
 /      can be opened simultaneously under file lock control. Note that the file
 /      lock control is independent of re-entrancy. */
 
-
-#define FF_FS_REENTRANT	0
-#define FF_FS_TIMEOUT	1000
+#define FF_FS_REENTRANT 0
+#define FF_FS_TIMEOUT 1000
 /* The option FF_FS_REENTRANT switches the re-entrancy (thread safe) of the FatFs
 /  module itself. Note that regardless of this option, file access to different
 /  volume is always re-entrant and volume control functions, f_mount(), f_mkfs()
@@ -290,7 +262,5 @@
 /
 /  The FF_FS_TIMEOUT defines timeout period in unit of O/S time tick.
 */
-
-
 
 /*--- End of configuration options ---*/

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
@@ -256,8 +256,10 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 uint32_t MXC_GPIO_InGet(mxc_gpio_regs_t *port, uint32_t mask)
 {
     if (port == MXC_GPIO4) {
-        uint32_t gpio40 = (MXC_MCR->gpio4_ctrl & MXC_F_MCR_GPIO4_CTRL_P40_IN) >> MXC_F_MCR_GPIO4_CTRL_P40_IN_POS;
-        uint32_t gpio41 = (MXC_MCR->gpio4_ctrl & MXC_F_MCR_GPIO4_CTRL_P41_IN) >> (MXC_F_MCR_GPIO4_CTRL_P41_IN_POS - 1);
+        uint32_t gpio40 = (MXC_MCR->gpio4_ctrl & MXC_F_MCR_GPIO4_CTRL_P40_IN) >>
+                          MXC_F_MCR_GPIO4_CTRL_P40_IN_POS;
+        uint32_t gpio41 = (MXC_MCR->gpio4_ctrl & MXC_F_MCR_GPIO4_CTRL_P41_IN) >>
+                          (MXC_F_MCR_GPIO4_CTRL_P41_IN_POS - 1);
         return ((gpio40 | gpio41) & mask);
     }
 
@@ -290,8 +292,10 @@ void MXC_GPIO_OutClr(mxc_gpio_regs_t *port, uint32_t mask)
 uint32_t MXC_GPIO_OutGet(mxc_gpio_regs_t *port, uint32_t mask)
 {
     if (port == MXC_GPIO4) {
-        uint32_t gpio40 = (MXC_MCR->gpio4_ctrl & MXC_F_MCR_GPIO4_CTRL_P40_DO) >> MXC_F_MCR_GPIO4_CTRL_P40_DO_POS;
-        uint32_t gpio41 = (MXC_MCR->gpio4_ctrl & MXC_F_MCR_GPIO4_CTRL_P41_DO) >> (MXC_F_MCR_GPIO4_CTRL_P41_DO_POS - 1);
+        uint32_t gpio40 = (MXC_MCR->gpio4_ctrl & MXC_F_MCR_GPIO4_CTRL_P40_DO) >>
+                          MXC_F_MCR_GPIO4_CTRL_P40_DO_POS;
+        uint32_t gpio41 = (MXC_MCR->gpio4_ctrl & MXC_F_MCR_GPIO4_CTRL_P41_DO) >>
+                          (MXC_F_MCR_GPIO4_CTRL_P41_DO_POS - 1);
         return ((gpio40 | gpio41) & mask);
     }
 

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
@@ -256,7 +256,9 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 uint32_t MXC_GPIO_InGet(mxc_gpio_regs_t *port, uint32_t mask)
 {
     if (port == MXC_GPIO4) {
-        return GPIO4_DATAIN_MASK(mask);
+        uint32_t gpio40 = (MXC_MCR->gpio4_ctrl & MXC_F_MCR_GPIO4_CTRL_P40_IN) >> MXC_F_MCR_GPIO4_CTRL_P40_IN_POS;
+        uint32_t gpio41 = (MXC_MCR->gpio4_ctrl & MXC_F_MCR_GPIO4_CTRL_P41_IN) >> (MXC_F_MCR_GPIO4_CTRL_P41_IN_POS - 1);
+        return ((gpio40 | gpio41) & mask);
     }
 
     return MXC_GPIO_RevA_InGet((mxc_gpio_reva_regs_t *)port, mask);
@@ -288,7 +290,9 @@ void MXC_GPIO_OutClr(mxc_gpio_regs_t *port, uint32_t mask)
 uint32_t MXC_GPIO_OutGet(mxc_gpio_regs_t *port, uint32_t mask)
 {
     if (port == MXC_GPIO4) {
-        return GPIO4_DATAOUT_GET_MASK(mask);
+        uint32_t gpio40 = (MXC_MCR->gpio4_ctrl & MXC_F_MCR_GPIO4_CTRL_P40_DO) >> MXC_F_MCR_GPIO4_CTRL_P40_DO_POS;
+        uint32_t gpio41 = (MXC_MCR->gpio4_ctrl & MXC_F_MCR_GPIO4_CTRL_P41_DO) >> (MXC_F_MCR_GPIO4_CTRL_P41_DO_POS - 1);
+        return ((gpio40 | gpio41) & mask);
     }
 
     return MXC_GPIO_RevA_OutGet((mxc_gpio_reva_regs_t *)port, mask);

--- a/Libraries/PeriphDrivers/Source/I2S/i2s_reva.c
+++ b/Libraries/PeriphDrivers/Source/I2S/i2s_reva.c
@@ -59,21 +59,21 @@ static void configure_data_sizes(mxc_i2s_reva_regs_t *i2s, uint8_t bits_word, ui
                                  uint8_t wsize)
 {
     if (bits_word > 0) {
-        MXC_SETFIELD(i2s->ctrl1ch0, 0b11111 << MXC_F_I2S_REVA_CTRL1CH0_BITS_WORD_POS,
+        MXC_SETFIELD(i2s->ctrl1ch0, MXC_F_I2S_REVA_CTRL1CH0_BITS_WORD,
                      (bits_word - 1) << MXC_F_I2S_REVA_CTRL1CH0_BITS_WORD_POS); // Subtract 1
     } else {
-        MXC_SETFIELD(i2s->ctrl1ch0, 0b11111 << MXC_F_I2S_REVA_CTRL1CH0_BITS_WORD_POS,
+        MXC_SETFIELD(i2s->ctrl1ch0, MXC_F_I2S_REVA_CTRL1CH0_BITS_WORD,
                      0); // Clear to 0
     }
 
     //Set sample length if defined:
     //The SMP_SIZE is equal to bitsWord when sampleSize == 0 or sampleSize > bitsWord
     if (smp_sz > 0) {
-        MXC_SETFIELD(i2s->ctrl1ch0, 0b11111 << MXC_F_I2S_REVA_CTRL1CH0_SMP_SIZE_POS,
+        MXC_SETFIELD(i2s->ctrl1ch0, MXC_F_I2S_REVA_CTRL1CH0_SMP_SIZE,
                      (smp_sz - 1) << MXC_F_I2S_REVA_CTRL1CH0_SMP_SIZE_POS); // Subtract 1
     } else {
-        MXC_SETFIELD(i2s->ctrl1ch0, 0b11111 << MXC_F_I2S_REVA_CTRL1CH0_SMP_SIZE_POS,
-                     smp_sz); // Clear to 0
+        MXC_SETFIELD(i2s->ctrl1ch0, MXC_F_I2S_REVA_CTRL1CH0_SMP_SIZE,
+                     0); // Clear to 0
     }
 
     //Set datasize to load in FIFO

--- a/Libraries/PeriphDrivers/Source/SEMA/sema_reva.c
+++ b/Libraries/PeriphDrivers/Source/SEMA/sema_reva.c
@@ -139,35 +139,37 @@ int MXC_SEMA_RevA_Init(mxc_sema_reva_regs_t *sema_regs)
 {
     if (MAILBOX_SIZE == 0) {
         return E_NONE_AVAIL;
-    }
+    } else {
 
-    /* Reset the async state */
-    mxcSemaCb.readBuf = NULL;
-    mxcSemaCb.readLen = 0;
-    mxcSemaCb.writeBuf = NULL;
-    mxcSemaCb.writeLen = 0;
+        /* Reset the async state */
+        mxcSemaCb.readBuf = NULL;
+        mxcSemaCb.readLen = 0;
+        mxcSemaCb.writeBuf = NULL;
+        mxcSemaCb.writeLen = 0;
 
-    /* Enable the semaphore interrupt */
+        /* Enable the semaphore interrupt */
 #ifndef __riscv
-    sema_regs->irq0 |= MXC_F_SEMA_REVA_IRQ0_EN;
+        sema_regs->irq0 |= MXC_F_SEMA_REVA_IRQ0_EN;
 #else
-    sema_regs->irq1 |= MXC_F_SEMA_REVA_IRQ1_EN;
+        sema_regs->irq1 |= MXC_F_SEMA_REVA_IRQ1_EN;
 #endif
 
-    return E_NO_ERROR;
+        return E_NO_ERROR;
+    }
 }
 
 int MXC_SEMA_RevA_InitBoxes(mxc_sema_reva_regs_t *sema_regs)
 {
     if (MAILBOX_SIZE == 0) {
         return E_NONE_AVAIL;
+    } else {
+
+        /* Reset the boxes */
+        memset((void *)mxcSemaBox0, 0, MAILBOX_SIZE);
+        memset((void *)mxcSemaBox1, 0, MAILBOX_SIZE);
+
+        return E_NO_ERROR;
     }
-
-    /* Reset the boxes */
-    memset((void *)mxcSemaBox0, 0, MAILBOX_SIZE);
-    memset((void *)mxcSemaBox1, 0, MAILBOX_SIZE);
-
-    return E_NO_ERROR;
 }
 
 static unsigned semaGetReadBoxAvailLen(void)
@@ -210,60 +212,61 @@ int MXC_SEMA_RevA_ReadBox(mxc_sema_reva_regs_t *sema_regs, uint8_t *data, unsign
 
     if (MAILBOX_SIZE == 0) {
         return E_NONE_AVAIL;
-    }
+    } else {
 
-    /* Lock the semaphore */
-    err = MXC_SEMA_RevA_GetSema(sema_regs, SEMA_READ_SEMA);
-    if (err != E_NO_ERROR) {
-        return E_BUSY;
-    }
-
-    /* Get the available read length */
-    if (len > semaGetReadBoxAvailLen()) {
-        MXC_SEMA_RevA_FreeSema(sema_regs, SEMA_READ_SEMA);
-        return E_UNDERFLOW;
-    }
-
-    /* Assign the box pointer */
-    if (SEMA_READ_BOX == 1) {
-        readBox = mxcSemaBox1;
-    } else if (SEMA_READ_BOX == 0) {
-        readBox = mxcSemaBox0;
-    }
-
-    /* Portion the read */
-    if (readBox->writeLocation < readBox->readLocation) {
-        /* Write location is behind the read location, wrap at the boundary */
-        if (len > (MAILBOX_PAYLOAD_LEN - readBox->readLocation)) {
-            readLen = (MAILBOX_PAYLOAD_LEN - readBox->readLocation);
-            semaReadBox(sema_regs, readBox, data, readLen);
-            data += readLen;
-            len -= readLen;
+        /* Lock the semaphore */
+        err = MXC_SEMA_RevA_GetSema(sema_regs, SEMA_READ_SEMA);
+        if (err != E_NO_ERROR) {
+            return E_BUSY;
         }
-    }
 
-    /* Complete the read */
-    semaReadBox(sema_regs, readBox, data, len);
+        /* Get the available read length */
+        if (len > semaGetReadBoxAvailLen()) {
+            MXC_SEMA_RevA_FreeSema(sema_regs, SEMA_READ_SEMA);
+            return E_UNDERFLOW;
+        }
 
-    /* Release the semaphore */
-    MXC_SEMA_RevA_FreeSema(sema_regs, SEMA_READ_SEMA);
+        /* Assign the box pointer */
+        if (SEMA_READ_BOX == 1) {
+            readBox = mxcSemaBox1;
+        } else if (SEMA_READ_BOX == 0) {
+            readBox = mxcSemaBox0;
+        }
 
-    /* Interrupt the peer when we're done reading */
+        /* Portion the read */
+        if (readBox->writeLocation < readBox->readLocation) {
+            /* Write location is behind the read location, wrap at the boundary */
+            if (len > (MAILBOX_PAYLOAD_LEN - readBox->readLocation)) {
+                readLen = (MAILBOX_PAYLOAD_LEN - readBox->readLocation);
+                semaReadBox(sema_regs, readBox, data, readLen);
+                data += readLen;
+                len -= readLen;
+            }
+        }
+
+        /* Complete the read */
+        semaReadBox(sema_regs, readBox, data, len);
+
+        /* Release the semaphore */
+        MXC_SEMA_RevA_FreeSema(sema_regs, SEMA_READ_SEMA);
+
+        /* Interrupt the peer when we're done reading */
 #if TARGET_NUM == 32570 || TARGET_NUM == 32650 || TARGET_NUM == 32665
 #ifndef __riscv
-    sema_regs->irq1 |= MXC_F_SEMA_REVA_IRQ1_RV32_IRQ;
+        sema_regs->irq1 |= MXC_F_SEMA_REVA_IRQ1_RV32_IRQ;
 #else
-    sema_regs->irq0 |= MXC_F_SEMA_REVA_IRQ0_CM4_IRQ;
+        sema_regs->irq0 |= MXC_F_SEMA_REVA_IRQ0_CM4_IRQ;
 #endif
 #else
 #ifndef __riscv
-    sema_regs->irq1 |= MXC_F_SEMA_IRQ1_RV32_IRQ;
+        sema_regs->irq1 |= MXC_F_SEMA_IRQ1_RV32_IRQ;
 #else
-    sema_regs->irq0 |= MXC_F_SEMA_IRQ0_CM4_IRQ;
+        sema_regs->irq0 |= MXC_F_SEMA_IRQ0_CM4_IRQ;
 #endif
 #endif
 
-    return E_NO_ERROR;
+        return E_NO_ERROR;
+    }
 }
 
 int MXC_SEMA_RevA_ReadBoxAsync(mxc_sema_reva_regs_t *sema_regs, mxc_sema_complete_cb_t cb,
@@ -271,34 +274,34 @@ int MXC_SEMA_RevA_ReadBoxAsync(mxc_sema_reva_regs_t *sema_regs, mxc_sema_complet
 {
     if (MAILBOX_SIZE == 0) {
         return E_NONE_AVAIL;
-    }
+    } else {
+        /* Read currently in progress */
+        if (mxcSemaCb.readBuf != NULL) {
+            return E_BUSY;
+        }
 
-    /* Read currently in progress */
-    if (mxcSemaCb.readBuf != NULL) {
-        return E_BUSY;
-    }
+        /* Register the read request */
+        mxcSemaCb.readBuf = data;
+        mxcSemaCb.readLen = len;
+        mxcSemaCb.readCb = cb;
 
-    /* Register the read request */
-    mxcSemaCb.readBuf = data;
-    mxcSemaCb.readLen = len;
-    mxcSemaCb.readCb = cb;
-
-    /* Pend the local interrupt to process the request */
+        /* Pend the local interrupt to process the request */
 #if TARGET_NUM == 32570 || TARGET_NUM == 32650 || TARGET_NUM == 32665
 #ifdef __riscv
-    sema_regs->irq1 |= MXC_F_SEMA_REVA_IRQ1_RV32_IRQ;
+        sema_regs->irq1 |= MXC_F_SEMA_REVA_IRQ1_RV32_IRQ;
 #else
-    sema_regs->irq0 |= MXC_F_SEMA_REVA_IRQ0_CM4_IRQ;
+        sema_regs->irq0 |= MXC_F_SEMA_REVA_IRQ0_CM4_IRQ;
 #endif
 #else
 #ifdef __riscv
-    sema_regs->irq1 |= MXC_F_SEMA_IRQ1_RV32_IRQ;
+        sema_regs->irq1 |= MXC_F_SEMA_IRQ1_RV32_IRQ;
 #else
-    sema_regs->irq0 |= MXC_F_SEMA_IRQ0_CM4_IRQ;
+        sema_regs->irq0 |= MXC_F_SEMA_IRQ0_CM4_IRQ;
 #endif
 #endif
 
-    return E_NO_ERROR;
+        return E_NO_ERROR;
+    }
 }
 
 static unsigned semaGetWriteBoxAvailLen(void)
@@ -341,53 +344,54 @@ int MXC_SEMA_RevA_WriteBox(mxc_sema_reva_regs_t *sema_regs, const uint8_t *data,
 
     if (MAILBOX_SIZE == 0) {
         return E_NONE_AVAIL;
-    }
+    } else {
 
-    err = MXC_SEMA_RevA_GetSema(sema_regs, SEMA_WRITE_SEMA);
-    if (err != E_NO_ERROR) {
-        return E_BUSY;
-    }
+        err = MXC_SEMA_RevA_GetSema(sema_regs, SEMA_WRITE_SEMA);
+        if (err != E_NO_ERROR) {
+            return E_BUSY;
+        }
 
-    if (len > semaGetWriteBoxAvailLen()) {
+        if (len > semaGetWriteBoxAvailLen()) {
+            MXC_SEMA_RevA_FreeSema(sema_regs, SEMA_WRITE_SEMA);
+            return E_OVERFLOW;
+        }
+
+        if (SEMA_WRITE_BOX == 1) {
+            writeBox = mxcSemaBox1;
+        } else if (SEMA_WRITE_BOX == 0) {
+            writeBox = mxcSemaBox0;
+        }
+
+        /* Portion the write */
+        if (len > (MAILBOX_PAYLOAD_LEN - writeBox->writeLocation)) {
+            writeLen = (MAILBOX_PAYLOAD_LEN - writeBox->writeLocation);
+            semaWriteBox(sema_regs, writeBox, data, writeLen);
+            data += writeLen;
+            len -= writeLen;
+        }
+
+        /* Complete the write */
+        semaWriteBox(sema_regs, writeBox, data, len);
+
         MXC_SEMA_RevA_FreeSema(sema_regs, SEMA_WRITE_SEMA);
-        return E_OVERFLOW;
-    }
 
-    if (SEMA_WRITE_BOX == 1) {
-        writeBox = mxcSemaBox1;
-    } else if (SEMA_WRITE_BOX == 0) {
-        writeBox = mxcSemaBox0;
-    }
-
-    /* Portion the write */
-    if (len > (MAILBOX_PAYLOAD_LEN - writeBox->writeLocation)) {
-        writeLen = (MAILBOX_PAYLOAD_LEN - writeBox->writeLocation);
-        semaWriteBox(sema_regs, writeBox, data, writeLen);
-        data += writeLen;
-        len -= writeLen;
-    }
-
-    /* Complete the write */
-    semaWriteBox(sema_regs, writeBox, data, len);
-
-    MXC_SEMA_RevA_FreeSema(sema_regs, SEMA_WRITE_SEMA);
-
-    /* Interrupt the peer when we're done writing */
+        /* Interrupt the peer when we're done writing */
 #if TARGET_NUM == 32570 || TARGET_NUM == 32650 || TARGET_NUM == 32665
 #ifndef __riscv
-    sema_regs->irq1 |= MXC_F_SEMA_REVA_IRQ1_RV32_IRQ;
+        sema_regs->irq1 |= MXC_F_SEMA_REVA_IRQ1_RV32_IRQ;
 #else
-    sema_regs->irq0 |= MXC_F_SEMA_REVA_IRQ0_CM4_IRQ;
+        sema_regs->irq0 |= MXC_F_SEMA_REVA_IRQ0_CM4_IRQ;
 #endif
 #else
 #ifndef __riscv
-    sema_regs->irq1 |= MXC_F_SEMA_IRQ1_RV32_IRQ;
+        sema_regs->irq1 |= MXC_F_SEMA_IRQ1_RV32_IRQ;
 #else
-    sema_regs->irq0 |= MXC_F_SEMA_IRQ0_CM4_IRQ;
+        sema_regs->irq0 |= MXC_F_SEMA_IRQ0_CM4_IRQ;
 #endif
 #endif
 
-    return E_NO_ERROR;
+        return E_NO_ERROR;
+    }
 }
 
 int MXC_SEMA_RevA_WriteBoxAsync(mxc_sema_reva_regs_t *sema_regs, mxc_sema_complete_cb_t cb,
@@ -395,34 +399,35 @@ int MXC_SEMA_RevA_WriteBoxAsync(mxc_sema_reva_regs_t *sema_regs, mxc_sema_comple
 {
     if (MAILBOX_SIZE == 0) {
         return E_NONE_AVAIL;
-    }
+    } else {
 
-    /* Read currently in progress */
-    if (mxcSemaCb.writeBuf != NULL) {
-        return E_BUSY;
-    }
+        /* Read currently in progress */
+        if (mxcSemaCb.writeBuf != NULL) {
+            return E_BUSY;
+        }
 
-    /* Register the read request */
-    mxcSemaCb.writeBuf = (uint8_t *)data;
-    mxcSemaCb.writeLen = len;
-    mxcSemaCb.writeCb = cb;
+        /* Register the read request */
+        mxcSemaCb.writeBuf = (uint8_t *)data;
+        mxcSemaCb.writeLen = len;
+        mxcSemaCb.writeCb = cb;
 
-    /* Pend the local interrupt to process the request */
+        /* Pend the local interrupt to process the request */
 #if TARGET_NUM == 32570 || TARGET_NUM == 32650 || TARGET_NUM == 32665
 #ifdef __riscv
-    sema_regs->irq1 |= MXC_F_SEMA_REVA_IRQ1_RV32_IRQ;
+        sema_regs->irq1 |= MXC_F_SEMA_REVA_IRQ1_RV32_IRQ;
 #else
-    sema_regs->irq0 |= MXC_F_SEMA_REVA_IRQ0_CM4_IRQ;
+        sema_regs->irq0 |= MXC_F_SEMA_REVA_IRQ0_CM4_IRQ;
 #endif
 #else
 #ifdef __riscv
-    sema_regs->irq1 |= MXC_F_SEMA_IRQ1_RV32_IRQ;
+        sema_regs->irq1 |= MXC_F_SEMA_IRQ1_RV32_IRQ;
 #else
-    sema_regs->irq0 |= MXC_F_SEMA_IRQ0_CM4_IRQ;
+        sema_regs->irq0 |= MXC_F_SEMA_IRQ0_CM4_IRQ;
 #endif
 #endif
 
-    return E_NO_ERROR;
+        return E_NO_ERROR;
+    }
 }
 
 static int MXC_SEMA_RevA_WriteHandler(mxc_sema_reva_regs_t *sema_regs)
@@ -433,81 +438,81 @@ static int MXC_SEMA_RevA_WriteHandler(mxc_sema_reva_regs_t *sema_regs)
 
     if (MAILBOX_SIZE == 0) {
         return E_NONE_AVAIL;
-    }
-
-    /* Check to see if we have any pending read requests */
-    if (mxcSemaCb.writeBuf == NULL) {
-        return E_NO_ERROR;
-    }
-
-    /* Get the write semaphore */
-    err = E_BUSY;
-    while (err != E_NO_ERROR) {
-        err = MXC_SEMA_RevA_GetSema(sema_regs, SEMA_WRITE_SEMA);
-    }
-
-    /* Assign the writeBox pointer */
-    if (SEMA_WRITE_BOX == 1) {
-        writeBox = mxcSemaBox1;
-    } else if (SEMA_WRITE_BOX == 0) {
-        writeBox = mxcSemaBox0;
-    }
-
-    /* Check the available write length */
-    writeAvailLen = semaGetWriteBoxAvailLen();
-    if (mxcSemaCb.writeLen < writeAvailLen) {
-        writeLen = mxcSemaCb.writeLen;
     } else {
-        writeLen = writeAvailLen;
-    }
-
-    /* Return without interrupting if not writing */
-    if (writeLen == 0) {
-        MXC_SEMA_RevA_FreeSema(sema_regs, SEMA_WRITE_SEMA);
-        return E_NO_ERROR;
-    }
-
-    /* Portion the write */
-    writeLenPart = 0;
-    if (writeLen > (MAILBOX_PAYLOAD_LEN - writeBox->writeLocation)) {
-        writeLenPart = (MAILBOX_PAYLOAD_LEN - writeBox->writeLocation);
-        semaWriteBox(sema_regs, writeBox, mxcSemaCb.writeBuf, writeLenPart);
-        mxcSemaCb.writeBuf += writeLenPart;
-        writeLen -= writeLenPart;
-    }
-
-    /* Complete the write */
-    semaWriteBox(sema_regs, writeBox, mxcSemaCb.writeBuf, writeLen);
-    mxcSemaCb.writeBuf += writeLen;
-    mxcSemaCb.writeLen -= (writeLenPart + writeLen);
-
-    MXC_SEMA_RevA_FreeSema(sema_regs, SEMA_WRITE_SEMA);
-
-    /* Call the callback if we're done with the read */
-    if (mxcSemaCb.writeLen == 0) {
-        mxcSemaCb.writeBuf = NULL;
-
-        if (mxcSemaCb.writeCb != NULL) {
-            mxcSemaCb.writeCb(E_NO_ERROR);
+        /* Check to see if we have any pending read requests */
+        if (mxcSemaCb.writeBuf == NULL) {
+            return E_NO_ERROR;
         }
-    }
 
-    /* Interrupt the peer when we're done writing */
+        /* Get the write semaphore */
+        err = E_BUSY;
+        while (err != E_NO_ERROR) {
+            err = MXC_SEMA_RevA_GetSema(sema_regs, SEMA_WRITE_SEMA);
+        }
+
+        /* Assign the writeBox pointer */
+        if (SEMA_WRITE_BOX == 1) {
+            writeBox = mxcSemaBox1;
+        } else if (SEMA_WRITE_BOX == 0) {
+            writeBox = mxcSemaBox0;
+        }
+
+        /* Check the available write length */
+        writeAvailLen = semaGetWriteBoxAvailLen();
+        if (mxcSemaCb.writeLen < writeAvailLen) {
+            writeLen = mxcSemaCb.writeLen;
+        } else {
+            writeLen = writeAvailLen;
+        }
+
+        /* Return without interrupting if not writing */
+        if (writeLen == 0) {
+            MXC_SEMA_RevA_FreeSema(sema_regs, SEMA_WRITE_SEMA);
+            return E_NO_ERROR;
+        }
+
+        /* Portion the write */
+        writeLenPart = 0;
+        if (writeLen > (MAILBOX_PAYLOAD_LEN - writeBox->writeLocation)) {
+            writeLenPart = (MAILBOX_PAYLOAD_LEN - writeBox->writeLocation);
+            semaWriteBox(sema_regs, writeBox, mxcSemaCb.writeBuf, writeLenPart);
+            mxcSemaCb.writeBuf += writeLenPart;
+            writeLen -= writeLenPart;
+        }
+
+        /* Complete the write */
+        semaWriteBox(sema_regs, writeBox, mxcSemaCb.writeBuf, writeLen);
+        mxcSemaCb.writeBuf += writeLen;
+        mxcSemaCb.writeLen -= (writeLenPart + writeLen);
+
+        MXC_SEMA_RevA_FreeSema(sema_regs, SEMA_WRITE_SEMA);
+
+        /* Call the callback if we're done with the read */
+        if (mxcSemaCb.writeLen == 0) {
+            mxcSemaCb.writeBuf = NULL;
+
+            if (mxcSemaCb.writeCb != NULL) {
+                mxcSemaCb.writeCb(E_NO_ERROR);
+            }
+        }
+
+        /* Interrupt the peer when we're done writing */
 #if TARGET_NUM == 32570 || TARGET_NUM == 32650 || TARGET_NUM == 32665
 #ifndef __riscv
-    sema_regs->irq1 |= MXC_F_SEMA_REVA_IRQ1_RV32_IRQ;
+        sema_regs->irq1 |= MXC_F_SEMA_REVA_IRQ1_RV32_IRQ;
 #else
-    sema_regs->irq0 |= MXC_F_SEMA_REVA_IRQ0_CM4_IRQ;
+        sema_regs->irq0 |= MXC_F_SEMA_REVA_IRQ0_CM4_IRQ;
 #endif
 #else
 #ifndef __riscv
-    sema_regs->irq1 |= MXC_F_SEMA_IRQ1_RV32_IRQ;
+        sema_regs->irq1 |= MXC_F_SEMA_IRQ1_RV32_IRQ;
 #else
-    sema_regs->irq0 |= MXC_F_SEMA_IRQ0_CM4_IRQ;
+        sema_regs->irq0 |= MXC_F_SEMA_IRQ0_CM4_IRQ;
 #endif
 #endif
 
-    return E_NO_ERROR;
+        return E_NO_ERROR;
+    }
 }
 
 static int MXC_SEMA_RevA_ReadHandler(mxc_sema_reva_regs_t *sema_regs)

--- a/Libraries/PeriphDrivers/Source/SEMA/sema_reva.c
+++ b/Libraries/PeriphDrivers/Source/SEMA/sema_reva.c
@@ -140,7 +140,6 @@ int MXC_SEMA_RevA_Init(mxc_sema_reva_regs_t *sema_regs)
     if (MAILBOX_SIZE == 0) {
         return E_NONE_AVAIL;
     } else {
-
         /* Reset the async state */
         mxcSemaCb.readBuf = NULL;
         mxcSemaCb.readLen = 0;
@@ -163,7 +162,6 @@ int MXC_SEMA_RevA_InitBoxes(mxc_sema_reva_regs_t *sema_regs)
     if (MAILBOX_SIZE == 0) {
         return E_NONE_AVAIL;
     } else {
-
         /* Reset the boxes */
         memset((void *)mxcSemaBox0, 0, MAILBOX_SIZE);
         memset((void *)mxcSemaBox1, 0, MAILBOX_SIZE);
@@ -213,7 +211,6 @@ int MXC_SEMA_RevA_ReadBox(mxc_sema_reva_regs_t *sema_regs, uint8_t *data, unsign
     if (MAILBOX_SIZE == 0) {
         return E_NONE_AVAIL;
     } else {
-
         /* Lock the semaphore */
         err = MXC_SEMA_RevA_GetSema(sema_regs, SEMA_READ_SEMA);
         if (err != E_NO_ERROR) {
@@ -345,7 +342,6 @@ int MXC_SEMA_RevA_WriteBox(mxc_sema_reva_regs_t *sema_regs, const uint8_t *data,
     if (MAILBOX_SIZE == 0) {
         return E_NONE_AVAIL;
     } else {
-
         err = MXC_SEMA_RevA_GetSema(sema_regs, SEMA_WRITE_SEMA);
         if (err != E_NO_ERROR) {
             return E_BUSY;
@@ -400,7 +396,6 @@ int MXC_SEMA_RevA_WriteBoxAsync(mxc_sema_reva_regs_t *sema_regs, mxc_sema_comple
     if (MAILBOX_SIZE == 0) {
         return E_NONE_AVAIL;
     } else {
-
         /* Read currently in progress */
         if (mxcSemaCb.writeBuf != NULL) {
             return E_BUSY;

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -769,7 +769,7 @@ int MXC_UART_RevB_AsyncHandler(mxc_uart_revb_regs_t *uart)
         numToWrite = MXC_UART_GetTXFIFOAvailable((mxc_uart_regs_t *)(req->uart));
         numToWrite = numToWrite > (req->txLen - req->txCnt) ? req->txLen - req->txCnt : numToWrite;
         numToWrite = MXC_UART_WriteTXFIFO((mxc_uart_regs_t *)(req->uart), &req->txData[req->txCnt],
-                                           numToWrite);
+                                          numToWrite);
         req->txCnt += numToWrite;
         MXC_UART_ClearFlags(req->uart, MXC_F_UART_REVB_INT_FL_TX_HE);
     }
@@ -779,7 +779,7 @@ int MXC_UART_RevB_AsyncHandler(mxc_uart_revb_regs_t *uart)
         numToRead = MXC_UART_GetRXFIFOAvailable((mxc_uart_regs_t *)(req->uart));
         numToRead = numToRead > (req->rxLen - req->rxCnt) ? req->rxLen - req->rxCnt : numToRead;
         numToRead = MXC_UART_ReadRXFIFO((mxc_uart_regs_t *)(req->uart), &req->rxData[req->rxCnt],
-                                          numToRead);
+                                        numToRead);
         req->rxCnt += numToRead;
 
         if ((req->rxLen - req->rxCnt) < MXC_UART_GetRXThreshold((mxc_uart_regs_t *)(req->uart))) {

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -768,8 +768,9 @@ int MXC_UART_RevB_AsyncHandler(mxc_uart_revb_regs_t *uart)
     if ((req != NULL) && (req->txLen)) {
         numToWrite = MXC_UART_GetTXFIFOAvailable((mxc_uart_regs_t *)(req->uart));
         numToWrite = numToWrite > (req->txLen - req->txCnt) ? req->txLen - req->txCnt : numToWrite;
-        req->txCnt += MXC_UART_WriteTXFIFO((mxc_uart_regs_t *)(req->uart), &req->txData[req->txCnt],
+        numToWrite = MXC_UART_WriteTXFIFO((mxc_uart_regs_t *)(req->uart), &req->txData[req->txCnt],
                                            numToWrite);
+        req->txCnt += numToWrite;
         MXC_UART_ClearFlags(req->uart, MXC_F_UART_REVB_INT_FL_TX_HE);
     }
 
@@ -777,8 +778,9 @@ int MXC_UART_RevB_AsyncHandler(mxc_uart_revb_regs_t *uart)
     if ((req != NULL) && (flags & MXC_F_UART_REVB_INT_FL_RX_THD) && (req->rxLen)) {
         numToRead = MXC_UART_GetRXFIFOAvailable((mxc_uart_regs_t *)(req->uart));
         numToRead = numToRead > (req->rxLen - req->rxCnt) ? req->rxLen - req->rxCnt : numToRead;
-        req->rxCnt += MXC_UART_ReadRXFIFO((mxc_uart_regs_t *)(req->uart), &req->rxData[req->rxCnt],
+        numToRead = MXC_UART_ReadRXFIFO((mxc_uart_regs_t *)(req->uart), &req->rxData[req->rxCnt],
                                           numToRead);
+        req->rxCnt += numToRead;
 
         if ((req->rxLen - req->rxCnt) < MXC_UART_GetRXThreshold((mxc_uart_regs_t *)(req->uart))) {
             MXC_UART_SetRXThreshold((mxc_uart_regs_t *)(req->uart), req->rxLen - req->rxCnt);

--- a/Libraries/PeriphDrivers/Source/WUT/wut_reva.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_reva.c
@@ -134,7 +134,7 @@ int MXC_WUT_RevA_GetTicks(mxc_wut_reva_regs_t *wut, uint32_t timerClock, uint32_
     uint32_t unit_div0, unit_div1;
     uint32_t prescale;
     uint64_t temp_ticks;
-    
+
     uint32_t wut_ctrl = wut->ctrl;
 
     prescale = ((wut_ctrl & MXC_F_WUT_REVA_CTRL_PRES) >> MXC_F_WUT_REVA_CTRL_PRES_POS) |

--- a/Libraries/PeriphDrivers/Source/WUT/wut_reva.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_reva.c
@@ -76,7 +76,8 @@ void MXC_WUT_RevA_Disable(mxc_wut_reva_regs_t *wut)
 void MXC_WUT_RevA_Config(mxc_wut_reva_regs_t *wut, const mxc_wut_reva_cfg_t *cfg)
 {
     // Configure the timer
-    wut->ctrl |= (wut->ctrl & ~(MXC_F_WUT_REVA_CTRL_TMODE | MXC_F_WUT_REVA_CTRL_TPOL)) |
+    uint32_t wut_ctrl = wut->ctrl;
+    wut->ctrl |= (wut_ctrl & ~(MXC_F_WUT_REVA_CTRL_TMODE | MXC_F_WUT_REVA_CTRL_TPOL)) |
                  ((cfg->mode << MXC_F_WUT_REVA_CTRL_TMODE_POS) & MXC_F_WUT_REVA_CTRL_TMODE);
 
     wut->cnt = 0x1;
@@ -133,9 +134,11 @@ int MXC_WUT_RevA_GetTicks(mxc_wut_reva_regs_t *wut, uint32_t timerClock, uint32_
     uint32_t unit_div0, unit_div1;
     uint32_t prescale;
     uint64_t temp_ticks;
+    
+    uint32_t wut_ctrl = wut->ctrl;
 
-    prescale = ((wut->ctrl & MXC_F_WUT_REVA_CTRL_PRES) >> MXC_F_WUT_REVA_CTRL_PRES_POS) |
-               (((wut->ctrl & MXC_F_WUT_REVA_CTRL_PRES3) >> (MXC_F_WUT_REVA_CTRL_PRES3_POS)) << 3);
+    prescale = ((wut_ctrl & MXC_F_WUT_REVA_CTRL_PRES) >> MXC_F_WUT_REVA_CTRL_PRES_POS) |
+               (((wut_ctrl & MXC_F_WUT_REVA_CTRL_PRES3) >> (MXC_F_WUT_REVA_CTRL_PRES3_POS)) << 3);
 
     switch (units) {
     case MXC_WUT_REVA_UNIT_NANOSEC:
@@ -178,9 +181,10 @@ int MXC_WUT_RevA_GetTime(mxc_wut_reva_regs_t *wut, uint32_t timerClock, uint32_t
                          uint32_t *time, mxc_wut_reva_unit_t *units)
 {
     uint64_t temp_time = 0;
+    uint32_t wut_ctrl = wut->ctrl;
     uint32_t prescale =
-        ((wut->ctrl & MXC_F_WUT_REVA_CTRL_PRES) >> MXC_F_WUT_REVA_CTRL_PRES_POS) |
-        (((wut->ctrl & MXC_F_WUT_REVA_CTRL_PRES3) >> (MXC_F_WUT_REVA_CTRL_PRES3_POS)) << 3);
+        ((wut_ctrl & MXC_F_WUT_REVA_CTRL_PRES) >> MXC_F_WUT_REVA_CTRL_PRES_POS) |
+        (((wut_ctrl & MXC_F_WUT_REVA_CTRL_PRES3) >> (MXC_F_WUT_REVA_CTRL_PRES3_POS)) << 3);
 
     temp_time = (uint64_t)ticks * 1000 * (1 << (prescale & 0xF)) / (timerClock / 1000000);
 


### PR DESCRIPTION
### Description

IAR's compiler generates a few warnings not caught by GCC.  This PR resolves those warnings.

