### PR TITLE
fix(CMSIS): Add GPIOWAKE_IRQn to MAX32675

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.h
@@ -121,7 +121,7 @@ typedef enum {
     RSV51_IRQn, /* 0x43  0x010C  67: Reserved */
     RSV52_IRQn, /* 0x44  0x0110  68: Reserved */
     RSV53_IRQn, /* 0x45  0x0114  69: Reserved */
-    RSV54_IRQn, /* 0x46  0x0118  70: Reserved */
+    GPIOWAKE_IRQn, /* 0x46  0x0118  70: GPIOWAKE */
     RSV55_IRQn, /* 0x47  0x011C  71: Reserved */
     RSV56_IRQn, /* 0x48  0x0120  72: Reserved */
     WDT1_IRQn, /* 0x49  0x0124  73: Watchdog 1 */

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Source/GCC/startup_max32675.S
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Source/GCC/startup_max32675.S
@@ -130,7 +130,7 @@ __isr_vector:
     .long RSV51_IRQHandler          /* 0x43  0x010C  67: Reserved */
     .long RSV52_IRQHandler          /* 0x44  0x0110  68: Reserved */
     .long RSV53_IRQHandler          /* 0x45  0x0114  69: Reserved */
-    .long RSV54_IRQHandler          /* 0x46  0x0118  70: Reserved */
+    .long GPIOWAKE_IRQHandler       /* 0x46  0x0118  70: GPIOWAKE */
     .long RSV55_IRQHandler          /* 0x47  0x011C  71: Reserved */
     .long RSV56_IRQHandler          /* 0x48  0x0120  72: Reserved */
     .long WDT1_IRQHandler           /* 0x49  0x0124  73: Watchdog 1 */
@@ -338,7 +338,7 @@ Reset_Handler:
     def_irq_handler     RSV51_IRQHandler          /* 0x43  0x010C  67: Reserved */
     def_irq_handler     RSV52_IRQHandler          /* 0x44  0x0110  68: Reserved */
     def_irq_handler     RSV53_IRQHandler          /* 0x45  0x0114  69: Reserved */
-    def_irq_handler     RSV54_IRQHandler          /* 0x46  0x0118  70: Reserved */
+    def_irq_handler     GPIOWAKE_IRQHandler       /* 0x46  0x0118  70: GPIOWAKE */
     def_irq_handler     RSV55_IRQHandler          /* 0x47  0x011C  71: Reserved */
     def_irq_handler     RSV56_IRQHandler          /* 0x48  0x0120  72: Reserved */
     def_irq_handler     WDT1_IRQHandler           /* 0x49  0x0124  73: Watchdog 1 */


### PR DESCRIPTION
### Description

The MAX32675 was missing the GPIOWAKE vector.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.