### PR TITLE
fix(workflow): Add token permissions to automatically re-trigger actions after a commit

### DIFF
--- a/.github/workflows/clang-format-run-pr.yml
+++ b/.github/workflows/clang-format-run-pr.yml
@@ -56,6 +56,7 @@ jobs:
         repository: ${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}
         ref: ${{ fromJSON(steps.get-pr.outputs.result).head.ref }}
         fetch-depth: 0
+        token: ${{ secrets.ADI_MSDK_Workflow }}
 
     - name: clang-format-run
       run: |


### PR DESCRIPTION
### Description

Added a new repo secret (similar to old MSDK repo location), so any commits made by a runner (like for clang-format-run) would automatically re-trigger all other actions.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.