### PR TITLE
ci(workflow): Add workflow for copying necessary files to Zephyr HAL repo

### DIFF
--- a/.github/workflows/scripts/zephyr-hal.sh
+++ b/.github/workflows/scripts/zephyr-hal.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo
+echo "Test workflow and script for copying files from MSDK repo to Zephyr repo."
+echo
+

--- a/.github/workflows/zephyr-hal.yml
+++ b/.github/workflows/zephyr-hal.yml
@@ -1,0 +1,72 @@
+name: Publish MSDK HAL for Zephyr
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Controls when the workflow will run
+on:
+  # Run only when a pull-request is closed.
+  # The 'if_merged' condition in the 'jobs' section below will make sure the PR was
+  #  approved before running the steps.
+  pull_request:
+    types:
+      - closed
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  # Add environment variables here
+  PR_NUM: ${{ github.event.number }}
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  if_merged:
+    # Run only when a PR is merged
+    if: github.event.pull_request.merged == true
+
+    # The type of OS that the job will run on
+    runs-on: [ ubuntu-latest ]
+
+    permissions:
+      # This will depend on permissions set by repo and org (separate levels of permissions)
+      contents: write
+
+    steps:
+      # Checkout msdk repository
+      - name: Checkout msdk repository
+        uses: actions/checkout@v4
+        with:
+          # Specific Branch, tag, or SHA to checkout (uses default branch if empty)
+          ref: ''
+          # Repository name (Default will be the current repo the action is running from)
+          repository: ${{ github.repository }}
+          fetch-depth: 0
+          # Name the path/directory of this repo for the runner's workspacee
+          path: msdk
+
+      # Checkout another repository
+      - name: Checkout zephry hal repository
+        uses: actions/checkout@v4
+        with:
+          # Specific Branch, tag, or SHA to checkout (uses default branch if empty)
+          ref: ''
+          # Name of different repository ('organization_name/repo_name')
+          repository: 'analogdevicesinc/IAR_Support_For_MAX32xxx'
+          fetch-depth: 0
+          # Name the path/directory of this repo for the runner's workspacee
+          path: zephyr-hal
+      
+      - name: Copy necessary files from msdk to zephyr-hal
+        run: |
+          # Call or run any tasks here
+          bash scripts/zephyr-hal.sh
+
+      - name: Push zephyr-hal directory to zephyr hal repository
+        uses: EndBug/add-and-commit@v9.0.1
+        with:
+          add: '*'
+          message: 'Updating Zephyr MSDK Hal based on msdk PR# $PR_NUM'
+          push: true
+          # Specify path in workspace to the repo you want to push to
+          cwd: './zephyr-hal'


### PR DESCRIPTION
## Mirror MSDK files used by Zephyr port

### Description

The Zephyr port for the MAX32xxx devices uses files from this repo.  The port will not be accepted by the Zephyr review committee if it contains too many extraneous files.  This workflow will copy only the files that Zephyr needs into a stand-alone, slimmed down repository.