### PR TITLE
revert(workflow): Remove token usage from clang-format-run workflow

### DIFF
--- a/.github/workflows/clang-format-run-pr.yml
+++ b/.github/workflows/clang-format-run-pr.yml
@@ -56,7 +56,6 @@ jobs:
         repository: ${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}
         ref: ${{ fromJSON(steps.get-pr.outputs.result).head.ref }}
         fetch-depth: 0
-        token: ${{ secrets.ADI_MSDK_Workflow }}
 
     - name: clang-format-run
       run: |


### PR DESCRIPTION
### Description

ADI organization requires SSO with the token when a runner pushes a commit... Repo-specific secrets are a bust when you need all actions to re-trigger after a runner makes a commit, but the created secret will remain available in case for future use. Need to find an alternative to retrigger workflows, if possible.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.