### PR TITLE
fix(PeriphDrivers): Fix Bitwise Logic for TMR RevA Prescaler Init

### DIFF
--- a/Libraries/PeriphDrivers/Source/TMR/tmr_reva.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_reva.c
@@ -83,22 +83,22 @@ void MXC_TMR_RevA_Init(mxc_tmr_reva_regs_t *tmr, mxc_tmr_cfg_t *cfg)
 
     case MXC_TMR_PRES_512:
         tmr->cn |= (MXC_F_TMR_REVA_CN_PRES3);
-        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV4);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV2);
         break;
 
     case MXC_TMR_PRES_1024:
         tmr->cn |= (MXC_F_TMR_REVA_CN_PRES3);
-        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV8);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV4);
         break;
 
     case MXC_TMR_PRES_2048:
         tmr->cn |= (MXC_F_TMR_REVA_CN_PRES3);
-        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV16);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV8);
         break;
 
     case MXC_TMR_PRES_4096:
         tmr->cn |= (MXC_F_TMR_REVA_CN_PRES3);
-        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV32);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV16);
         break;
 
     default:

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_reva.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_reva.c
@@ -37,64 +37,72 @@ void MXC_TMR_RevA_Init(mxc_tmr_reva_regs_t *tmr, mxc_tmr_cfg_t *cfg)
     // Set the prescaler
     switch (cfg->pres) {
     case MXC_TMR_PRES_1:
-        tmr->cn |= (MXC_S_TMR_REVA_CN_PRES_DIV1);
+        tmr->cn &= ~(MXC_F_TMR_REVA_CN_PRES3);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV1);
         break;
 
     case MXC_TMR_PRES_2:
-        tmr->cn |= (MXC_S_TMR_REVA_CN_PRES_DIV2);
+        tmr->cn &= ~(MXC_F_TMR_REVA_CN_PRES3);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV2);
         break;
 
     case MXC_TMR_PRES_4:
-        tmr->cn |= (MXC_S_TMR_REVA_CN_PRES_DIV4);
+        tmr->cn &= ~(MXC_F_TMR_REVA_CN_PRES3);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV4);
         break;
 
     case MXC_TMR_PRES_8:
-        tmr->cn |= (MXC_S_TMR_REVA_CN_PRES_DIV8);
+        tmr->cn &= ~(MXC_F_TMR_REVA_CN_PRES3);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV8);
         break;
 
     case MXC_TMR_PRES_16:
-        tmr->cn |= (MXC_S_TMR_REVA_CN_PRES_DIV16);
+        tmr->cn &= ~(MXC_F_TMR_REVA_CN_PRES3);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV16);
         break;
 
     case MXC_TMR_PRES_32:
-        tmr->cn |= (MXC_S_TMR_REVA_CN_PRES_DIV32);
+        tmr->cn &= ~(MXC_F_TMR_REVA_CN_PRES3);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV32);
         break;
 
     case MXC_TMR_PRES_64:
-        tmr->cn |= (MXC_S_TMR_REVA_CN_PRES_DIV64);
+        tmr->cn &= ~(MXC_F_TMR_REVA_CN_PRES3);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV64);
         break;
 
     case MXC_TMR_PRES_128:
-        tmr->cn |= (MXC_S_TMR_REVA_CN_PRES_DIV128);
+        tmr->cn &= ~(MXC_F_TMR_REVA_CN_PRES3);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV128);
         break;
 
     case MXC_TMR_PRES_256:
         tmr->cn |= (MXC_F_TMR_REVA_CN_PRES3);
-        tmr->cn &= ~(MXC_S_TMR_REVA_CN_PRES_DIV1);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV1);
         break;
 
     case MXC_TMR_PRES_512:
         tmr->cn |= (MXC_F_TMR_REVA_CN_PRES3);
-        tmr->cn |= (MXC_S_TMR_REVA_CN_PRES_DIV4);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV4);
         break;
 
     case MXC_TMR_PRES_1024:
         tmr->cn |= (MXC_F_TMR_REVA_CN_PRES3);
-        tmr->cn |= (MXC_S_TMR_REVA_CN_PRES_DIV8);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV8);
         break;
 
     case MXC_TMR_PRES_2048:
         tmr->cn |= (MXC_F_TMR_REVA_CN_PRES3);
-        tmr->cn |= (MXC_S_TMR_REVA_CN_PRES_DIV16);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV16);
         break;
 
     case MXC_TMR_PRES_4096:
         tmr->cn |= (MXC_F_TMR_REVA_CN_PRES3);
-        tmr->cn |= (MXC_S_TMR_REVA_CN_PRES_DIV32);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV32);
         break;
 
     default:
-        tmr->cn |= (MXC_S_TMR_REVA_CN_PRES_DIV1);
+        MXC_SETFIELD(tmr->cn, 0b111 << MXC_F_TMR_REVA_CN_PRES_POS, MXC_S_TMR_REVA_CN_PRES_DIV1);
         break;
     }
 


### PR DESCRIPTION
### Description

Fixes #947 

The ME10 UG has a mistake that propagated itself to our periphdrivers.  The logic table skips from `0b000` to `0b010` at the transition between 256 -> 512.  This causes 512 - 2048 to be twice what they should, and 4096 to roll over to an invalid setting that behaves like a divisor of 1.

![image](https://github.com/analogdevicesinc/msdk/assets/38844790/8572de4f-cc73-449c-934e-0584f63849be)

This PR updates the divisor settings to remove the skip

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
