### PR TITLE
feat(PeriphDrivers): Allow Skipping Clock and GPIO Initialization on CAN

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32662/can.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/can.h
@@ -322,6 +322,10 @@ mxc_can_capabilities_t MXC_CAN_GetCapabilities(void);
 
 /**
  * @brief   Initializes CAN event callbacks
+ * @note    On default this function enables CAN peripheral clock and CAN gpio pins.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file.
+ *          By this flag this function will remove clock and gpio related codes from file.
  * 
  * @param can_idx   Index of the CAN peripheral to initialize
  * @param cfg       Specifies how to configure CAN peripheral (see MXC_CAN_ObjectConfigure)
@@ -336,6 +340,10 @@ int MXC_CAN_Init(uint32_t can_idx, mxc_can_obj_cfg_t cfg, mxc_can_unit_event_cb_
 
 /**
  * @brief   Free CAN resources (does not reset or disable CAN peripherals)
+ * @note    On default this function enables CAN peripheral clock.
+ *          if you wish to manage clock related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file.
+ *          By this flag this function will remove clock related codes from file.
  *
  * @param can_idx   Index of CAN peripheral to un-initialize (shutdown)
  * 
@@ -345,6 +353,10 @@ int MXC_CAN_UnInit(uint32_t can_idx);
 
 /**
  * @brief   Change Power state of the CAN peripherals
+ * @note    On default this function enables CAN peripheral clock.
+ *          if you wish to manage clock related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file.
+ *          By this flag this function will remove clock related codes from file.
  * 
  * @param can_idx   Index of CAN peripheral to alter power settings for
  * @param pwr       Desired power state of the CAN peripherals
@@ -466,6 +478,10 @@ int MXC_CAN_ObjectSetFilter(uint32_t can_idx, mxc_can_filt_cfg_t cfg, uint32_t i
 
 /**
  * @brief   Configure CAN object
+ * @note    On default this function enables CAN gpio pins.
+ *          if you wish to manage gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file.
+ *          By this flag this function will remove gpio related codes from file.
  * 
  * @param can_idx   Index of CAN peripheral instance
  * @param cfg       Specifies how the filter should be configured

--- a/Libraries/PeriphDrivers/Include/MAX32690/can.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/can.h
@@ -324,6 +324,10 @@ mxc_can_capabilities_t MXC_CAN_GetCapabilities(void);
 
 /**
  * @brief   Initializes CAN event callbacks
+ * @note    On default this function enables CAN peripheral clock and CAN gpio pins.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file.
+ *          By this flag this function will remove clock and gpio related codes from file.
  * 
  * @param can_idx   Index of the CAN peripheral to initialize
  * @param cfg       Specifies how to configure CAN peripheral (see MXC_CAN_ObjectConfigure)
@@ -337,6 +341,10 @@ int MXC_CAN_Init(uint32_t can_idx, mxc_can_obj_cfg_t cfg, mxc_can_unit_event_cb_
 
 /**
  * @brief   Free CAN resources (does not reset or disable CAN peripherals)
+ * @note    On default this function enables CAN peripheral clock.
+ *          if you wish to manage clock related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file.
+ *          By this flag this function will remove clock related codes from file.
  *
  * @param can_idx   Index of CAN peripheral to un-initialize (shutdown)
  * 
@@ -346,6 +354,10 @@ int MXC_CAN_UnInit(uint32_t can_idx);
 
 /**
  * @brief   Change Power state of the CAN peripherals
+ * @note    On default this function enables CAN peripheral clock.
+ *          if you wish to manage clock related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file.
+ *          By this flag this function will remove clock related codes from file.
  * 
  * @param can_idx   Index of CAN peripheral to alter power settings for
  * @param pwr       Desired power state of the CAN peripherals
@@ -467,6 +479,10 @@ int MXC_CAN_ObjectSetFilter(uint32_t can_idx, mxc_can_filt_cfg_t cfg, uint32_t i
 
 /**
  * @brief   Configure CAN object
+ * @note    On default this function enables CAN gpio pins.
+ *          if you wish to manage gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file.
+ *          By this flag this function will remove gpio related codes from file.
  * 
  * @param can_idx   Pointer to CAN instance
  * @param cfg       Specifies how the filter should be configured

--- a/Libraries/PeriphDrivers/Source/CAN/can_me12.c
+++ b/Libraries/PeriphDrivers/Source/CAN/can_me12.c
@@ -63,7 +63,9 @@ int MXC_CAN_UnInit(uint32_t can_idx)
     switch (can_idx) {
     case 0:
         MXC_SYS_Reset_Periph(MXC_SYS_RESET0_CAN);
+#ifndef MSDK_NO_GPIO_CLK_INIT
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_CAN);
+#endif // MSDK_NO_GPIO_CLK_INIT
         break;
     default:
         return E_BAD_PARAM;
@@ -84,11 +86,15 @@ int MXC_CAN_PowerControl(uint32_t can_idx, mxc_can_pwr_ctrl_t pwr)
 
     switch (pwr) {
     case MXC_CAN_PWR_CTRL_OFF:
+#ifndef MSDK_NO_GPIO_CLK_INIT
         MXC_SYS_ClockDisable(periph_clk);
+#endif // MSDK_NO_GPIO_CLK_INIT
         return E_NO_ERROR;
     case MXC_CAN_PWR_CTRL_SLEEP: //Fall through
     case MXC_CAN_PWR_CTRL_FULL:
+#ifndef MSDK_NO_GPIO_CLK_INIT
         MXC_SYS_ClockEnable(periph_clk);
+#endif // MSDK_NO_GPIO_CLK_INIT
         break;
     default:
         return E_BAD_PARAM;
@@ -220,6 +226,7 @@ int MXC_CAN_ObjectConfigure(uint32_t can_idx, mxc_can_obj_cfg_t cfg, uint8_t map
         return E_BAD_PARAM;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     switch (map) {
     case 0:
         MXC_GPIO_Config(&gpio_cfg_can);
@@ -228,6 +235,7 @@ int MXC_CAN_ObjectConfigure(uint32_t can_idx, mxc_can_obj_cfg_t cfg, uint8_t map
         MXC_GPIO_Config(&gpio_cfg_canb);
         break;
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_CAN_RevA_ObjectConfigure((mxc_can_reva_regs_t *)can, cfg);
 }

--- a/Libraries/PeriphDrivers/Source/CAN/can_me18.c
+++ b/Libraries/PeriphDrivers/Source/CAN/can_me18.c
@@ -62,11 +62,15 @@ int MXC_CAN_UnInit(uint32_t can_idx)
     switch (can_idx) {
     case 0:
         MXC_SYS_Reset_Periph(MXC_SYS_RESET0_CAN0);
+#ifndef MSDK_NO_GPIO_CLK_INIT
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_CAN0);
+#endif // MSDK_NO_GPIO_CLK_INIT
         break;
     case 1:
         MXC_SYS_Reset_Periph(MXC_SYS_RESET0_CAN1);
+#ifndef MSDK_NO_GPIO_CLK_INIT
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_CAN1);
+#endif // MSDK_NO_GPIO_CLK_INIT
         break;
     default:
         return E_BAD_PARAM;
@@ -89,11 +93,15 @@ int MXC_CAN_PowerControl(uint32_t can_idx, mxc_can_pwr_ctrl_t pwr)
 
     switch (pwr) {
     case MXC_CAN_PWR_CTRL_OFF:
+#ifndef MSDK_NO_GPIO_CLK_INIT
         MXC_SYS_ClockDisable(periph_clk);
+#endif // MSDK_NO_GPIO_CLK_INIT
         return E_NO_ERROR;
     case MXC_CAN_PWR_CTRL_SLEEP: //Fall through
     case MXC_CAN_PWR_CTRL_FULL:
+#ifndef MSDK_NO_GPIO_CLK_INIT
         MXC_SYS_ClockEnable(periph_clk);
+#endif // MSDK_NO_GPIO_CLK_INIT
         break;
     default:
         return E_BAD_PARAM;
@@ -225,6 +233,7 @@ int MXC_CAN_ObjectConfigure(uint32_t can_idx, mxc_can_obj_cfg_t cfg)
         return E_BAD_PARAM;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     switch (can_idx) {
     case 0:
         MXC_GPIO_Config(&gpio_cfg_can0);
@@ -233,6 +242,7 @@ int MXC_CAN_ObjectConfigure(uint32_t can_idx, mxc_can_obj_cfg_t cfg)
         MXC_GPIO_Config(&gpio_cfg_can1);
         break;
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_CAN_RevA_ObjectConfigure((mxc_can_reva_regs_t *)can, cfg);
 }


### PR DESCRIPTION
## Pull Request Template

### Description

This PR can be considered as part of https://github.com/analogdevicesinc/msdk/pull/730 https://github.com/analogdevicesinc/msdk/pull/809 https://github.com/analogdevicesinc/msdk/pull/932

The clock disable mechanism propagated other devices.

Changes applied to the below peripherals.

- CAN

### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [X] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
