### PR TITLE
fix(PeriphDrivers): Clarify GPIO drive strength enum documentation

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32520/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32520/gpio.h
@@ -127,12 +127,26 @@ typedef enum {
 
 /**
  * @brief   Enumeration type for drive strength on a given pin.
+ *          This represents what the two GPIO_DS[2] (Drive Strength) 
+ *          registers are set to for a given GPIO pin; NOT the
+ *          drive strength level.
+ *
+ *          For example:
+ *              MXC_GPIO_DRVSTR_0: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_1: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 1
+ *              MXC_GPIO_DRVSTR_2: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_3: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 1
+ *
+ *          Refer to the user guide and datasheet to select the
+ *          appropriate drive strength. Note: the drive strength values
+ *          are not linear, and can vary from pin-to-pin and the state
+ *          of the GPIO pin (alternate function and voltage level).
  */
 typedef enum {
-    MXC_GPIO_DRVSTR_0, ///< Drive Strength 0
-    MXC_GPIO_DRVSTR_1, ///< Drive Strength 1
-    MXC_GPIO_DRVSTR_2, ///< Drive Strength 2
-    MXC_GPIO_DRVSTR_3, ///< Drive Strength 3
+    MXC_GPIO_DRVSTR_0, ///< Drive Strength GPIO_DS[2][pin]=0b00
+    MXC_GPIO_DRVSTR_1, ///< Drive Strength GPIO_DS[2][pin]=0b01
+    MXC_GPIO_DRVSTR_2, ///< Drive Strength GPIO_DS[2][pin]=0b10
+    MXC_GPIO_DRVSTR_3, ///< Drive Strength GPIO_DS[2][pin]=0b11
 } mxc_gpio_drvstr_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32570/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/gpio.h
@@ -126,12 +126,26 @@ typedef enum {
 
 /**
  * @brief   Enumeration type for drive strength on a given pin.
+ *          This represents what the two GPIO_DS[2] (Drive Strength) 
+ *          registers are set to for a given GPIO pin; NOT the
+ *          drive strength level.
+ *
+ *          For example:
+ *              MXC_GPIO_DRVSTR_0: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_1: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 1
+ *              MXC_GPIO_DRVSTR_2: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_3: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 1
+ *
+ *          Refer to the user guide and datasheet to select the
+ *          appropriate drive strength. Note: the drive strength values
+ *          are not linear, and can vary from pin-to-pin and the state
+ *          of the GPIO pin (alternate function and voltage level).
  */
 typedef enum {
-    MXC_GPIO_DRVSTR_0, ///< Drive Strength 0
-    MXC_GPIO_DRVSTR_1, ///< Drive Strength 1
-    MXC_GPIO_DRVSTR_2, ///< Drive Strength 2
-    MXC_GPIO_DRVSTR_3, ///< Drive Strength 3
+    MXC_GPIO_DRVSTR_0, ///< Drive Strength GPIO_DS[2][pin]=0b00
+    MXC_GPIO_DRVSTR_1, ///< Drive Strength GPIO_DS[2][pin]=0b01
+    MXC_GPIO_DRVSTR_2, ///< Drive Strength GPIO_DS[2][pin]=0b10
+    MXC_GPIO_DRVSTR_3, ///< Drive Strength GPIO_DS[2][pin]=0b11
 } mxc_gpio_drvstr_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32572/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/gpio.h
@@ -127,12 +127,26 @@ typedef enum {
 
 /**
  * @brief   Enumeration type for drive strength on a given pin.
+ *          This represents what the two GPIO_DS[2] (Drive Strength) 
+ *          registers are set to for a given GPIO pin; NOT the
+ *          drive strength level.
+ *
+ *          For example:
+ *              MXC_GPIO_DRVSTR_0: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_1: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 1
+ *              MXC_GPIO_DRVSTR_2: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_3: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 1
+ *
+ *          Refer to the user guide and datasheet to select the
+ *          appropriate drive strength. Note: the drive strength values
+ *          are not linear, and can vary from pin-to-pin and the state
+ *          of the GPIO pin (alternate function and voltage level).
  */
 typedef enum {
-    MXC_GPIO_DRVSTR_0, ///< Drive Strength 0
-    MXC_GPIO_DRVSTR_1, ///< Drive Strength 1
-    MXC_GPIO_DRVSTR_2, ///< Drive Strength 2
-    MXC_GPIO_DRVSTR_3, ///< Drive Strength 3
+    MXC_GPIO_DRVSTR_0, ///< Drive Strength GPIO_DS[2][pin]=0b00
+    MXC_GPIO_DRVSTR_1, ///< Drive Strength GPIO_DS[2][pin]=0b01
+    MXC_GPIO_DRVSTR_2, ///< Drive Strength GPIO_DS[2][pin]=0b10
+    MXC_GPIO_DRVSTR_3, ///< Drive Strength GPIO_DS[2][pin]=0b11
 } mxc_gpio_drvstr_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32650/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/gpio.h
@@ -126,13 +126,27 @@ typedef enum {
 } mxc_gpio_vssel_t;
 
 /**
- * @brief   Enumeration type for drive strength configuration.
+ * @brief   Enumeration type for drive strength on a given pin.
+ *          This represents what the two GPIO_DS[2] (Drive Strength) 
+ *          registers are set to for a given GPIO pin; NOT the
+ *          drive strength level.
+ *
+ *          For example:
+ *              MXC_GPIO_DRVSTR_0: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_1: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 1
+ *              MXC_GPIO_DRVSTR_2: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_3: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 1
+ *
+ *          Refer to the user guide and datasheet to select the
+ *          appropriate drive strength. Note: the drive strength values
+ *          are not linear, and can vary from pin-to-pin and the state
+ *          of the GPIO pin (alternate function and voltage level).
  */
 typedef enum {
-    MXC_GPIO_DRVSTR_0, /**< Drive Strength 0 */
-    MXC_GPIO_DRVSTR_1, /**< Drive Strength 1 */
-    MXC_GPIO_DRVSTR_2, /**< Drive Strength 2 */
-    MXC_GPIO_DRVSTR_3, /**< Drive Strength 3 */
+    MXC_GPIO_DRVSTR_0, /**< Drive Strength GPIO_DS[2][pin]=0b00 */
+    MXC_GPIO_DRVSTR_1, /**< Drive Strength GPIO_DS[2][pin]=0b01 */
+    MXC_GPIO_DRVSTR_2, /**< Drive Strength GPIO_DS[2][pin]=0b10 */
+    MXC_GPIO_DRVSTR_3, /**< Drive Strength GPIO_DS[2][pin]=0b11 */
 } mxc_gpio_drvstr_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32655/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/gpio.h
@@ -126,12 +126,26 @@ typedef enum {
 
 /**
  * @brief   Enumeration type for drive strength on a given pin.
+ *          This represents what the two GPIO_DS[2] (Drive Strength) 
+ *          registers are set to for a given GPIO pin; NOT the
+ *          drive strength level.
+ *
+ *          For example:
+ *              MXC_GPIO_DRVSTR_0: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_1: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 1
+ *              MXC_GPIO_DRVSTR_2: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_3: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 1
+ *
+ *          Refer to the user guide and datasheet to select the
+ *          appropriate drive strength. Note: the drive strength values
+ *          are not linear, and can vary from pin-to-pin and the state
+ *          of the GPIO pin (alternate function and voltage level).
  */
 typedef enum {
-    MXC_GPIO_DRVSTR_0, /**< Drive Strength 0 */
-    MXC_GPIO_DRVSTR_1, /**< Drive Strength 1 */
-    MXC_GPIO_DRVSTR_2, /**< Drive Strength 2 */
-    MXC_GPIO_DRVSTR_3, /**< Drive Strength 3 */
+    MXC_GPIO_DRVSTR_0, /**< Drive Strength GPIO_DS[2][pin]=0b00 */
+    MXC_GPIO_DRVSTR_1, /**< Drive Strength GPIO_DS[2][pin]=0b01 */
+    MXC_GPIO_DRVSTR_2, /**< Drive Strength GPIO_DS[2][pin]=0b10 */
+    MXC_GPIO_DRVSTR_3, /**< Drive Strength GPIO_DS[2][pin]=0b11 */
 } mxc_gpio_drvstr_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32660/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/gpio.h
@@ -105,12 +105,26 @@ typedef enum {
 
 /**
  * @brief   Enumeration type for drive strength on a given pin.
+ *          This represents what the two GPIO_DS[2] (Drive Strength) 
+ *          registers are set to for a given GPIO pin; NOT the
+ *          drive strength level.
+ *
+ *          For example:
+ *              MXC_GPIO_DRVSTR_0: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_1: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 1
+ *              MXC_GPIO_DRVSTR_2: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_3: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 1
+ *
+ *          Refer to the user guide and datasheet to select the
+ *          appropriate drive strength. Note: the drive strength values
+ *          are not linear, and can vary from pin-to-pin and the state
+ *          of the GPIO pin (alternate function and voltage level).
  */
 typedef enum {
-    MXC_GPIO_DRVSTR_0, ///< Drive Strength 0
-    MXC_GPIO_DRVSTR_1, ///< Drive Strength 1
-    MXC_GPIO_DRVSTR_2, ///< Drive Strength 2
-    MXC_GPIO_DRVSTR_3, ///< Drive Strength 3
+    MXC_GPIO_DRVSTR_0, ///< Drive Strength GPIO_DS[2][pin]=0b00
+    MXC_GPIO_DRVSTR_1, ///< Drive Strength GPIO_DS[2][pin]=0b01
+    MXC_GPIO_DRVSTR_2, ///< Drive Strength GPIO_DS[2][pin]=0b10
+    MXC_GPIO_DRVSTR_3, ///< Drive Strength GPIO_DS[2][pin]=0b11
 } mxc_gpio_drvstr_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32662/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/gpio.h
@@ -125,12 +125,26 @@ typedef enum {
 
 /**
  * @brief   Enumeration type for drive strength on a given pin.
+ *          This represents what the two GPIO_DS[2] (Drive Strength) 
+ *          registers are set to for a given GPIO pin; NOT the
+ *          drive strength level.
+ *
+ *          For example:
+ *              MXC_GPIO_DRVSTR_0: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_1: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 1
+ *              MXC_GPIO_DRVSTR_2: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_3: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 1
+ *
+ *          Refer to the user guide and datasheet to select the
+ *          appropriate drive strength. Note: the drive strength values
+ *          are not linear, and can vary from pin-to-pin and the state
+ *          of the GPIO pin (alternate function and voltage level).
  */
 typedef enum {
-    MXC_GPIO_DRVSTR_0, /**< Drive Strength 0 */
-    MXC_GPIO_DRVSTR_1, /**< Drive Strength 1 */
-    MXC_GPIO_DRVSTR_2, /**< Drive Strength 2 */
-    MXC_GPIO_DRVSTR_3, /**< Drive Strength 3 */
+    MXC_GPIO_DRVSTR_0, /**< Drive Strength GPIO_DS[2][pin]=0b00 */
+    MXC_GPIO_DRVSTR_1, /**< Drive Strength GPIO_DS[2][pin]=0b01 */
+    MXC_GPIO_DRVSTR_2, /**< Drive Strength GPIO_DS[2][pin]=0b10 */
+    MXC_GPIO_DRVSTR_3, /**< Drive Strength GPIO_DS[2][pin]=0b11 */
 } mxc_gpio_drvstr_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32665/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/gpio.h
@@ -124,13 +124,27 @@ typedef enum {
 } mxc_gpio_vssel_t;
 
 /**
- * @brief   Enumeration type for drive strength configuration.
+ * @brief   Enumeration type for drive strength on a given pin.
+ *          This represents what the two GPIO_DS[2] (Drive Strength) 
+ *          registers are set to for a given GPIO pin; NOT the
+ *          drive strength level.
+ *
+ *          For example:
+ *              MXC_GPIO_DRVSTR_0: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_1: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 1
+ *              MXC_GPIO_DRVSTR_2: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_3: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 1
+ *
+ *          Refer to the user guide and datasheet to select the
+ *          appropriate drive strength. Note: the drive strength values
+ *          are not linear, and can vary from pin-to-pin and the state
+ *          of the GPIO pin (alternate function and voltage level).
  */
 typedef enum {
-    MXC_GPIO_DRVSTR_0, /**< Drive Strength 0 */
-    MXC_GPIO_DRVSTR_1, /**< Drive Strength 1 */
-    MXC_GPIO_DRVSTR_2, /**< Drive Strength 2 */
-    MXC_GPIO_DRVSTR_3, /**< Drive Strength 3 */
+    MXC_GPIO_DRVSTR_0, /**< Drive Strength GPIO_DS[2][pin]=0b00 */
+    MXC_GPIO_DRVSTR_1, /**< Drive Strength GPIO_DS[2][pin]=0b01 */
+    MXC_GPIO_DRVSTR_2, /**< Drive Strength GPIO_DS[2][pin]=0b10 */
+    MXC_GPIO_DRVSTR_3, /**< Drive Strength GPIO_DS[2][pin]=0b11 */
 } mxc_gpio_drvstr_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32670/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/gpio.h
@@ -126,12 +126,26 @@ typedef enum {
 
 /**
  * @brief   Enumeration type for drive strength on a given pin.
+ *          This represents what the two GPIO_DS[2] (Drive Strength) 
+ *          registers are set to for a given GPIO pin; NOT the
+ *          drive strength level.
+ *
+ *          For example:
+ *              MXC_GPIO_DRVSTR_0: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_1: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 1
+ *              MXC_GPIO_DRVSTR_2: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_3: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 1
+ *
+ *          Refer to the user guide and datasheet to select the
+ *          appropriate drive strength. Note: the drive strength values
+ *          are not linear, and can vary from pin-to-pin and the state
+ *          of the GPIO pin (alternate function and voltage level).
  */
 typedef enum {
-    MXC_GPIO_DRVSTR_0, ///< Drive Strength 0
-    MXC_GPIO_DRVSTR_1, ///< Drive Strength 1
-    MXC_GPIO_DRVSTR_2, ///< Drive Strength 2
-    MXC_GPIO_DRVSTR_3, ///< Drive Strength 3
+    MXC_GPIO_DRVSTR_0, ///< Drive Strength GPIO_DS[2][pin]=0b00
+    MXC_GPIO_DRVSTR_1, ///< Drive Strength GPIO_DS[2][pin]=0b01
+    MXC_GPIO_DRVSTR_2, ///< Drive Strength GPIO_DS[2][pin]=0b10
+    MXC_GPIO_DRVSTR_3, ///< Drive Strength GPIO_DS[2][pin]=0b11
 } mxc_gpio_drvstr_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32672/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/gpio.h
@@ -126,12 +126,26 @@ typedef enum {
 
 /**
  * @brief   Enumeration type for drive strength on a given pin.
+ *          This represents what the two GPIO_DS[2] (Drive Strength) 
+ *          registers are set to for a given GPIO pin; NOT the
+ *          drive strength level.
+ *
+ *          For example:
+ *              MXC_GPIO_DRVSTR_0: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_1: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 1
+ *              MXC_GPIO_DRVSTR_2: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_3: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 1
+ *
+ *          Refer to the user guide and datasheet to select the
+ *          appropriate drive strength. Note: the drive strength values
+ *          are not linear, and can vary from pin-to-pin and the state
+ *          of the GPIO pin (alternate function and voltage level).
  */
 typedef enum {
-    MXC_GPIO_DRVSTR_0, ///< Drive Strength 0
-    MXC_GPIO_DRVSTR_1, ///< Drive Strength 1
-    MXC_GPIO_DRVSTR_2, ///< Drive Strength 2
-    MXC_GPIO_DRVSTR_3, ///< Drive Strength 3
+    MXC_GPIO_DRVSTR_0, ///< Drive Strength GPIO_DS[2][pin]=0b00
+    MXC_GPIO_DRVSTR_1, ///< Drive Strength GPIO_DS[2][pin]=0b01
+    MXC_GPIO_DRVSTR_2, ///< Drive Strength GPIO_DS[2][pin]=0b10
+    MXC_GPIO_DRVSTR_3, ///< Drive Strength GPIO_DS[2][pin]=0b11
 } mxc_gpio_drvstr_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32675/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/gpio.h
@@ -125,13 +125,27 @@ typedef enum {
 } mxc_gpio_vssel_t;
 
 /**
- * @brief   Enumeration type for the voltage level on a given pin.
+ * @brief   Enumeration type for drive strength on a given pin.
+ *          This represents what the two GPIO_DS[2] (Drive Strength) 
+ *          registers are set to for a given GPIO pin; NOT the
+ *          drive strength level.
+ *
+ *          For example:
+ *              MXC_GPIO_DRVSTR_0: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_1: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 1
+ *              MXC_GPIO_DRVSTR_2: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_3: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 1
+ *
+ *          Refer to the user guide and datasheet to select the
+ *          appropriate drive strength. Note: the drive strength values
+ *          are not linear, and can vary from pin-to-pin and the state
+ *          of the GPIO pin (alternate function and voltage level).
  */
 typedef enum {
-    MXC_GPIO_DRVSTR_0, ///< Drive Strength 0
-    MXC_GPIO_DRVSTR_1, ///< Drive Strength 1
-    MXC_GPIO_DRVSTR_2, ///< Drive Strength 2
-    MXC_GPIO_DRVSTR_3, ///< Drive Strength 3
+    MXC_GPIO_DRVSTR_0, ///< Drive Strength GPIO_DS[2][pin]=0b00
+    MXC_GPIO_DRVSTR_1, ///< Drive Strength GPIO_DS[2][pin]=0b01
+    MXC_GPIO_DRVSTR_2, ///< Drive Strength GPIO_DS[2][pin]=0b10
+    MXC_GPIO_DRVSTR_3, ///< Drive Strength GPIO_DS[2][pin]=0b11
 } mxc_gpio_drvstr_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32680/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/gpio.h
@@ -126,12 +126,26 @@ typedef enum {
 
 /**
  * @brief   Enumeration type for drive strength on a given pin.
+ *          This represents what the two GPIO_DS[2] (Drive Strength) 
+ *          registers are set to for a given GPIO pin; NOT the
+ *          drive strength level.
+ *
+ *          For example:
+ *              MXC_GPIO_DRVSTR_0: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_1: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 1
+ *              MXC_GPIO_DRVSTR_2: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_3: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 1
+ *
+ *          Refer to the user guide and datasheet to select the
+ *          appropriate drive strength. Note: the drive strength values
+ *          are not linear, and can vary from pin-to-pin and the state
+ *          of the GPIO pin (alternate function and voltage level).
  */
 typedef enum {
-    MXC_GPIO_DRVSTR_0, /**< Drive Strength 0 */
-    MXC_GPIO_DRVSTR_1, /**< Drive Strength 1 */
-    MXC_GPIO_DRVSTR_2, /**< Drive Strength 2 */
-    MXC_GPIO_DRVSTR_3, /**< Drive Strength 3 */
+    MXC_GPIO_DRVSTR_0, ///< Drive Strength GPIO_DS[2][pin]=0b00
+    MXC_GPIO_DRVSTR_1, ///< Drive Strength GPIO_DS[2][pin]=0b01
+    MXC_GPIO_DRVSTR_2, ///< Drive Strength GPIO_DS[2][pin]=0b10
+    MXC_GPIO_DRVSTR_3, ///< Drive Strength GPIO_DS[2][pin]=0b11
 } mxc_gpio_drvstr_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32690/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/gpio.h
@@ -127,12 +127,26 @@ typedef enum {
 
 /**
  * @brief   Enumeration type for drive strength on a given pin.
+ *          This represents what the two GPIO_DS[2] (Drive Strength) 
+ *          registers are set to for a given GPIO pin; NOT the
+ *          drive strength level.
+ *
+ *          For example:
+ *              MXC_GPIO_DRVSTR_0: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_1: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 1
+ *              MXC_GPIO_DRVSTR_2: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_3: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 1
+ *
+ *          Refer to the user guide and datasheet to select the
+ *          appropriate drive strength. Note: the drive strength values
+ *          are not linear, and can vary from pin-to-pin and the state
+ *          of the GPIO pin (alternate function and voltage level).
  */
 typedef enum {
-    MXC_GPIO_DRVSTR_0 = 0, /**< Drive Strength 0 */
-    MXC_GPIO_DRVSTR_1, /**< Drive Strength 1 */
-    MXC_GPIO_DRVSTR_2, /**< Drive Strength 2 */
-    MXC_GPIO_DRVSTR_3, /**< Drive Strength 3 */
+    MXC_GPIO_DRVSTR_0, /**< Drive Strength GPIO_DS[2][pin]=0b00 */
+    MXC_GPIO_DRVSTR_1, /**< Drive Strength GPIO_DS[2][pin]=0b01 */
+    MXC_GPIO_DRVSTR_2, /**< Drive Strength GPIO_DS[2][pin]=0b10 */
+    MXC_GPIO_DRVSTR_3, /**< Drive Strength GPIO_DS[2][pin]=0b11 */
 } mxc_gpio_drvstr_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX78000/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/gpio.h
@@ -126,12 +126,26 @@ typedef enum {
 
 /**
  * @brief   Enumeration type for drive strength on a given pin.
+ *          This represents what the two GPIO_DS[2] (Drive Strength) 
+ *          registers are set to for a given GPIO pin; NOT the
+ *          drive strength level.
+ *
+ *          For example:
+ *              MXC_GPIO_DRVSTR_0: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_1: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 1
+ *              MXC_GPIO_DRVSTR_2: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_3: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 1
+ *
+ *          Refer to the user guide and datasheet to select the
+ *          appropriate drive strength. Note: the drive strength values
+ *          are not linear, and can vary from pin-to-pin and the state
+ *          of the GPIO pin (alternate function and voltage level).
  */
 typedef enum {
-    MXC_GPIO_DRVSTR_0, /**< Drive Strength 0 */
-    MXC_GPIO_DRVSTR_1, /**< Drive Strength 1 */
-    MXC_GPIO_DRVSTR_2, /**< Drive Strength 2 */
-    MXC_GPIO_DRVSTR_3, /**< Drive Strength 3 */
+    MXC_GPIO_DRVSTR_0, /**< Drive Strength GPIO_DS[2][pin]=0b00 */
+    MXC_GPIO_DRVSTR_1, /**< Drive Strength GPIO_DS[2][pin]=0b01 */
+    MXC_GPIO_DRVSTR_2, /**< Drive Strength GPIO_DS[2][pin]=0b10 */
+    MXC_GPIO_DRVSTR_3, /**< Drive Strength GPIO_DS[2][pin]=0b11 */
 } mxc_gpio_drvstr_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX78002/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/gpio.h
@@ -125,13 +125,27 @@ typedef enum {
 } mxc_gpio_vssel_t;
 
 /**
- * @brief   Enumeration type for drive strength configuration.
+ * @brief   Enumeration type for drive strength on a given pin.
+ *          This represents what the two GPIO_DS[2] (Drive Strength) 
+ *          registers are set to for a given GPIO pin; NOT the
+ *          drive strength level.
+ *
+ *          For example:
+ *              MXC_GPIO_DRVSTR_0: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_1: GPIO_DS1[pin] = 0; GPIO_DS0[pin] = 1
+ *              MXC_GPIO_DRVSTR_2: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 0
+ *              MXC_GPIO_DRVSTR_3: GPIO_DS1[pin] = 1; GPIO_DS0[pin] = 1
+ *
+ *          Refer to the user guide and datasheet to select the
+ *          appropriate drive strength. Note: the drive strength values
+ *          are not linear, and can vary from pin-to-pin and the state
+ *          of the GPIO pin (alternate function and voltage level).
  */
 typedef enum {
-    MXC_GPIO_DRVSTR_0, /**< Drive Strength 0 */
-    MXC_GPIO_DRVSTR_1, /**< Drive Strength 1 */
-    MXC_GPIO_DRVSTR_2, /**< Drive Strength 2 */
-    MXC_GPIO_DRVSTR_3, /**< Drive Strength 3 */
+    MXC_GPIO_DRVSTR_0, /**< Drive Strength GPIO_DS[2][pin]=0b00 */
+    MXC_GPIO_DRVSTR_1, /**< Drive Strength GPIO_DS[2][pin]=0b01 */
+    MXC_GPIO_DRVSTR_2, /**< Drive Strength GPIO_DS[2][pin]=0b10 */
+    MXC_GPIO_DRVSTR_3, /**< Drive Strength GPIO_DS[2][pin]=0b11 */
 } mxc_gpio_drvstr_t;
 
 /**


### PR DESCRIPTION
### Description

Hope this makes sense - let me know if not.

This PR updates the GPIO drive strength documentation to make it clear that it does not represent the GPIO drive strength level, but rather what the GPIO drive strength registers `GPIO_DS[2]` are set to. The actual drive strength values are not used in the enum names because the drive strength values can vary from pin-to-pin and the state of the GPIO pin (alternate function and voltage setting). 

Refer to https://github.com/analogdevicesinc/msdk/issues/983 for more info.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.