### PR TITLE
fix(MiscDrivers): Fix Blank MAX78000EVKIT TFT Display

### DIFF
--- a/Libraries/MiscDrivers/Display/tft_ssd2119.c
+++ b/Libraries/MiscDrivers/Display/tft_ssd2119.c
@@ -511,6 +511,7 @@ static void tft_spi_init(void)
     tft_pins.mosi = true; ///< mosi pin
     tft_pins.sdio2 = false; ///< SDIO2 pin
     tft_pins.sdio3 = false; ///< SDIO3 pin
+    tft_pins.vddioh = true;
 
     MXC_SPI_Init((mxc_spi_regs_t *)spi, master, quadMode, numSlaves, ssPol, tft_spi_freq, tft_pins);
 #endif


### PR DESCRIPTION
## Pull Request Template

### Description

After #880, @aniktash reported the TFT on the MAX78000EVKIT was broken/blank.  None of the demos were working.

It turns out that the driver simply did not initialize the vddioh member of an internal struct describing the SPI pins, so it was initialized to a random undefined value and optimized out by the compiler.  The SPI pins then got initialized to 1.8V instead of 3.3V. 

After this fix, all the TFT-based demos should be working again.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.