### PR TITLE
chore(Other): Add zephyr related wrapper and system file in MSDK

### DIFF
--- a/.github/workflows/scripts/zephyr-hal.sh
+++ b/.github/workflows/scripts/zephyr-hal.sh
@@ -12,9 +12,6 @@ else
     hal_adi="./hal_adi"
 fi
 
-src="${msdk}/Libraries"
-dst="${hal_adi}/MAX/Libraries"
-
 root_dir=$(pwd)
 
 # Get SHA
@@ -24,29 +21,35 @@ cd ${root_dir}
 
 
 # Cleanup hal_adi
-rm -rf ${dst}/CMSIS/*
-rm -rf ${dst}/PeriphDrivers/*
+rm -rf ${hal_adi}/MAX/
+
+# Create parent folder
+mkdir -p ${hal_adi}/MAX/Libraries/CMSIS
+mkdir -p ${hal_adi}/MAX/Libraries/PeriphDrivers
+
+# Copy zephyr wrappers, system files and cmakefiles
+cp -rf ${msdk}/Libraries/zephyr/MAX/*  ${hal_adi}/MAX/
 
 # Copy CMSIS folder
-cp -rf ${src}/CMSIS/Device  ${dst}/CMSIS/
-cp -rf ${src}/CMSIS/Include  ${dst}/CMSIS/
+cp -rf ${msdk}/Libraries/CMSIS/Device  ${hal_adi}/MAX/Libraries/CMSIS/
+cp -rf ${msdk}/Libraries/CMSIS/Include ${hal_adi}/MAX/Libraries/CMSIS/
 
 # Copy PeriphDrivers folder
-cp -rf ${src}/PeriphDrivers/Include  ${dst}/PeriphDrivers/
-cp -rf ${src}/PeriphDrivers/Source  ${dst}/PeriphDrivers/
+cp -rf ${msdk}/Libraries/PeriphDrivers/Include ${hal_adi}/MAX/Libraries/PeriphDrivers/
+cp -rf ${msdk}/Libraries/PeriphDrivers/Source  ${hal_adi}/MAX/Libraries/PeriphDrivers/
 
 # Remove unneeded files
-rm -rf ${dst}/CMSIS/Device/Maxim/GCC
-rm -rf ${dst}/CMSIS/Device/Maxim/MAX*/Source/IAR
-rm -rf ${dst}/CMSIS/Device/Maxim/MAX*/Source/GCC
-rm -rf ${dst}/CMSIS/Device/Maxim/MAX*/Source/ARM
+rm -rf ${hal_adi}/MAX/Libraries/CMSIS/Device/Maxim/GCC
+rm -rf ${hal_adi}/MAX/Libraries/CMSIS/Device/Maxim/MAX*/Source/IAR
+rm -rf ${hal_adi}/MAX/Libraries/CMSIS/Device/Maxim/MAX*/Source/GCC
+rm -rf ${hal_adi}/MAX/Libraries/CMSIS/Device/Maxim/MAX*/Source/ARM
 
 # Check either dirty or clean
 cd ${hal_adi}
 if [[ -n $(git status -s) ]]; then
     echo "New change exist need to be pushed"
     # Set new SHA
-    echo "${msdk_head}" > MAX/Libraries/msdk_sha
+    echo "${msdk_head}" > MAX/msdk_sha
 else
     # No need to push to hal_adi
     echo "No any change in hal_adi"

--- a/Libraries/zephyr/MAX/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/CMakeLists.txt
@@ -1,8 +1,20 @@
-# Makefile - Analog Devices SDK
+##############################################################################
 #
-# Copyright (c) 2023 Analog Devices, Inc.
+# Copyright (C) 2023-2024 Analog Devices, Inc.
 #
-# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##############################################################################
 
 
 if (${CONFIG_SOC} MATCHES "max32666")

--- a/Libraries/zephyr/MAX/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/CMakeLists.txt
@@ -1,0 +1,50 @@
+# Makefile - Analog Devices SDK
+#
+# Copyright (c) 2023 Analog Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+if (${CONFIG_SOC} MATCHES "max32666")
+    set(TARGET_LC "max32665")
+elseif (${CONFIG_SOC} MATCHES "max326651")
+    set(TARGET_LC "max32650")
+else ()
+    set(TARGET_LC ${CONFIG_SOC})
+endif()
+string(TOUPPER ${TARGET_LC} TARGET_UC)
+
+zephyr_compile_definitions(
+    -DTARGET=${TARGET_UC}
+    -DMSDK_NO_GPIO_CLK_INIT=1
+    -DMSDK_NO_LOCKING=1
+)
+
+get_filename_component(MSDK_LIBRARY_DIR "./Libraries" ABSOLUTE)
+set(MSDK_CMSIS_DIR       ${MSDK_LIBRARY_DIR}/CMSIS/Device/Maxim/${TARGET_UC})
+set(MSDK_PERIPH_DIR      ${MSDK_LIBRARY_DIR}/PeriphDrivers)
+set(MSDK_PERIPH_SRC_DIR  ${MSDK_PERIPH_DIR}/Source)
+set(MSDK_PERIPH_INC_DIR  ${MSDK_PERIPH_DIR}/Include/${TARGET_UC})
+
+zephyr_include_directories(
+    ./Include
+    ${MSDK_CMSIS_DIR}/Include
+    ${MSDK_PERIPH_INC_DIR}
+)
+
+add_subdirectory_ifdef(CONFIG_SOC_MAX32520 Source/MAX32520)
+add_subdirectory_ifdef(CONFIG_SOC_MAX32570 Source/MAX32570)
+add_subdirectory_ifdef(CONFIG_SOC_MAX32572 Source/MAX32572)
+add_subdirectory_ifdef(CONFIG_SOC_MAX32650 Source/MAX32650)
+add_subdirectory_ifdef(CONFIG_SOC_MAX32655 Source/MAX32655)
+add_subdirectory_ifdef(CONFIG_SOC_MAX32660 Source/MAX32660)
+add_subdirectory_ifdef(CONFIG_SOC_MAX32662 Source/MAX32662)
+add_subdirectory_ifdef(CONFIG_SOC_MAX32665 Source/MAX32665)
+add_subdirectory_ifdef(CONFIG_SOC_MAX32666 Source/MAX32665)
+add_subdirectory_ifdef(CONFIG_SOC_MAX32670 Source/MAX32670)
+add_subdirectory_ifdef(CONFIG_SOC_MAX32672 Source/MAX32672)
+add_subdirectory_ifdef(CONFIG_SOC_MAX32675 Source/MAX32675)
+add_subdirectory_ifdef(CONFIG_SOC_MAX32680 Source/MAX32680)
+add_subdirectory_ifdef(CONFIG_SOC_MAX32690 Source/MAX32690)
+add_subdirectory_ifdef(CONFIG_SOC_MAX78000 Source/MAX78000)
+add_subdirectory_ifdef(CONFIG_SOC_MAX78002 Source/MAX78002)

--- a/Libraries/zephyr/MAX/Include/wrap_max32_adc.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_adc.h
@@ -16,8 +16,8 @@
  *
  ******************************************************************************/
 
-#ifndef _WRAP_MAX32_ADC_H_
-#define _WRAP_MAX32_ADC_H_
+#ifndef LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_ADC_H_
+#define LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_ADC_H_
 
 /***** Includes *****/
 #include <adc.h>
@@ -221,7 +221,7 @@ static inline int Wrap_MXC_ADC_AverageConfig(uint8_t oversampling)
 static inline void Wrap_MXC_ADC_ChannelSelect(uint32_t *sample_channels)
 {
     const uint8_t num_of_channels = POPCOUNT(*sample_channels);
-    mxc_adc_slot_req_t slots[num_of_channels];
+    mxc_adc_slot_req_t slots[MAX_ADC_SLOT_NUM];
     mxc_adc_conversion_req_t req;
     uint8_t slot_index = 0;
     int channel_id;
@@ -302,4 +302,4 @@ static inline void Wrap_MXC_ADC_GetData(uint16_t **outdata)
 }
 #endif
 
-#endif // _WRAP_MAX32_ADC_H_
+#endif // LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_ADC_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_adc.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_adc.h
@@ -1,0 +1,305 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#ifndef _WRAP_MAX32_ADC_H_
+#define _WRAP_MAX32_ADC_H_
+
+/***** Includes *****/
+#include <adc.h>
+#include <wrap_utils.h>
+#include <mxc_delay.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint8_t clock; ///< clock to use
+    uint8_t clkdiv; ///< clock divider
+    uint8_t cal; ///< skip calibration
+    uint8_t ref; ///< ADC reference voltage
+    uint32_t trackCount; ///< Sample Clock High time
+    uint32_t idleCount; ///< Sample Clock Low time
+} wrap_mxc_adc_req_t;
+
+typedef enum {
+    WRAP_MXC_ADC_SCALE_2X, // ADC Scale by 2x (this scales ADC Reference by 1/2)
+    WRAP_MXC_ADC_SCALE_1, // ADC Scale by 1x (no scaling)
+    WRAP_MXC_ADC_SCALE_2, // ADC Scale by 1/2
+    WRAP_MXC_ADC_SCALE_3, // ADC Scale by 1/3
+    WRAP_MXC_ADC_SCALE_4, // ADC Scale by 1/4
+    WRAP_MXC_ADC_SCALE_6, // ADC Scale by 1/6 (this uses 1/3 and an additional 1/2 scaling)
+} wrap_mxc_adc_scale_t;
+
+#define ADI_MAX32_ADC_REF_EXT0 0
+#define ADI_MAX32_ADC_REF_INTERNAL 1
+#define ADI_MAX32_ADC_REF_VDD_1_2 2
+
+/*
+ *  MAX32655, MAX32665, MAX32666 related mapping
+ */
+#if defined(CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666) || \
+    (CONFIG_SOC_MAX32680)
+
+#define WRAP_MXC_F_ADC_CONV_DONE_IE MXC_F_ADC_INTR_DONE_IE
+#define WRAP_MXC_F_ADC_CONV_DONE_IF MXC_F_ADC_INTR_DONE_IF
+
+static inline int Wrap_MXC_ADC_Init(wrap_mxc_adc_req_t *req)
+{
+    (void)req;
+    return MXC_ADC_Init();
+}
+
+static inline void Wrap_MXC_ADC_ChannelSelect(uint32_t *sample_channels)
+{
+    mxc_adc_regs_t *adc = MXC_ADC;
+    int channel_id;
+
+    channel_id = wrap_utils_find_lsb_set(*sample_channels);
+    if (channel_id == 0) {
+        return;
+    }
+    --channel_id;
+
+    adc->ctrl &= ~(MXC_F_ADC_CTRL_CH_SEL);
+    adc->ctrl |= (channel_id << MXC_F_ADC_CTRL_CH_SEL_POS) & MXC_F_ADC_CTRL_CH_SEL;
+}
+
+static inline int Wrap_MXC_ADC_SetExtScale(wrap_mxc_adc_scale_t scale)
+{
+    MXC_ADC_SetExtScale(scale);
+    return 0;
+}
+
+static inline int Wrap_MXC_ADC_AverageConfig(uint8_t oversampling)
+{
+    if (oversampling != 0) {
+        return -1; /* Oversampling is not supported */
+    }
+
+    return 0;
+}
+
+static inline int Wrap_MXC_ADC_ReferenceSelect(uint8_t ref)
+{
+    mxc_adc_regs_t *adc = MXC_ADC;
+
+    if (ref == ADI_MAX32_ADC_REF_INTERNAL) {
+        adc->ctrl &= ~MXC_F_ADC_CTRL_REF_SEL;
+    } else if (ref == ADI_MAX32_ADC_REF_VDD_1_2) {
+        adc->ctrl |= MXC_F_ADC_CTRL_REF_SEL;
+    } else {
+        return -1;
+    }
+
+    return 0;
+}
+
+static inline void Wrap_MXC_ADC_DisableConversion(void)
+{
+    return;
+}
+
+static inline int Wrap_MXC_ADC_StartConversion(uint32_t *sample_channels)
+{
+    int channel_id;
+
+    channel_id = wrap_utils_find_lsb_set(*sample_channels);
+    if (channel_id == 0) {
+        return -1;
+    }
+    --channel_id;
+    *sample_channels &= ~(1 << channel_id);
+
+    return MXC_ADC_StartConversion((mxc_adc_chsel_t)channel_id);
+}
+
+static inline int Wrap_MXC_ADC_StartConversionAsync(uint32_t *sample_channels,
+                                                    mxc_adc_complete_cb_t callback)
+{
+    int channel_id;
+
+    channel_id = wrap_utils_find_lsb_set(*sample_channels);
+    if (channel_id == 0) {
+        return -1;
+    }
+    --channel_id;
+    *sample_channels &= ~(1 << channel_id);
+
+    return MXC_ADC_StartConversionAsync((mxc_adc_chsel_t)channel_id, callback);
+}
+
+static inline void Wrap_MXC_ADC_GetData(uint16_t **outdata)
+{
+    MXC_ADC_GetData(*outdata);
+    *outdata += 1;
+}
+
+/*
+ *  MAX32690,  related mapping
+ */
+#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662)
+
+#define WRAP_MXC_F_ADC_CONV_DONE_IE MXC_F_ADC_INTEN_SEQ_DONE
+#define WRAP_MXC_F_ADC_CONV_DONE_IF MXC_F_ADC_INTFL_SEQ_DONE
+
+#define MAX_OVERSAMPLING_VALUE 7
+
+static inline int Wrap_MXC_ADC_Init(wrap_mxc_adc_req_t *req)
+{
+    mxc_adc_req_t mxc_req;
+
+    mxc_req.clock = (mxc_adc_clock_t)req->clock;
+    mxc_req.cal = (mxc_adc_calibration_t)req->cal;
+    mxc_req.ref = (mxc_adc_refsel_t)req->ref;
+    mxc_req.trackCount = req->trackCount;
+    mxc_req.idleCount = req->idleCount;
+
+    switch (req->clkdiv) {
+    case 1:
+        mxc_req.clkdiv = MXC_ADC_CLKDIV_1;
+        break;
+    case 2:
+        mxc_req.clkdiv = MXC_ADC_CLKDIV_2;
+        break;
+    case 4:
+        mxc_req.clkdiv = MXC_ADC_CLKDIV_4;
+        break;
+    case 8:
+        mxc_req.clkdiv = MXC_ADC_CLKDIV_8;
+        break;
+    case 16:
+        mxc_req.clkdiv = MXC_ADC_CLKDIV_16;
+        break;
+    default:
+        return -1;
+    }
+
+    /*
+    TODO: MXC_ADC_RevB_Init function calls MXC_Delay function which uses SysTick and
+    program stucks in this function. Added following line to solve the problem until
+    develop a Zephyr compatible 'mxc_delay.c' file.
+    */
+    MXC_DelayAsync(1000, NULL);
+
+    return MXC_ADC_Init(&mxc_req);
+}
+
+static inline int Wrap_MXC_ADC_SetExtScale(wrap_mxc_adc_scale_t scale)
+{
+    if (scale != WRAP_MXC_ADC_SCALE_1) {
+        return -1; /* Scaling is not supported */
+    }
+    return 0;
+}
+
+static inline int Wrap_MXC_ADC_AverageConfig(uint8_t oversampling)
+{
+    if (oversampling > MAX_OVERSAMPLING_VALUE) {
+        return -EINVAL; /* Oversampling value too high */
+    }
+
+    MXC_ADC_AverageConfig(oversampling << MXC_F_ADC_CTRL1_AVG_POS);
+    return 0;
+}
+
+static inline void Wrap_MXC_ADC_ChannelSelect(uint32_t *sample_channels)
+{
+    const uint8_t num_of_channels = POPCOUNT(*sample_channels);
+    mxc_adc_slot_req_t slots[num_of_channels];
+    mxc_adc_conversion_req_t req;
+    uint8_t slot_index = 0;
+    int channel_id;
+
+    req.num_slots = num_of_channels - 1;
+
+    for (slot_index = 0; slot_index < num_of_channels; slot_index++) {
+        channel_id = wrap_utils_find_lsb_set(*sample_channels);
+        if (channel_id == 0) {
+            continue;
+        }
+        --channel_id;
+
+        slots[slot_index].channel = (mxc_adc_chsel_t)channel_id;
+        *sample_channels &= ~(1 << channel_id);
+    }
+
+    MXC_ADC_Clear_ChannelSelect();
+    MXC_ADC_SlotsConfig(&req);
+    MXC_ADC_SlotConfiguration(slots, num_of_channels - 1);
+}
+
+static inline int Wrap_MXC_ADC_ReferenceSelect(uint8_t ref)
+{
+    if ((ref != ADI_MAX32_ADC_REF_EXT0) && (ref != ADI_MAX32_ADC_REF_INTERNAL)) {
+        return -1;
+    }
+
+    MXC_ADC_ReferenceSelect(ref); /* Sets MXC_ADC_REF_EXT or MXC_ADC_REF_INT_1V25 for reference. */
+    return 0;
+}
+
+static inline void Wrap_MXC_ADC_DisableConversion(void)
+{
+    MXC_ADC_DisableConversion();
+}
+
+static inline int Wrap_MXC_ADC_StartConversion(uint32_t *sample_channels)
+{
+    int ret = 0;
+
+    MXC_ADC_FIFO_Threshold_Config(MAX_ADC_FIFO_LEN >> 1);
+    Wrap_MXC_ADC_ChannelSelect(sample_channels);
+
+    ret = MXC_ADC_StartConversion();
+    while ((MXC_ADC_GetFlags() & WRAP_MXC_F_ADC_CONV_DONE_IF) != WRAP_MXC_F_ADC_CONV_DONE_IF) {
+        {
+        }
+    }
+
+    return ret;
+}
+
+static inline int Wrap_MXC_ADC_StartConversionAsync(uint32_t *sample_channels,
+                                                    mxc_adc_complete_cb_t callback)
+{
+    MXC_ADC_FIFO_Threshold_Config(MAX_ADC_FIFO_LEN >> 1);
+    Wrap_MXC_ADC_ChannelSelect(sample_channels);
+    return MXC_ADC_StartConversionAsync(callback);
+}
+
+static inline void Wrap_MXC_ADC_GetData(uint16_t **outdata)
+{
+    mxc_adc_regs_t *adc = MXC_ADC;
+    uint32_t loop_counter, length;
+
+    length = (adc->status & MXC_F_ADC_STATUS_FIFO_LEVEL) >> MXC_F_ADC_STATUS_FIFO_LEVEL_POS;
+
+    for (loop_counter = 0; loop_counter < length; loop_counter++) {
+        **outdata = adc->data & MXC_F_ADC_DATA_DATA;
+        *outdata += 1;
+    }
+}
+
+#endif // part number
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _WRAP_MAX32_ADC_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_dma.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_dma.h
@@ -16,8 +16,8 @@
  *
  ******************************************************************************/
 
-#ifndef _WRAP_MAX32_DMA_H_
-#define _WRAP_MAX32_DMA_H_
+#ifndef LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_DMA_H_
+#define LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_DMA_H_
 
 /***** Includes *****/
 #include <dma.h>
@@ -146,4 +146,4 @@ static inline int Wrap_MXC_DMA_DoTransfer(mxc_dma_regs_t *dma, mxc_dma_config_t 
 }
 #endif
 
-#endif // _WRAP_MAX32_DMA_H_
+#endif // LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_DMA_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_dma.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_dma.h
@@ -1,0 +1,149 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#ifndef _WRAP_MAX32_DMA_H_
+#define _WRAP_MAX32_DMA_H_
+
+/***** Includes *****/
+#include <dma.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ *  MAX32665, MAX32666 related mapping
+ */
+#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+
+#define ADI_MAX32_DMA_CTRL_DIS_IE MXC_F_DMA_CFG_CHDIEN
+#define ADI_MAX32_DMA_CTRL_CTZIEN MXC_F_DMA_CFG_CTZIEN
+
+#define ADI_MAX32_DMA_STATUS_IPEND MXC_F_DMA_ST_IPEND
+#define ADI_MAX32_DMA_STATUS_BUS_ERR MXC_F_DMA_ST_BUS_ERR
+#define ADI_MAX32_DMA_STATUS_TO_IF MXC_F_DMA_ST_TO_ST
+#define ADI_MAX32_DMA_STATUS_ST MXC_F_DMA_ST_CH_ST
+
+#define ADI_MAX32_DMA_CFG_REQ_POS MXC_F_DMA_CFG_REQSEL_POS
+
+static inline int MXC_DMA_GetIntFlags(mxc_dma_regs_t *dma)
+{
+    return dma->intr;
+}
+
+static inline int Wrap_MXC_DMA_Init(mxc_dma_regs_t *dma)
+{
+    return MXC_DMA_Init(dma);
+}
+
+static inline void Wrap_MXC_DMA_DeInit(mxc_dma_regs_t *dma)
+{
+    MXC_DMA_DeInit(dma);
+}
+
+static inline int Wrap_MXC_DMA_AcquireChannel(mxc_dma_regs_t *dma)
+{
+    return MXC_DMA_AcquireChannel(dma);
+}
+
+static inline void Wrap_MXC_DMA_Handler(mxc_dma_regs_t *dma)
+{
+    MXC_DMA_Handler(dma);
+}
+
+static inline int Wrap_MXC_DMA_MemCpy(mxc_dma_regs_t *dma, void *dest, void *src, int len,
+                                      mxc_dma_complete_cb_t callback)
+{
+    return MXC_DMA_MemCpy(dma, dest, src, len, callback);
+}
+
+static inline int Wrap_MXC_DMA_DoTransfer(mxc_dma_regs_t *dma, mxc_dma_config_t config,
+                                          mxc_dma_srcdst_t firstSrcDst,
+                                          mxc_dma_trans_chain_t callback)
+{
+    return MXC_DMA_DoTransfer(dma, config, firstSrcDst, callback);
+}
+
+/*
+ *  MAX32690, MAX32655 related mapping
+ */
+#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32670) || \
+    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675) ||          \
+    (CONFIG_SOC_MAX32680)
+
+#define ADI_MAX32_DMA_CTRL_DIS_IE MXC_F_DMA_CTRL_DIS_IE
+#define ADI_MAX32_DMA_CTRL_CTZIEN MXC_F_DMA_CTRL_CTZ_IE
+
+#define ADI_MAX32_DMA_STATUS_IPEND MXC_F_DMA_STATUS_IPEND
+#define ADI_MAX32_DMA_STATUS_BUS_ERR MXC_F_DMA_STATUS_BUS_ERR
+#define ADI_MAX32_DMA_STATUS_TO_IF MXC_F_DMA_STATUS_TO_IF
+#define ADI_MAX32_DMA_STATUS_ST MXC_F_DMA_STATUS_STATUS
+
+#define ADI_MAX32_DMA_CFG_REQ_POS MXC_F_DMA_CTRL_REQUEST_POS
+
+static inline int MXC_DMA_GetIntFlags(mxc_dma_regs_t *dma)
+{
+    return dma->intfl;
+}
+
+static inline int Wrap_MXC_DMA_Init(mxc_dma_regs_t *dma)
+{
+    (void)dma;
+    return MXC_DMA_Init();
+}
+
+static inline void Wrap_MXC_DMA_DeInit(mxc_dma_regs_t *dma)
+{
+    (void)dma;
+    MXC_DMA_DeInit();
+}
+
+static inline int Wrap_MXC_DMA_AcquireChannel(mxc_dma_regs_t *dma)
+{
+    (void)dma;
+    return MXC_DMA_AcquireChannel();
+}
+
+static inline void Wrap_MXC_DMA_Handler(mxc_dma_regs_t *dma)
+{
+    (void)dma;
+    MXC_DMA_Handler();
+}
+
+static inline int Wrap_MXC_DMA_MemCpy(mxc_dma_regs_t *dma, void *dest, void *src, int len,
+                                      mxc_dma_complete_cb_t callback)
+{
+    (void)dma;
+    return MXC_DMA_MemCpy(dest, src, len, callback);
+}
+
+static inline int Wrap_MXC_DMA_DoTransfer(mxc_dma_regs_t *dma, mxc_dma_config_t config,
+                                          mxc_dma_srcdst_t firstSrcDst,
+                                          mxc_dma_trans_chain_t callback)
+{
+    (void)dma;
+    return MXC_DMA_DoTransfer(config, firstSrcDst, callback);
+}
+
+#endif // part number
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _WRAP_MAX32_DMA_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_i2c.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_i2c.h
@@ -16,8 +16,8 @@
  *
  ******************************************************************************/
 
-#ifndef _WRAP_MAX32_I2C_H_
-#define _WRAP_MAX32_I2C_H_
+#ifndef LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_I2C_H_
+#define LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_I2C_H_
 
 /***** Includes *****/
 #include <i2c.h>
@@ -231,4 +231,4 @@ static inline void Wrap_MXC_I2C_Stop(mxc_i2c_regs_t *i2c)
 }
 #endif
 
-#endif /* _WRAP_MAX32_I2C_H_ */
+#endif // LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_I2C_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_i2c.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_i2c.h
@@ -1,0 +1,234 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#ifndef _WRAP_MAX32_I2C_H_
+#define _WRAP_MAX32_I2C_H_
+
+/***** Includes *****/
+#include <i2c.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ *  MAX32665, MAX32666 related mapping
+ */
+#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+
+/*
+ *  Control register bits
+ */
+#define ADI_MAX32_I2C_CTRL_MASTER MXC_F_I2C_CTRL_MST
+
+/*
+ *  Interrupt enable bits
+ */
+#define ADI_MAX32_I2C_INT_EN0_RX_THD MXC_F_I2C_INT_EN0_RX_THRESH
+#define ADI_MAX32_I2C_INT_EN0_TX_LOCK_OUT MXC_F_I2C_INT_EN0_TX_LOCK_OUT
+#define ADI_MAX32_I2C_INT_EN0_TX_THD MXC_F_I2C_INT_EN0_TX_THRESH
+#define ADI_MAX32_I2C_INT_EN0_DONE MXC_F_I2C_INT_EN0_DONE
+#define ADI_MAX32_I2C_INT_EN0_STOP MXC_F_I2C_INT_EN0_STOP
+#define ADI_MAX32_I2C_INT_EN0_ADDR_MATCH MXC_F_I2C_INT_EN0_ADDR_MATCH
+#define ADI_MAX32_I2C_INT_EN0_ADDR_ACK MXC_F_I2C_INT_EN0_ADDR_ACK
+#define ADI_MAX32_I2C_INT_EN1_RX_OVERFLOW MXC_F_I2C_INT_EN1_RX_OVERFLOW
+#define ADI_MAX32_I2C_INT_EN1_TX_UNDERFLOW MXC_F_I2C_INT_EN1_TX_UNDERFLOW
+
+#define ADI_MAX32_I2C_INT_EN0_ERR                                                                \
+    (MXC_F_I2C_INT_EN0_ARB_ER | MXC_F_I2C_INT_EN0_TO_ER | MXC_F_I2C_INT_EN0_ADDR_NACK_ER |       \
+     MXC_F_I2C_INT_EN0_DATA_ER | MXC_F_I2C_INT_EN0_DO_NOT_RESP_ER | MXC_F_I2C_INT_EN0_START_ER | \
+     MXC_F_I2C_INT_EN0_STOP_ER)
+
+/*
+ *  Interrupt flags
+ */
+#define ADI_MAX32_I2C_INT_FL0_RX_THD MXC_F_I2C_INT_FL0_RX_THRESH
+#define ADI_MAX32_I2C_INT_FL0_TX_LOCK_OUT MXC_F_I2C_INT_FL0_TX_LOCK_OUT
+#define ADI_MAX32_I2C_INT_FL0_TX_THD MXC_F_I2C_INT_FL0_TX_THRESH
+#define ADI_MAX32_I2C_INT_FL0_ADDR_MATCH MXC_F_I2C_INT_FL0_ADDR_MATCH
+#define ADI_MAX32_I2C_INT_FL0_ADDR_ACK MXC_F_I2C_INT_FL0_ADDR_ACK
+#define ADI_MAX32_I2C_INT_FL0_STOP MXC_F_I2C_INT_FL0_STOP
+#define ADI_MAX32_I2C_INT_FL0_DONE MXC_F_I2C_INT_FL0_DONE
+#define ADI_MAX32_I2C_INT_FL1_RX_OVERFLOW MXC_F_I2C_INT_FL1_RX_OVERFLOW
+
+#define ADI_MAX32_I2C_INT_FL0_ERR                                                                \
+    (MXC_F_I2C_INT_FL0_ARB_ER | MXC_F_I2C_INT_FL0_TO_ER | MXC_F_I2C_INT_FL0_ADDR_NACK_ER |       \
+     MXC_F_I2C_INT_FL0_DATA_ER | MXC_F_I2C_INT_FL0_DO_NOT_RESP_ER | MXC_F_I2C_INT_FL0_START_ER | \
+     MXC_F_I2C_INT_FL0_STOP_ER)
+
+/*
+ *  DMA enable bits
+ */
+#define ADI_MAX32_I2C_DMA_RX_EN MXC_F_I2C_DMA_RXEN
+#define ADI_MAX32_I2C_DMA_TX_EN MXC_F_I2C_DMA_TXEN
+
+static inline void Wrap_MXC_I2C_GetIntEn(mxc_i2c_regs_t *i2c, unsigned int *int_en0,
+                                         unsigned int *int_en1)
+{
+    *int_en0 = i2c->int_en0;
+    *int_en1 = i2c->int_en1;
+}
+
+static inline void Wrap_MXC_I2C_SetIntEn(mxc_i2c_regs_t *i2c, unsigned int int_en0,
+                                         unsigned int int_en1)
+{
+    i2c->int_en0 = int_en0;
+    i2c->int_en1 = int_en1;
+}
+
+static inline uint32_t Wrap_MXC_I2C_GetTxFIFOLevel(mxc_i2c_regs_t *i2c)
+{
+    return (i2c->tx_ctrl1 & MXC_F_I2C_TX_CTRL1_TXFIFO) >> MXC_F_I2C_TX_CTRL1_TXFIFO_POS;
+}
+
+static inline void Wrap_MXC_I2C_SetRxCount(mxc_i2c_regs_t *i2c, unsigned int len)
+{
+    if (len < 256) {
+        i2c->rx_ctrl1 = len;
+    } else {
+        i2c->rx_ctrl1 = 0;
+    }
+}
+
+static inline void Wrap_MXC_I2C_WaitForRestart(mxc_i2c_regs_t *i2c)
+{
+    while (i2c->master_ctrl & MXC_F_I2C_MASTER_CTRL_RESTART) {}
+}
+
+static inline void Wrap_MXC_I2C_Start(mxc_i2c_regs_t *i2c)
+{
+    i2c->master_ctrl |= MXC_F_I2C_MASTER_CTRL_START;
+}
+
+static inline void Wrap_MXC_I2C_Restart(mxc_i2c_regs_t *i2c)
+{
+    i2c->master_ctrl |= MXC_F_I2C_MASTER_CTRL_RESTART;
+}
+
+static inline void Wrap_MXC_I2C_Stop(mxc_i2c_regs_t *i2c)
+{
+    i2c->master_ctrl |= MXC_F_I2C_MASTER_CTRL_STOP;
+}
+
+/*
+ *  MAX32690, MAX32655 related mapping
+ */
+#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32670) || \
+    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675) ||          \
+    (CONFIG_SOC_MAX32680)
+/*
+ *  Control register bits
+ */
+#define ADI_MAX32_I2C_CTRL_MASTER MXC_F_I2C_CTRL_MST_MODE
+
+/*
+ *  Interrupt enable bits
+ */
+#define ADI_MAX32_I2C_INT_EN0_RX_THD MXC_F_I2C_INTEN0_RX_THD
+#define ADI_MAX32_I2C_INT_EN0_TX_LOCK_OUT MXC_F_I2C_INTEN0_TX_LOCKOUT
+#define ADI_MAX32_I2C_INT_EN0_TX_THD MXC_F_I2C_INTEN0_TX_THD
+#define ADI_MAX32_I2C_INT_EN0_DONE MXC_F_I2C_INTEN0_DONE
+#define ADI_MAX32_I2C_INT_EN0_STOP MXC_F_I2C_INTEN0_STOP
+#define ADI_MAX32_I2C_INT_EN0_ADDR_MATCH MXC_F_I2C_INTEN0_ADDR_MATCH
+#define ADI_MAX32_I2C_INT_EN0_ADDR_ACK MXC_F_I2C_INTEN0_ADDR_ACK
+#define ADI_MAX32_I2C_INT_EN1_RX_OVERFLOW MXC_F_I2C_INTEN1_RX_OV
+#define ADI_MAX32_I2C_INT_EN1_TX_UNDERFLOW MXC_F_I2C_INTEN1_TX_UN
+
+#define ADI_MAX32_I2C_INT_EN0_ERR                                                          \
+    (MXC_F_I2C_INTEN0_ARB_ERR | MXC_F_I2C_INTEN0_TO_ERR | MXC_F_I2C_INTEN0_ADDR_NACK_ERR | \
+     MXC_F_I2C_INTEN0_DATA_ERR | MXC_F_I2C_INTEN0_DNR_ERR | MXC_F_I2C_INTEN0_START_ERR |   \
+     MXC_F_I2C_INTEN0_STOP_ERR)
+
+/*
+ *  Interrupt flags
+ */
+#define ADI_MAX32_I2C_INT_FL0_RX_THD MXC_F_I2C_INTFL0_RX_THD
+#define ADI_MAX32_I2C_INT_FL0_TX_LOCK_OUT MXC_F_I2C_INTFL0_TX_LOCKOUT
+#define ADI_MAX32_I2C_INT_FL0_TX_THD MXC_F_I2C_INTFL0_TX_THD
+#define ADI_MAX32_I2C_INT_FL0_ADDR_MATCH MXC_F_I2C_INTFL0_ADDR_MATCH
+#define ADI_MAX32_I2C_INT_FL0_ADDR_ACK MXC_F_I2C_INTFL0_ADDR_ACK
+#define ADI_MAX32_I2C_INT_FL0_STOP MXC_F_I2C_INTFL0_STOP
+#define ADI_MAX32_I2C_INT_FL0_DONE MXC_F_I2C_INTFL0_DONE
+#define ADI_MAX32_I2C_INT_FL1_RX_OVERFLOW MXC_F_I2C_INTFL1_RX_OV
+
+#define ADI_MAX32_I2C_INT_FL0_ERR                                                          \
+    (MXC_F_I2C_INTFL0_ARB_ERR | MXC_F_I2C_INTFL0_TO_ERR | MXC_F_I2C_INTFL0_ADDR_NACK_ERR | \
+     MXC_F_I2C_INTFL0_DATA_ERR | MXC_F_I2C_INTFL0_DNR_ERR | MXC_F_I2C_INTFL0_START_ERR |   \
+     MXC_F_I2C_INTFL0_STOP_ERR)
+
+/*
+ *  DMA enable bits
+ */
+#define ADI_MAX32_I2C_DMA_RX_EN MXC_F_I2C_DMA_RX_EN
+#define ADI_MAX32_I2C_DMA_TX_EN MXC_F_I2C_DMA_TX_EN
+
+static inline void Wrap_MXC_I2C_GetIntEn(mxc_i2c_regs_t *i2c, unsigned int *int_en0,
+                                         unsigned int *int_en1)
+{
+    *int_en0 = i2c->inten0;
+    *int_en1 = i2c->inten1;
+}
+
+static inline void Wrap_MXC_I2C_SetIntEn(mxc_i2c_regs_t *i2c, unsigned int int_en0,
+                                         unsigned int int_en1)
+{
+    i2c->inten0 = int_en0;
+    i2c->inten1 = int_en1;
+}
+
+static inline uint32_t Wrap_MXC_I2C_GetTxFIFOLevel(mxc_i2c_regs_t *i2c)
+{
+    return (i2c->txctrl1 & MXC_F_I2C_TXCTRL1_LVL) >> MXC_F_I2C_TXCTRL1_LVL_POS;
+}
+
+static inline void Wrap_MXC_I2C_SetRxCount(mxc_i2c_regs_t *i2c, unsigned int len)
+{
+    if (len < 256) {
+        i2c->rxctrl1 = len;
+    } else {
+        i2c->rxctrl1 = 0;
+    }
+}
+
+static inline void Wrap_MXC_I2C_WaitForRestart(mxc_i2c_regs_t *i2c)
+{
+    while (i2c->mstctrl & MXC_F_I2C_MSTCTRL_RESTART) {}
+}
+
+static inline void Wrap_MXC_I2C_Start(mxc_i2c_regs_t *i2c)
+{
+    i2c->mstctrl |= MXC_F_I2C_MSTCTRL_START;
+}
+
+static inline void Wrap_MXC_I2C_Restart(mxc_i2c_regs_t *i2c)
+{
+    i2c->mstctrl |= MXC_F_I2C_MSTCTRL_RESTART;
+}
+
+static inline void Wrap_MXC_I2C_Stop(mxc_i2c_regs_t *i2c)
+{
+    i2c->mstctrl |= MXC_F_I2C_MSTCTRL_STOP;
+}
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _WRAP_MAX32_I2C_H_ */

--- a/Libraries/zephyr/MAX/Include/wrap_max32_lp.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_lp.h
@@ -16,8 +16,8 @@
  *
  ******************************************************************************/
 
-#ifndef _WRAP_MAX32_LP_H_
-#define _WRAP_MAX32_LP_H_
+#ifndef LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_LP_H_
+#define LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_LP_H_
 
 /***** Includes *****/
 #include <lp.h>
@@ -83,4 +83,4 @@ static inline void Wrap_MXC_LP_EnterPowerDownMode(void)
 }
 #endif
 
-#endif // _WRAP_MAX32_LP_H_
+#endif // LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_LP_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_lp.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_lp.h
@@ -1,0 +1,86 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#ifndef _WRAP_MAX32_LP_H_
+#define _WRAP_MAX32_LP_H_
+
+/***** Includes *****/
+#include <lp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ *  MAX32665, MAX32666 related mapping
+ */
+#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666) || (CONFIG_SOC_MAX32670) || \
+    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675)
+
+static inline void Wrap_MXC_LP_EnterLowPowerMode(void)
+{
+    MXC_LP_EnterDeepSleepMode();
+}
+
+static inline void Wrap_MXC_LP_EnterMicroPowerMode(void)
+{
+    MXC_LP_EnterDeepSleepMode();
+}
+
+static inline void Wrap_MXC_LP_EnterStandbyMode(void)
+{
+    MXC_LP_EnterDeepSleepMode();
+}
+
+static inline void Wrap_MXC_LP_EnterPowerDownMode(void)
+{
+    MXC_LP_EnterShutDownMode();
+}
+
+/*
+ *  MAX32690, MAX32655 related mapping
+ */
+#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32680)
+
+static inline void Wrap_MXC_LP_EnterLowPowerMode(void)
+{
+    MXC_LP_EnterLowPowerMode();
+}
+
+static inline void Wrap_MXC_LP_EnterMicroPowerMode(void)
+{
+    MXC_LP_EnterMicroPowerMode();
+}
+
+static inline void Wrap_MXC_LP_EnterStandbyMode(void)
+{
+    MXC_LP_EnterStandbyMode();
+}
+
+static inline void Wrap_MXC_LP_EnterPowerDownMode(void)
+{
+    MXC_LP_EnterPowerDownMode();
+}
+
+#endif // part number
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _WRAP_MAX32_LP_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_owm.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_owm.h
@@ -16,8 +16,8 @@
  *
  ******************************************************************************/
 
-#ifndef _WRAP_MAX32_OWM_H_
-#define _WRAP_MAX32_OWM_H_
+#ifndef LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_OWM_H_
+#define LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_OWM_H_
 
 /***** Includes *****/
 #include <owm.h>
@@ -53,4 +53,4 @@ static inline int Wrap_MXC_OWM_Init(const mxc_owm_cfg_t *cfg)
 }
 #endif
 
-#endif // _WRAP_MAX32_OWM_H_
+#endif // LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_OWM_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_owm.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_owm.h
@@ -1,0 +1,56 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#ifndef _WRAP_MAX32_OWM_H_
+#define _WRAP_MAX32_OWM_H_
+
+/***** Includes *****/
+#include <owm.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ *  MAX32665, MAX32666 related mapping
+ */
+#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+
+static inline int Wrap_MXC_OWM_Init(const mxc_owm_cfg_t *cfg)
+{
+    /* map parameters does not have any effect */
+    return MXC_OWM_Init(cfg, (sys_map_t)0);
+}
+
+/*
+ *  MAX32690, MAX32655 related mapping
+ */
+#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32680)
+
+static inline int Wrap_MXC_OWM_Init(const mxc_owm_cfg_t *cfg)
+{
+    return MXC_OWM_Init(cfg);
+}
+
+#endif // part number
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _WRAP_MAX32_OWM_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_spi.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_spi.h
@@ -16,8 +16,8 @@
  *
  ******************************************************************************/
 
-#ifndef _WRAP_MAX32_SPI_H_
-#define _WRAP_MAX32_SPI_H_
+#ifndef LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_SPI_H_
+#define LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_SPI_H_
 
 /***** Includes *****/
 #include <spi.h>
@@ -127,4 +127,4 @@ static inline int Wrap_MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int qua
 }
 #endif
 
-#endif // _WRAP_MAX32_SPI_H_
+#endif // LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_SPI_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_spi.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_spi.h
@@ -1,0 +1,130 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#ifndef _WRAP_MAX32_SPI_H_
+#define _WRAP_MAX32_SPI_H_
+
+/***** Includes *****/
+#include <spi.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ *  MAX32665, MAX32666 related mapping
+ */
+#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+
+#define ADI_MAX32_SPI_CTRL_MASTER_MODE MXC_F_SPI_CTRL0_MASTER
+
+#define ADI_MAX32_SPI_INT_FL_RX_UN MXC_F_SPI_INT_FL_RX_UND
+#define ADI_MAX32_SPI_INT_FL_RX_OV MXC_F_SPI_INT_FL_RX_OVR
+#define ADI_MAX32_SPI_INT_FL_TX_UN MXC_F_SPI_INT_FL_TX_UND
+#define ADI_MAX32_SPI_INT_FL_TX_OV MXC_F_SPI_INT_FL_TX_OVR
+#define ADI_MAX32_SPI_INT_FL_MST_DONE MXC_F_SPI_INT_FL_M_DONE
+#define ADI_MAX32_SPI_INT_FL_ABORT MXC_F_SPI_INT_FL_ABORT
+#define ADI_MAX32_SPI_INT_FL_FAULT MXC_F_SPI_INT_FL_FAULT
+#define ADI_MAX32_SPI_INT_FL_SSD MXC_F_SPI_INT_FL_SSD
+#define ADI_MAX32_SPI_INT_FL_SSA MXC_F_SPI_INT_FL_SSA
+#define ADI_MAX32_SPI_INT_FL_RX_THD MXC_F_SPI_INT_FL_RX_THRESH
+#define ADI_MAX32_SPI_INT_FL_TX_EMPTY MXC_F_SPI_INT_FL_TX_EMPTY
+#define ADI_MAX32_SPI_INT_FL_TX_THD MXC_F_SPI_INT_FL_TX_THRESH
+
+#define ADI_MAX32_SPI_INT_EN_RX_UN MXC_F_SPI_INT_EN_RX_UN
+#define ADI_MAX32_SPI_INT_EN_RX_OV MXC_F_SPI_INT_EN_RX_OV
+#define ADI_MAX32_SPI_INT_EN_TX_UN MXC_F_SPI_INT_EN_TX_UN
+#define ADI_MAX32_SPI_INT_EN_TX_OV MXC_F_SPI_INT_EN_TX_OV
+#define ADI_MAX32_SPI_INT_EN_MST_DONE MXC_F_SPI_INT_EN_M_DONE
+#define ADI_MAX32_SPI_INT_EN_ABORT MXC_F_SPI_INT_EN_ABORT
+#define ADI_MAX32_SPI_INT_EN_FAULT MXC_F_SPI_INT_EN_FAULT
+#define ADI_MAX32_SPI_INT_EN_SSD MXC_F_SPI_INT_EN_SSD
+#define ADI_MAX32_SPI_INT_EN_SSA MXC_F_SPI_INT_EN_SSA
+#define ADI_MAX32_SPI_INT_EN_RX_THD MXC_F_SPI_INT_EN_RX_THRESH
+#define ADI_MAX32_SPI_INT_EN_TX_EMPTY MXC_F_SPI_INT_EN_TX_EMPTY
+#define ADI_MAX32_SPI_INT_EN_TX_THD MXC_F_SPI_INT_EN_TX_THRESH
+
+#define ADI_MAX32_SPI_DMA_TX_FIFO_CLEAR MXC_F_SPI_DMA_TX_FIFO_CLEAR
+#define ADI_MAX32_SPI_DMA_TX_DMA_EN MXC_F_SPI_DMA_TX_DMA_EN
+#define ADI_MAX32_SPI_DMA_RX_FIFO_CLEAR MXC_F_SPI_DMA_RX_FIFO_CLEAR
+#define ADI_MAX32_SPI_DMA_RX_DMA_EN MXC_F_SPI_DMA_RX_DMA_EN
+
+static inline int Wrap_MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed,
+                                    int numSlaves, unsigned ssPolarity, unsigned int hz)
+{
+    return MXC_SPI_Init(spi, masterMode, quadModeUsed, numSlaves, ssPolarity, hz, (sys_map_t)0);
+}
+
+/*
+ *  MAX32690, MAX32655 related mapping
+ */
+#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32670) || \
+    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675) ||          \
+    (CONFIG_SOC_MAX32680)
+
+#define ADI_MAX32_SPI_CTRL_MASTER_MODE MXC_F_SPI_CTRL0_MST_MODE
+
+#define ADI_MAX32_SPI_INT_FL_RX_UN MXC_F_SPI_INTFL_RX_UN
+#define ADI_MAX32_SPI_INT_FL_RX_OV MXC_F_SPI_INTFL_RX_OV
+#define ADI_MAX32_SPI_INT_FL_TX_UN MXC_F_SPI_INTFL_TX_UN
+#define ADI_MAX32_SPI_INT_FL_TX_OV MXC_F_SPI_INTFL_TX_OV
+#define ADI_MAX32_SPI_INT_FL_MST_DONE MXC_F_SPI_INTFL_MST_DONE
+#define ADI_MAX32_SPI_INT_FL_ABORT MXC_F_SPI_INTFL_ABORT
+#define ADI_MAX32_SPI_INT_FL_FAULT MXC_F_SPI_INTFL_FAULT
+#define ADI_MAX32_SPI_INT_FL_SSD MXC_F_SPI_INTFL_SSD
+#define ADI_MAX32_SPI_INT_FL_SSA MXC_F_SPI_INTFL_SSA
+#define ADI_MAX32_SPI_INT_FL_RX_THD MXC_F_SPI_INTFL_RX_THD
+#define ADI_MAX32_SPI_INT_FL_TX_EMPTY MXC_F_SPI_INTFL_TX_EMPTY
+#define ADI_MAX32_SPI_INT_FL_TX_THD MXC_F_SPI_INTFL_TX_THD
+
+#define ADI_MAX32_SPI_INT_EN_RX_UN MXC_F_SPI_INTEN_RX_UN
+#define ADI_MAX32_SPI_INT_EN_RX_OV MXC_F_SPI_INTEN_RX_OV
+#define ADI_MAX32_SPI_INT_EN_TX_UN MXC_F_SPI_INTEN_TX_UN
+#define ADI_MAX32_SPI_INT_EN_TX_OV MXC_F_SPI_INTEN_TX_OV
+#define ADI_MAX32_SPI_INT_EN_MST_DONE MXC_F_SPI_INTEN_MST_DONE
+#define ADI_MAX32_SPI_INT_EN_ABORT MXC_F_SPI_INTEN_ABORT
+#define ADI_MAX32_SPI_INT_EN_FAULT MXC_F_SPI_INTEN_FAULT
+#define ADI_MAX32_SPI_INT_EN_SSD MXC_F_SPI_INTEN_SSD
+#define ADI_MAX32_SPI_INT_EN_SSA MXC_F_SPI_INTEN_SSA
+#define ADI_MAX32_SPI_INT_EN_RX_THD MXC_F_SPI_INTEN_RX_THD
+#define ADI_MAX32_SPI_INT_EN_TX_EMPTY MXC_F_SPI_INTEN_TX_EMPTY
+#define ADI_MAX32_SPI_INT_EN_TX_THD MXC_F_SPI_INTEN_TX_THD
+
+#define ADI_MAX32_SPI_DMA_TX_FIFO_CLEAR MXC_F_SPI_DMA_TX_FLUSH
+#define ADI_MAX32_SPI_DMA_TX_DMA_EN MXC_F_SPI_DMA_DMA_TX_EN
+#define ADI_MAX32_SPI_DMA_RX_FIFO_CLEAR MXC_F_SPI_DMA_RX_FLUSH
+#define ADI_MAX32_SPI_DMA_RX_DMA_EN MXC_F_SPI_DMA_DMA_RX_EN
+
+static inline int Wrap_MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed,
+                                    int numSlaves, unsigned ssPolarity, unsigned int hz)
+{
+#if defined(CONFIG_SOC_MAX32670) || (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32675)
+    return MXC_SPI_Init(spi, masterMode, quadModeUsed, numSlaves, ssPolarity, hz);
+#else
+    mxc_spi_pins_t tmp; // not used
+    return MXC_SPI_Init(spi, masterMode, quadModeUsed, numSlaves, ssPolarity, hz, tmp);
+#endif
+}
+
+#endif // part number
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _WRAP_MAX32_SPI_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
@@ -16,8 +16,8 @@
  *
  ******************************************************************************/
 
-#ifndef _WRAP_MAX32_SYS_H_
-#define _WRAP_MAX32_SYS_H_
+#ifndef LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_SYS_H_
+#define LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_SYS_H_
 
 /***** Includes *****/
 #include <mxc_sys.h>
@@ -87,4 +87,4 @@ static inline void Wrap_MXC_SYS_SetClockDiv(int div)
 }
 #endif
 
-#endif // _WRAP_MAX32_SYS_H_
+#endif // LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_SYS_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
@@ -1,0 +1,90 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#ifndef _WRAP_MAX32_SYS_H_
+#define _WRAP_MAX32_SYS_H_
+
+/***** Includes *****/
+#include <mxc_sys.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ *  Apply preinit configuration for the target
+ */
+void max32xx_system_init(void);
+
+/*
+ *  MAX32665, MAX32666 related mapping
+ */
+#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+
+#define ADI_MAX32_CLK_IPO MXC_SYS_CLOCK_HIRC96
+#define ADI_MAX32_CLK_ERFO MXC_SYS_CLOCK_XTAL32M
+#define ADI_MAX32_CLK_IBRO MXC_SYS_CLOCK_HIRC8
+#define ADI_MAX32_CLK_ISO MXC_SYS_CLOCK_HIRC
+#define ADI_MAX32_CLK_INRO MXC_SYS_CLOCK_LIRC8K
+#define ADI_MAX32_CLK_ERTCO MXC_SYS_CLOCK_XTAL32K
+
+#define z_sysclk_prescaler(v) MXC_SYS_SYSTEM_DIV_##v
+#define sysclk_prescaler(v) z_sysclk_prescaler(v)
+
+static inline void Wrap_MXC_SYS_SetClockDiv(int div)
+{
+    MXC_SYS_Clock_Div((mxc_sys_system_div_t)div);
+}
+
+/*
+ *  MAX32690, MAX32655 related mapping
+ */
+#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32670) || \
+    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675) ||          \
+    (CONFIG_SOC_MAX32680)
+
+#define ADI_MAX32_CLK_IPO MXC_SYS_CLOCK_IPO
+#define ADI_MAX32_CLK_ERFO MXC_SYS_CLOCK_ERFO
+#define ADI_MAX32_CLK_IBRO MXC_SYS_CLOCK_IBRO
+#define ADI_MAX32_CLK_INRO MXC_SYS_CLOCK_INRO
+#define ADI_MAX32_CLK_ERTCO MXC_SYS_CLOCK_ERTCO
+#define ADI_MAX32_CLK_EXTCLK MXC_SYS_CLOCK_EXTCLK
+#if !(defined(CONFIG_SOC_MAX32670) || (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || \
+      (CONFIG_SOC_MAX32675))
+#define ADI_MAX32_CLK_ISO MXC_SYS_CLOCK_ISO
+#endif
+
+#if !defined(CONFIG_SOC_MAX32690)
+
+#define z_sysclk_prescaler(v) MXC_SYS_CLOCK_DIV_##v
+#define sysclk_prescaler(v) z_sysclk_prescaler(v)
+
+static inline void Wrap_MXC_SYS_SetClockDiv(int div)
+{
+    MXC_SYS_SetClockDiv((mxc_sys_system_clock_div_t)div);
+}
+
+#endif // !defined(CONFIG_SOC_MAX32690)
+
+#endif // part number
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _WRAP_MAX32_SYS_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_tmr.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_tmr.h
@@ -16,8 +16,8 @@
  *
  ******************************************************************************/
 
-#ifndef _WRAP_MAX32_TMR_H_
-#define _WRAP_MAX32_TMR_H_
+#ifndef LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_TMR_H_
+#define LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_TMR_H_
 
 /***** Includes *****/
 #include <tmr.h>
@@ -208,4 +208,4 @@ int Wrap_MXC_TMR_GetPendingInt(mxc_tmr_regs_t *tmr)
 }
 #endif
 
-#endif // _WRAP_MAX32_TMR_H_
+#endif // LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_TMR_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_tmr.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_tmr.h
@@ -1,0 +1,211 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#ifndef _WRAP_MAX32_TMR_H_
+#define _WRAP_MAX32_TMR_H_
+
+/***** Includes *****/
+#include <tmr.h>
+#include <lp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    mxc_tmr_pres_t pres;
+    mxc_tmr_mode_t mode;
+    int bitMode; /* Some PN does not support it, check mxc_tmr_bit_mode_t in tmr.h file */
+    int clock; /* Some PN does not support it, check mxc_tmr_clock_t in tmr.h file */
+    uint32_t cmp_cnt; /**< Compare register value in timer ticks */
+    unsigned pol; /**< Polarity (0 or 1) */
+} wrap_mxc_tmr_cfg_t;
+
+/*
+ *  MAX32665, MAX32666 related mapping
+ */
+#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+
+/* All timers are 32bits */
+#define WRAP_MXC_IS_32B_TIMER(idx) (1)
+
+static inline int Wrap_MXC_TMR_Init(mxc_tmr_regs_t *tmr, wrap_mxc_tmr_cfg_t *cfg)
+{
+    mxc_tmr_cfg_t mxc_cfg;
+
+    mxc_cfg.pres = cfg->pres;
+    mxc_cfg.mode = cfg->mode;
+    mxc_cfg.cmp_cnt = cfg->cmp_cnt;
+    mxc_cfg.pol = cfg->pol;
+
+    MXC_TMR_Init(tmr, &mxc_cfg);
+    return 0;
+}
+
+static inline int Wrap_MXC_TMR_GetClockIndex(int z_clock)
+{
+    if (z_clock == 0) {
+        /* Only peripheral clock is supported, just retunr 0 */
+        return 0;
+    } else {
+        return -1; /* Not supported */
+    }
+}
+
+void Wrap_MXC_TMR_EnableWakeup(mxc_tmr_regs_t *tmr, wrap_mxc_tmr_cfg_t *cfg)
+{
+    (void)tmr;
+    (void)cfg;
+}
+
+void Wrap_MXC_TMR_ClearWakeupFlags(mxc_tmr_regs_t *tmr)
+{
+    (void)tmr;
+}
+
+void Wrap_MXC_TMR_DisableInt(mxc_tmr_regs_t *tmr)
+{
+    (void)tmr;
+}
+
+void Wrap_MXC_TMR_EnableInt(mxc_tmr_regs_t *tmr)
+{
+    (void)tmr;
+}
+
+int Wrap_MXC_TMR_GetPendingInt(mxc_tmr_regs_t *tmr)
+{
+    uint32_t mask = MXC_F_TMR_INTR_IRQ;
+    uint32_t flags;
+
+    flags = MXC_TMR_GetFlags(tmr);
+
+    return ((flags & mask) == mask);
+}
+
+/*
+ *  MAX32690, MAX32655 related mapping
+ */
+#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32670) || \
+    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675) ||          \
+    (CONFIG_SOC_MAX32680)
+
+#if defined(CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32675)
+/* All timers are 32bits */
+#define WRAP_MXC_IS_32B_TIMER(idx) (1)
+#elif defined(CONFIG_SOC_MAX32662)
+#define WRAP_MXC_IS_32B_TIMER(idx) (MXC_TMR_GET_IDX(idx) == 3 ? 0 : 1)
+#else
+#define WRAP_MXC_IS_32B_TIMER(idx) \
+    (MXC_TMR_GET_IDX(idx) == 4 ? 0 : MXC_TMR_GET_IDX(idx) == 5 ? 0 : 1)
+#endif
+
+static inline int Wrap_MXC_TMR_Init(mxc_tmr_regs_t *tmr, wrap_mxc_tmr_cfg_t *cfg)
+{
+    mxc_tmr_cfg_t mxc_cfg;
+
+    mxc_cfg.pres = cfg->pres;
+    mxc_cfg.mode = cfg->mode;
+    mxc_cfg.cmp_cnt = cfg->cmp_cnt;
+    mxc_cfg.pol = cfg->pol;
+    mxc_cfg.bitMode = (mxc_tmr_bit_mode_t)cfg->bitMode;
+    mxc_cfg.clock = (mxc_tmr_clock_t)cfg->clock;
+
+#if defined(CONFIG_SOC_MAX32662)
+    return MXC_TMR_Init(tmr, &mxc_cfg, 0, (sys_map_t)0);
+#else
+    return MXC_TMR_Init(tmr, &mxc_cfg, 0); // init_pins not used
+#endif
+}
+
+static inline int Wrap_MXC_TMR_GetClockIndex(int z_clock)
+{
+    switch (z_clock) {
+    case 0: // ADI_MAX32_PRPH_CLK_SRC_PCLK
+        return MXC_TMR_APB_CLK;
+    case 1: // ADI_MAX32_PRPH_CLK_SRC_EXTCLK
+        return MXC_TMR_EXT_CLK;
+    case 2: // ADI_MAX32_PRPH_CLK_SRC_IBRO
+        return MXC_TMR_8M_CLK;
+    case 3: //ADI_MAX32_PRPH_CLK_SRC_ERFO
+        return MXC_TMR_32M_CLK;
+    case 4: //ADI_MAX32_PRPH_CLK_SRC_ERTCO
+        return MXC_TMR_32K_CLK;
+    case 5: //ADI_MAX32_PRPH_CLK_SRC_INRO
+        return MXC_TMR_INRO_CLK;
+#if defined(CONFIG_SOC_MAX32690)
+    case 6: //ADI_MAX32_PRPH_CLK_SRC_ISO
+        return MXC_TMR_ISO_CLK;
+#endif
+    }
+
+    return -1; /* Not supported */
+}
+
+void Wrap_MXC_TMR_EnableWakeup(mxc_tmr_regs_t *tmr, wrap_mxc_tmr_cfg_t *cfg)
+{
+    mxc_tmr_cfg_t mxc_cfg;
+
+    mxc_cfg.pres = cfg->pres;
+    mxc_cfg.mode = cfg->mode;
+    mxc_cfg.cmp_cnt = cfg->cmp_cnt;
+    mxc_cfg.pol = cfg->pol;
+    mxc_cfg.bitMode = (mxc_tmr_bit_mode_t)cfg->bitMode;
+    mxc_cfg.clock = (mxc_tmr_clock_t)cfg->clock;
+
+    // Enable wakeup source in power seq register
+    MXC_LP_EnableTimerWakeup(tmr);
+    // Enable Timer wake-up source
+    MXC_TMR_EnableWakeup(tmr, &mxc_cfg);
+}
+
+void Wrap_MXC_TMR_ClearWakeupFlags(mxc_tmr_regs_t *tmr)
+{
+    if (tmr->wkfl & MXC_F_TMR_WKFL_A) {
+        // Write 1 to clear
+        tmr->wkfl |= MXC_F_TMR_WKFL_A;
+    }
+}
+
+void Wrap_MXC_TMR_DisableInt(mxc_tmr_regs_t *tmr)
+{
+    MXC_TMR_DisableInt(tmr);
+}
+
+void Wrap_MXC_TMR_EnableInt(mxc_tmr_regs_t *tmr)
+{
+    MXC_TMR_EnableInt(tmr);
+}
+
+int Wrap_MXC_TMR_GetPendingInt(mxc_tmr_regs_t *tmr)
+{
+    uint32_t mask = MXC_F_TMR_INTFL_IRQ_A | MXC_F_TMR_INTFL_IRQ_B;
+    uint32_t flags;
+
+    flags = MXC_TMR_GetFlags(tmr);
+
+    return ((flags & mask) == mask);
+}
+
+#endif // part number
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _WRAP_MAX32_TMR_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_trng.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_trng.h
@@ -16,8 +16,8 @@
  *
  ******************************************************************************/
 
-#ifndef _WRAP_MAX32_TRNG_H_
-#define _WRAP_MAX32_TRNG_H_
+#ifndef LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_TRNG_H_
+#define LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_TRNG_H_
 
 /***** Includes *****/
 #include <trng.h>
@@ -63,4 +63,4 @@ static inline int Wrap_MXC_TRNG_RandomInt_NonBlocking(uint32_t *data)
 }
 #endif
 
-#endif // _WRAP_MAX32_TRNG_H_
+#endif // LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_TRNG_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_trng.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_trng.h
@@ -1,0 +1,66 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#ifndef _WRAP_MAX32_TRNG_H_
+#define _WRAP_MAX32_TRNG_H_
+
+/***** Includes *****/
+#include <trng.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ *  MAX32665, MAX32666 related mapping
+ */
+#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+
+static inline int Wrap_MXC_TRNG_RandomInt_NonBlocking(uint32_t *data)
+{
+    if ((MXC_TRNG->st & MXC_F_TRNG_ST_RND_RDY) == 0) {
+        return -1; /* Not ready */
+    }
+    *data = MXC_TRNG->data;
+
+    return 0;
+}
+
+/*
+ *  MAX32690, MAX32655 related mapping
+ */
+#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32670) || \
+    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675) ||          \
+    (CONFIG_SOC_MAX32680)
+
+static inline int Wrap_MXC_TRNG_RandomInt_NonBlocking(uint32_t *data)
+{
+    if ((MXC_TRNG->status & MXC_F_TRNG_STATUS_RDY) == 0) {
+        return -1; /* Not ready */
+    }
+    *data = MXC_TRNG->data;
+
+    return 0;
+}
+#endif // part number
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _WRAP_MAX32_TRNG_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_uart.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_uart.h
@@ -1,0 +1,220 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#ifndef _WRAP_MAX32_UART_H_
+#define _WRAP_MAX32_UART_H_
+
+/***** Includes *****/
+#include <uart.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+// status flags
+#define ADI_MAX32_UART_RX_EMPTY MXC_F_UART_STATUS_RX_EMPTY
+#define ADI_MAX32_UART_TX_EMPTY MXC_F_UART_STATUS_TX_EMPTY
+// error flags
+#define ADI_MAX32_UART_ERROR_OVERRUN MXC_F_UART_INT_FL_RX_OVERRUN
+#define ADI_MAX32_UART_ERROR_PARITY MXC_F_UART_INT_FL_RX_PARITY_ERROR
+#define ADI_MAX32_UART_ERROR_FRAMING MXC_F_UART_INT_FL_RX_FRAME_ERROR
+// interrupt flag
+#define ADI_MAX32_UART_INT_EOT MXC_F_UART_INT_EN_LAST_BREAK // End Of Transmission Interrupt
+#define ADI_MAX32_UART_INT_OE MXC_F_UART_INT_EN_RX_OVERRUN // Overrun Error Interrupt
+#define ADI_MAX32_UART_INT_BE MXC_F_UART_INT_EN_BREAK // Break Error Interrupt
+#define ADI_MAX32_UART_INT_PE MXC_F_UART_INT_EN_RX_PARITY_ERROR // Parity Error Interrupt
+#define ADI_MAX32_UART_INT_FE MXC_F_UART_INT_EN_RX_FRAME_ERROR // Framing Error Interrupt
+#define ADI_MAX32_UART_INT_RT MXC_F_UART_INT_EN_RX_TIMEOUT // Receive Timeout Interrupt
+#define ADI_MAX32_UART_INT_TX MXC_F_UART_INT_EN_TX_FIFO_THRESH // Transmit Interrupt
+#define ADI_MAX32_UART_INT_RX MXC_F_UART_INT_EN_RX_FIFO_THRESH // Receive Interrupt
+#define ADI_MAX32_UART_INT_CTS MXC_F_UART_INT_EN_CTS_CHANGE // CTS Modem Interrupt
+#define ADI_MAX32_UART_INT_TX_OEM \
+    MXC_F_UART_INT_EN_TX_FIFO_ALMOST_EMPTY // TX FIFO Almost Empty Interrupt
+// parity
+#define ADI_MAX32_UART_CFG_PARITY_NONE MXC_UART_PARITY_DISABLE
+#define ADI_MAX32_UART_CFG_PARITY_ODD MXC_UART_PARITY_ODD
+#define ADI_MAX32_UART_CFG_PARITY_EVEN MXC_UART_PARITY_EVEN
+#define ADI_MAX32_UART_CFG_PARITY_MARK MXC_UART_PARITY_MARK
+#define ADI_MAX32_UART_CFG_PARITY_SPACE MXC_UART_PARITY_SPACE
+
+/* Error interrupts */
+#define ADI_MAX32_UART_ERROR_INTERRUPTS \
+    (ADI_MAX32_UART_INT_OE | ADI_MAX32_UART_INT_PE | ADI_MAX32_UART_INT_FE)
+
+static inline int Wrap_MXC_UART_Init(mxc_uart_regs_t *uart)
+{
+    int ret;
+
+    ret = MXC_UART_SetRXThreshold(uart, 1);
+    if (ret) {
+        return ret;
+    }
+
+    // default values as per of MSDK
+    ret = MXC_UART_SetTXThreshold(uart, 2);
+    if (ret) {
+        return ret;
+    }
+
+    uart->ctrl |= MXC_F_UART_CTRL_ENABLE;
+
+    return ret;
+}
+
+static inline int Wrap_MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud,
+                                             int clock_source)
+{
+    (void)clock_source;
+    return MXC_UART_SetFrequency(uart, baud);
+}
+
+static inline void Wrap_MXC_UART_SetTxDMALevel(mxc_uart_regs_t *uart, uint8_t bytes)
+{
+    uart->dma |= ((bytes & 0x1F) << MXC_F_UART_DMA_TXDMA_LEVEL_POS);
+}
+
+static inline void Wrap_MXC_UART_SetRxDMALevel(mxc_uart_regs_t *uart, uint8_t bytes)
+{
+    uart->dma |= ((bytes & 0x1F) << MXC_F_UART_DMA_RXDMA_LEVEL_POS);
+}
+
+static inline void Wrap_MXC_UART_EnableTxDMA(mxc_uart_regs_t *uart)
+{
+    uart->dma |= MXC_F_UART_DMA_TXDMA_EN;
+}
+
+static inline void Wrap_MXC_UART_EnableRxDMA(mxc_uart_regs_t *uart)
+{
+    uart->dma |= MXC_F_UART_DMA_RXDMA_EN;
+}
+
+static inline void Wrap_MXC_UART_DisableTxDMA(mxc_uart_regs_t *uart)
+{
+    uart->dma &= ~MXC_F_UART_DMA_TXDMA_EN;
+}
+
+static inline void Wrap_MXC_UART_DisableRxDMA(mxc_uart_regs_t *uart)
+{
+    uart->dma &= ~MXC_F_UART_DMA_RXDMA_EN;
+}
+
+/*
+ *  MAX32690, MAX32655 related mapping
+ */
+#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32670) || \
+    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675) ||          \
+    (CONFIG_SOC_MAX32680)
+// status flags
+#define ADI_MAX32_UART_RX_EMPTY MXC_F_UART_STATUS_RX_EM
+#define ADI_MAX32_UART_TX_EMPTY MXC_F_UART_STATUS_TX_EM
+
+#if defined(CONFIG_SOC_MAX32662)
+// error flags
+#define ADI_MAX32_UART_ERROR_OVERRUN MXC_F_UART_INTFL_RX_OV
+#define ADI_MAX32_UART_ERROR_PARITY MXC_F_UART_INTFL_RX_PAR
+#define ADI_MAX32_UART_ERROR_FRAMING MXC_F_UART_INTFL_RX_FERR
+// interrupt flag
+#define ADI_MAX32_UART_INT_OE MXC_F_UART_INTEN_RX_OV // Overrun Error Interrupt
+#define ADI_MAX32_UART_INT_PE MXC_F_UART_INTEN_RX_PAR // Parity Error Interrupt
+#define ADI_MAX32_UART_INT_FE MXC_F_UART_INTEN_RX_FERR // Framing Error Interrupt
+#define ADI_MAX32_UART_INT_TX MXC_F_UART_INTEN_TX_HE // Transmit Interrupt
+#define ADI_MAX32_UART_INT_RX MXC_F_UART_INTEN_RX_THD // Receive Interrupt
+#define ADI_MAX32_UART_INT_CTS MXC_F_UART_INTEN_CTS_EV // CTS Modem Interrupt
+#define ADI_MAX32_UART_INT_TX_OEM MXC_F_UART_INTEN_TX_OB // TX FIFO Almost Empty Interrupt
+#else
+// error flags
+#define ADI_MAX32_UART_ERROR_OVERRUN MXC_F_UART_INT_FL_RX_OV
+#define ADI_MAX32_UART_ERROR_PARITY MXC_F_UART_INT_FL_RX_PAR
+#define ADI_MAX32_UART_ERROR_FRAMING MXC_F_UART_INT_FL_RX_FERR
+// interrupt flag
+#define ADI_MAX32_UART_INT_OE MXC_F_UART_INT_EN_RX_OV // Overrun Error Interrupt
+#define ADI_MAX32_UART_INT_PE MXC_F_UART_INT_EN_RX_PAR // Parity Error Interrupt
+#define ADI_MAX32_UART_INT_FE MXC_F_UART_INT_EN_RX_FERR // Framing Error Interrupt
+#define ADI_MAX32_UART_INT_TX MXC_F_UART_INT_EN_TX_HE // Transmit Interrupt
+#define ADI_MAX32_UART_INT_RX MXC_F_UART_INT_EN_RX_THD // Receive Interrupt
+#define ADI_MAX32_UART_INT_CTS MXC_F_UART_INT_EN_CTS_EV // CTS Modem Interrupt
+#define ADI_MAX32_UART_INT_TX_OEM MXC_F_UART_INT_EN_TX_OB // TX FIFO Almost Empty Interrupt
+#endif
+//#define ADI_MAX32_UART_INT_RT   // Receive Timeout Interrupt
+//#define ADI_MAX32_UART_INT_BE   // Break Error Interrupt
+//#define ADI_MAX32_UART_INT_EOT  // End Of Transmission Interrupt
+
+// parity
+#define ADI_MAX32_UART_CFG_PARITY_NONE MXC_UART_PARITY_DISABLE
+#define ADI_MAX32_UART_CFG_PARITY_ODD MXC_UART_PARITY_ODD_0
+#define ADI_MAX32_UART_CFG_PARITY_EVEN MXC_UART_PARITY_EVEN_0
+//#define	ADI_MAX32_UART_CFG_PARITY_MARK
+//#define	ADI_MAX32_UART_CFG_PARITY_SPACE
+
+/* Error interrupts */
+#define ADI_MAX32_UART_ERROR_INTERRUPTS \
+    (ADI_MAX32_UART_INT_OE | ADI_MAX32_UART_INT_PE | ADI_MAX32_UART_INT_FE)
+
+static inline int Wrap_MXC_UART_Init(mxc_uart_regs_t *uart)
+{
+    int ret;
+
+    ret = MXC_UART_SetRXThreshold(uart, 1);
+
+    return ret;
+}
+
+static inline int Wrap_MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud,
+                                             int clock_source)
+{
+    return MXC_UART_SetFrequency(uart, baud, (mxc_uart_clock_t)clock_source);
+}
+
+static inline void Wrap_MXC_UART_SetTxDMALevel(mxc_uart_regs_t *uart, uint8_t bytes)
+{
+    uart->dma |= ((bytes & 0xF) << MXC_F_UART_DMA_TX_THD_VAL_POS);
+}
+
+static inline void Wrap_MXC_UART_SetRxDMALevel(mxc_uart_regs_t *uart, uint8_t bytes)
+{
+    uart->dma |= ((bytes & 0xF) << MXC_F_UART_DMA_RX_THD_VAL_POS);
+}
+
+static inline void Wrap_MXC_UART_EnableTxDMA(mxc_uart_regs_t *uart)
+{
+    uart->dma |= MXC_F_UART_DMA_TX_EN;
+}
+
+static inline void Wrap_MXC_UART_EnableRxDMA(mxc_uart_regs_t *uart)
+{
+    uart->dma |= MXC_F_UART_DMA_RX_EN;
+}
+
+static inline void Wrap_MXC_UART_DisableTxDMA(mxc_uart_regs_t *uart)
+{
+    uart->dma &= ~MXC_F_UART_DMA_TX_EN;
+}
+
+static inline void Wrap_MXC_UART_DisableRxDMA(mxc_uart_regs_t *uart)
+{
+    uart->dma &= ~MXC_F_UART_DMA_RX_EN;
+}
+
+#endif // defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _WRAP_MAX32_UART_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_uart.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_uart.h
@@ -16,8 +16,8 @@
  *
  ******************************************************************************/
 
-#ifndef _WRAP_MAX32_UART_H_
-#define _WRAP_MAX32_UART_H_
+#ifndef LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_UART_H_
+#define LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_UART_H_
 
 /***** Includes *****/
 #include <uart.h>
@@ -159,8 +159,8 @@ static inline void Wrap_MXC_UART_DisableRxDMA(mxc_uart_regs_t *uart)
 #define ADI_MAX32_UART_CFG_PARITY_NONE MXC_UART_PARITY_DISABLE
 #define ADI_MAX32_UART_CFG_PARITY_ODD MXC_UART_PARITY_ODD_0
 #define ADI_MAX32_UART_CFG_PARITY_EVEN MXC_UART_PARITY_EVEN_0
-//#define	ADI_MAX32_UART_CFG_PARITY_MARK
-//#define	ADI_MAX32_UART_CFG_PARITY_SPACE
+//#define ADI_MAX32_UART_CFG_PARITY_MARK
+//#define ADI_MAX32_UART_CFG_PARITY_SPACE
 
 /* Error interrupts */
 #define ADI_MAX32_UART_ERROR_INTERRUPTS \
@@ -217,4 +217,4 @@ static inline void Wrap_MXC_UART_DisableRxDMA(mxc_uart_regs_t *uart)
 }
 #endif
 
-#endif // _WRAP_MAX32_UART_H_
+#endif // LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_UART_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_wdt.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_wdt.h
@@ -16,8 +16,8 @@
  *
  ******************************************************************************/
 
-#ifndef _WRAP_MAX32_WDT_H_
-#define _WRAP_MAX32_WDT_H_
+#ifndef LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_WDT_H_
+#define LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_WDT_H_
 
 /***** Includes *****/
 #include <wdt.h>
@@ -156,4 +156,4 @@ static inline int Wrap_MXC_WDT_SelectClockSource(mxc_wdt_regs_t *wdt, uint32_t c
 }
 #endif
 
-#endif // _WRAP_MAX32_WDT_H_
+#endif // LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_WDT_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32_wdt.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_wdt.h
@@ -1,0 +1,159 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#ifndef _WRAP_MAX32_WDT_H_
+#define _WRAP_MAX32_WDT_H_
+
+/***** Includes *****/
+#include <wdt.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    char mode; ///< WDT mode
+    mxc_wdt_period_t upperResetPeriod; ///< Reset upper limit
+    mxc_wdt_period_t lowerResetPeriod; ///< Reset lower limit
+    mxc_wdt_period_t upperIntPeriod; ///< Interrupt upper limit
+    mxc_wdt_period_t lowerIntPeriod; ///< Interrupt lower limit
+} wrap_mxc_wdt_cfg_t;
+
+/*
+ *  MAX32665, MAX32666 related mapping
+ */
+#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+
+#define WRAP_MXC_F_WDT_CTRL_EN MXC_F_WDT_CTRL_WDT_EN
+
+typedef enum {
+    MXC_WDT_COMPATIBILITY = 0,
+    MXC_WDT_WINDOWED = 1, /* Not support on MAX32665/6, added here to get common zephyr driver */
+} mxc_wdt_mode_t;
+
+static inline int Wrap_MXC_WDT_Init(mxc_wdt_regs_t *wdt, wrap_mxc_wdt_cfg_t *cfg)
+{
+    int ret;
+
+    if (cfg && ((mxc_wdt_mode_t)cfg->mode == MXC_WDT_COMPATIBILITY)) {
+        /* only support compatibility mode */
+        ret = MXC_WDT_Init(wdt);
+    } else {
+        ret = -1;
+    }
+
+    return ret;
+}
+
+static inline void Wrap_MXC_WDT_SetResetPeriod(mxc_wdt_regs_t *wdt, wrap_mxc_wdt_cfg_t *cfg)
+{
+    (void)cfg;
+
+    MXC_WDT_SetResetPeriod(wdt, cfg->upperResetPeriod);
+}
+
+static inline void Wrap_MXC_WDT_SetIntPeriod(mxc_wdt_regs_t *wdt, wrap_mxc_wdt_cfg_t *cfg)
+{
+    return MXC_WDT_SetIntPeriod(wdt, cfg->upperIntPeriod);
+}
+
+static inline int Wrap_MXC_WDT_SelectClockSource(mxc_wdt_regs_t *wdt, uint32_t clock_src)
+{
+    (void)wdt;
+    (void)clock_src;
+
+    return 0;
+}
+
+/*
+ *  MAX32690, MAX32655 related mapping
+ */
+#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32670) || \
+    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675) ||          \
+    (CONFIG_SOC_MAX32680)
+
+#define WRAP_MXC_F_WDT_CTRL_EN MXC_F_WDT_CTRL_EN
+
+static inline int Wrap_MXC_WDT_Init(mxc_wdt_regs_t *wdt, wrap_mxc_wdt_cfg_t *cfg)
+{
+    mxc_wdt_cfg_t mxc_cfg;
+
+    mxc_cfg.mode = (mxc_wdt_mode_t)cfg->mode;
+    mxc_cfg.upperResetPeriod = cfg->upperResetPeriod;
+    mxc_cfg.lowerResetPeriod = cfg->lowerResetPeriod;
+    mxc_cfg.upperIntPeriod = cfg->upperIntPeriod;
+    mxc_cfg.lowerIntPeriod = cfg->lowerIntPeriod;
+
+    return MXC_WDT_Init(wdt, &mxc_cfg);
+}
+
+static inline void Wrap_MXC_WDT_SetResetPeriod(mxc_wdt_regs_t *wdt, wrap_mxc_wdt_cfg_t *cfg)
+{
+    MXC_WDT_SetResetPeriod(wdt, (mxc_wdt_cfg_t *)cfg);
+}
+
+static inline void Wrap_MXC_WDT_SetIntPeriod(mxc_wdt_regs_t *wdt, wrap_mxc_wdt_cfg_t *cfg)
+{
+    mxc_wdt_cfg_t mxc_cfg;
+
+    mxc_cfg.mode = (mxc_wdt_mode_t)cfg->mode;
+    mxc_cfg.upperResetPeriod = cfg->upperResetPeriod;
+    mxc_cfg.lowerResetPeriod = cfg->lowerResetPeriod;
+    mxc_cfg.upperIntPeriod = cfg->upperIntPeriod;
+    mxc_cfg.lowerIntPeriod = cfg->lowerIntPeriod;
+
+    return MXC_WDT_SetIntPeriod(wdt, &mxc_cfg);
+}
+
+static inline int Wrap_MXC_WDT_SelectClockSource(mxc_wdt_regs_t *wdt, uint32_t clock_src)
+{
+    mxc_wdt_clock_t clk_src;
+
+    switch (clock_src) {
+    case 0: // ADI_MAX32_PRPH_CLK_SRC_PCLK
+        clk_src = MXC_WDT_PCLK;
+        break;
+    case 2: // ADI_MAX32_PRPH_CLK_SRC_IBRO
+        clk_src = MXC_WDT_IBRO_CLK;
+        break;
+    case 5: // ADI_MAX32_PRPH_CLK_SRC_INRO
+#if defined(CONFIG_SOC_MAX32662)
+        clk_src = MXC_WDT_NANO_CLK;
+#else
+        clk_src = MXC_WDT_INRO_CLK;
+#endif
+        break;
+#if !(defined(CONFIG_SOC_MAX32675) || (CONFIG_SOC_MAX32680))
+    case 4: // ADI_MAX32_PRPH_CLK_SRC_ERTCO
+        clk_src = MXC_WDT_ERTCO_CLK;
+        break;
+#endif
+    default:
+        return -1;
+    }
+
+    return MXC_WDT_SetClockSource(wdt, clk_src);
+}
+
+#endif // part number
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _WRAP_MAX32_WDT_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32xxx.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32xxx.h
@@ -16,8 +16,8 @@
  *
  ******************************************************************************/
 
-#ifndef _WRAP_MAX32XXX_H_
-#define _WRAP_MAX32XXX_H_
+#ifndef LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32XXX_H_
+#define LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32XXX_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -63,4 +63,4 @@ extern "C" {
 }
 #endif
 
-#endif // _WRAP_MAX32XXX_H_
+#endif // LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32XXX_H_

--- a/Libraries/zephyr/MAX/Include/wrap_max32xxx.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32xxx.h
@@ -1,0 +1,66 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#ifndef _WRAP_MAX32XXX_H_
+#define _WRAP_MAX32XXX_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(CONFIG_SOC_MAX32520)
+#include <max32520.h>
+#elif defined(CONFIG_SOC_MAX32570)
+#include <max32570.h>
+#elif defined(CONFIG_SOC_MAX32572)
+#include <max32572.h>
+#elif defined(CONFIG_SOC_MAX32650)
+#include <max32650.h>
+#elif defined(CONFIG_SOC_MAX32651)
+#include <max32650.h>
+#elif defined(CONFIG_SOC_MAX32655)
+#include <max32655.h>
+#elif defined(CONFIG_SOC_MAX32660)
+#include <max326660.h>
+#elif defined(CONFIG_SOC_MAX32662)
+#include <max32662.h>
+#elif defined(CONFIG_SOC_MAX32665)
+#include <max326665.h>
+#elif defined(CONFIG_SOC_MAX32666)
+#include <max32665.h>
+#elif defined(CONFIG_SOC_MAX32670)
+#include <max32670.h>
+#elif defined(CONFIG_SOC_MAX32672)
+#include <max32672.h>
+#elif defined(CONFIG_SOC_MAX32675)
+#include <max32675.h>
+#elif defined(CONFIG_SOC_MAX32680)
+#include <max32680.h>
+#elif defined(CONFIG_SOC_MAX32690)
+#include <max32690.h>
+#elif defined(CONFIG_SOC_MAX78000)
+#include <max78000.h>
+#elif defined(CONFIG_SOC_MAX78002)
+#include <max78002.h>
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _WRAP_MAX32XXX_H_

--- a/Libraries/zephyr/MAX/Include/wrap_utils.h
+++ b/Libraries/zephyr/MAX/Include/wrap_utils.h
@@ -1,0 +1,51 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#ifndef _WRAP_UTILS_H_
+#define _WRAP_UTILS_H_
+
+/***** Includes *****/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* 
+ * Find least significant bit set in a 32-bit word
+ * Returns
+ *    least significant bit set, 0 if val is 0
+ */
+static inline int wrap_utils_find_lsb_set(uint32_t val)
+{
+    int lsb = 0;
+
+    for (int i = 0; i < 32; i++) {
+        if (val & (1 << i)) {
+            lsb = (i + 1);
+            break;
+        }
+    }
+
+    return lsb;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _WRAP_UTILS_H_

--- a/Libraries/zephyr/MAX/Include/wrap_utils.h
+++ b/Libraries/zephyr/MAX/Include/wrap_utils.h
@@ -16,8 +16,8 @@
  *
  ******************************************************************************/
 
-#ifndef _WRAP_UTILS_H_
-#define _WRAP_UTILS_H_
+#ifndef LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_UTILS_H_
+#define LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_UTILS_H_
 
 /***** Includes *****/
 
@@ -48,4 +48,4 @@ static inline int wrap_utils_find_lsb_set(uint32_t val)
 }
 #endif
 
-#endif // _WRAP_UTILS_H_
+#endif // LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_UTILS_H_

--- a/Libraries/zephyr/MAX/Source/MAX32655/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32655/CMakeLists.txt
@@ -1,8 +1,20 @@
-# Makefile - Analog Devices SDK
+##############################################################################
 #
-# Copyright (c) 2023 Analog Devices, Inc.
+# Copyright (C) 2023-2024 Analog Devices, Inc.
 #
-# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##############################################################################
 
 
 if(NOT TARGET_REV)

--- a/Libraries/zephyr/MAX/Source/MAX32655/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32655/CMakeLists.txt
@@ -1,0 +1,171 @@
+# Makefile - Analog Devices SDK
+#
+# Copyright (c) 2023 Analog Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+if(NOT TARGET_REV)
+  # Default version A1, not actively use in driver but requires to be defined.
+  zephyr_compile_definitions(-DTARGET_REV=0x4131)
+endif()
+
+zephyr_include_directories(
+    ${MSDK_PERIPH_SRC_DIR}/SYS
+    ${MSDK_PERIPH_SRC_DIR}/ADC
+    ${MSDK_PERIPH_SRC_DIR}/AES
+    ${MSDK_PERIPH_SRC_DIR}/CRC
+    ${MSDK_PERIPH_SRC_DIR}/DMA
+    ${MSDK_PERIPH_SRC_DIR}/FLC
+    ${MSDK_PERIPH_SRC_DIR}/GPIO
+    ${MSDK_PERIPH_SRC_DIR}/I2C
+    ${MSDK_PERIPH_SRC_DIR}/I2S
+    ${MSDK_PERIPH_SRC_DIR}/ICC
+    ${MSDK_PERIPH_SRC_DIR}/LP
+    ${MSDK_PERIPH_SRC_DIR}/LPCMP
+    ${MSDK_PERIPH_SRC_DIR}/OWM 
+    ${MSDK_PERIPH_SRC_DIR}/PT
+    ${MSDK_PERIPH_SRC_DIR}/RTC
+    ${MSDK_PERIPH_SRC_DIR}/SEMA
+    ${MSDK_PERIPH_SRC_DIR}/SIMO
+    ${MSDK_PERIPH_SRC_DIR}/SPI
+    ${MSDK_PERIPH_SRC_DIR}/TRNG
+    ${MSDK_PERIPH_SRC_DIR}/TMR
+    ${MSDK_PERIPH_SRC_DIR}/UART
+    ${MSDK_PERIPH_SRC_DIR}/WDT
+    ${MSDK_PERIPH_SRC_DIR}/WUT
+)
+
+zephyr_library_sources(
+    ./max32xxx_system.c
+
+    ${MSDK_CMSIS_DIR}/Source/system_max32655.c
+
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_assert.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_delay.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_lock.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/pins_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/sys_me17.c
+     
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/LP/lp_me17.c
+
+    ${MSDK_PERIPH_SRC_DIR}/LPCMP/lpcmp_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/LPCMP/lpcmp_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/PT/pt_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/PT/pt_reva.c
+        
+    ${MSDK_PERIPH_SRC_DIR}/SEMA/sema_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/SEMA/sema_reva.c
+
+    ${MSDK_PERIPH_SRC_DIR}/SIMO/simo_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/SIMO/simo_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/WUT/wut_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/WUT/wut_reva.c
+
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_reva.c
+)
+
+if (CONFIG_UART_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_common.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_revb.c
+)
+endif()
+
+if (CONFIG_GPIO_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_common.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_reva.c
+)
+endif()
+
+if (CONFIG_SPI_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_reva1.c
+)
+endif()
+
+if (CONFIG_I2C_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_reva.c
+)
+endif()
+
+if (CONFIG_WDT_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_common.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_revb.c
+)
+endif()
+
+if (CONFIG_RTC_MAX32 OR CONFIG_COUNTER_RTC_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/RTC/rtc_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/RTC/rtc_reva.c
+)
+endif()
+
+if (CONFIG_SOC_FLASH_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_common.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_reva.c
+)
+endif()
+
+if (CONFIG_ADC_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/ADC/adc_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/ADC/adc_reva.c
+)
+endif()
+
+if (CONFIG_W1_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/OWM/owm_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/OWM/owm_reva.c
+)
+endif()
+
+if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32) 
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_common.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_revb.c
+)
+endif()
+
+if (CONFIG_I2S_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/I2S/i2s_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/I2S/i2s_reva.c
+)
+endif()
+
+if (CONFIG_ENTROPY_MAX32_TRNG)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/TRNG/trng_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/TRNG/trng_revb.c
+)
+endif()
+
+if (CONFIG_CRYPTO_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/AES/aes_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/AES/aes_revb.c
+
+    ${MSDK_PERIPH_SRC_DIR}/CRC/crc_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/CRC/crc_reva.c
+)
+endif()

--- a/Libraries/zephyr/MAX/Source/MAX32655/max32xxx_system.c
+++ b/Libraries/zephyr/MAX/Source/MAX32655/max32xxx_system.c
@@ -1,0 +1,63 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#include "max32655.h"
+#include "gcr_regs.h"
+#include "icc.h"
+#include "simo.h"
+#include "mcr_regs.h"
+
+static int pre_init(void)
+{
+    uint32_t psc = MXC_GCR->clkctrl & MXC_F_GCR_CLKCTRL_SYSCLK_DIV;
+
+    /* Divide down system clock until SIMO is ready */
+    MXC_GCR->clkctrl = (MXC_GCR->clkctrl & ~(MXC_F_GCR_CLKCTRL_SYSCLK_DIV)) |
+                       (MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV128);
+
+    while (!(MXC_SIMO->buck_out_ready & MXC_F_SIMO_BUCK_OUT_READY_BUCKOUTRDYA)) {}
+    while (!(MXC_SIMO->buck_out_ready & MXC_F_SIMO_BUCK_OUT_READY_BUCKOUTRDYB)) {}
+    while (!(MXC_SIMO->buck_out_ready & MXC_F_SIMO_BUCK_OUT_READY_BUCKOUTRDYC)) {}
+
+    /* Restore system clock divider */
+    MXC_GCR->clkctrl = (MXC_GCR->clkctrl & ~(MXC_F_GCR_CLKCTRL_SYSCLK_DIV)) | (psc);
+
+    return 0;
+}
+
+/* 
+ * This function is called during boot up.
+ */
+void max32xx_system_init(void)
+{
+    pre_init();
+
+    /* Disable SRAM ECC until it is handled on zephyr side */
+    MXC_MCR->eccen &= ~MXC_F_MCR_ECCEN_RAM0;
+
+    /* Enable instruction cache */
+    MXC_ICC_Enable(MXC_ICC0);
+
+    /* Setup the SIMO voltages */
+    MXC_SIMO_SetVregO_A(1750);
+    while (MXC_SIMO_GetOutReadyA() != E_NO_ERROR) {}
+    MXC_SIMO_SetVregO_B(1100);
+    while (MXC_SIMO_GetOutReadyB() != E_NO_ERROR) {}
+    MXC_SIMO_SetVregO_C(1100);
+    while (MXC_SIMO_GetOutReadyC() != E_NO_ERROR) {}
+}

--- a/Libraries/zephyr/MAX/Source/MAX32662/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32662/CMakeLists.txt
@@ -1,8 +1,20 @@
-# Makefile - Analog Devices SDK
+##############################################################################
 #
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (C) 2024 Analog Devices, Inc.
 #
-# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##############################################################################
 
 
 if(NOT TARGET_REV)

--- a/Libraries/zephyr/MAX/Source/MAX32662/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32662/CMakeLists.txt
@@ -1,0 +1,148 @@
+# Makefile - Analog Devices SDK
+#
+# Copyright (c) 2024 Analog Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+if(NOT TARGET_REV)
+  # Default version A1, not actively use in driver but requires to be defined.
+  zephyr_compile_definitions(-DTARGET_REV=0x4131)
+endif()
+
+zephyr_include_directories(
+    ${MSDK_PERIPH_SRC_DIR}/ADC
+    ${MSDK_PERIPH_SRC_DIR}/AES
+    ${MSDK_PERIPH_SRC_DIR}/DMA
+    ${MSDK_PERIPH_SRC_DIR}/FLC
+    ${MSDK_PERIPH_SRC_DIR}/GPIO
+    ${MSDK_PERIPH_SRC_DIR}/I2C
+    ${MSDK_PERIPH_SRC_DIR}/I2S
+    ${MSDK_PERIPH_SRC_DIR}/ICC
+    ${MSDK_PERIPH_SRC_DIR}/LP
+    ${MSDK_PERIPH_SRC_DIR}/RTC
+    ${MSDK_PERIPH_SRC_DIR}/SPI
+    ${MSDK_PERIPH_SRC_DIR}/SYS
+    ${MSDK_PERIPH_SRC_DIR}/TMR
+    ${MSDK_PERIPH_SRC_DIR}/TRNG
+    ${MSDK_PERIPH_SRC_DIR}/UART
+    ${MSDK_PERIPH_SRC_DIR}/WDT
+    ${MSDK_PERIPH_SRC_DIR}/CAN
+    ${MSDK_PERIPH_SRC_DIR}/PT
+)
+
+zephyr_library_sources(
+    ./max32xxx_system.c
+
+    ${MSDK_CMSIS_DIR}/Source/system_max32662.c
+
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_common.c
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_me12.c
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_reva.c
+
+    ${MSDK_PERIPH_SRC_DIR}/LP/lp_me12.c
+
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_assert.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_delay.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_lock.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/pins_me12.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/sys_me12.c
+
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_me12.c
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_reva.c
+
+    ${MSDK_PERIPH_SRC_DIR}/CAN/can_me12.c
+    ${MSDK_PERIPH_SRC_DIR}/CAN/can_reva.c
+
+    ${MSDK_PERIPH_SRC_DIR}/PT/pt_me12.c
+    ${MSDK_PERIPH_SRC_DIR}/PT/pt_reva.c
+)
+
+if (CONFIG_ADC_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/ADC/adc_me12.c
+    ${MSDK_PERIPH_SRC_DIR}/ADC/adc_revb.c
+)
+endif()
+
+if (CONFIG_UART_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_common.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_me12.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_revb.c
+)
+endif()
+
+if (CONFIG_GPIO_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_common.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_me12.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_reva.c
+)
+endif()
+
+if (CONFIG_SPI_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_me12.c
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_reva1.c
+)
+endif()
+
+if (CONFIG_I2C_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_me12.c
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_reva.c
+)
+endif()
+
+if (CONFIG_I2S_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/I2S/i2s_me12.c
+    ${MSDK_PERIPH_SRC_DIR}/I2S/i2s_reva.c
+)
+endif()
+
+if (CONFIG_WDT_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_common.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_me12.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_revb.c
+)
+endif()
+
+if (CONFIG_RTC_MAX32 OR CONFIG_COUNTER_RTC_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/RTC/rtc_me12.c
+    ${MSDK_PERIPH_SRC_DIR}/RTC/rtc_reva.c
+)
+endif()
+
+if (CONFIG_SOC_FLASH_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_common.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_me12.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_reva.c
+)
+endif()
+
+if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32) 
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_common.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_me12.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_revb.c
+)
+endif()
+
+if (CONFIG_ENTROPY_MAX32_TRNG)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/TRNG/trng_me12.c
+    ${MSDK_PERIPH_SRC_DIR}/TRNG/trng_revb.c
+)
+endif()
+
+if (CONFIG_CRYPTO_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/AES/aes_me12.c
+    ${MSDK_PERIPH_SRC_DIR}/AES/aes_revb.c
+)
+endif()

--- a/Libraries/zephyr/MAX/Source/MAX32662/max32xxx_system.c
+++ b/Libraries/zephyr/MAX/Source/MAX32662/max32xxx_system.c
@@ -1,0 +1,24 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2024 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#include "max32662.h"
+
+/* 
+ * This function is called during boot up.
+ */
+void max32xx_system_init(void) {}

--- a/Libraries/zephyr/MAX/Source/MAX32665/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32665/CMakeLists.txt
@@ -1,8 +1,20 @@
-# Makefile - Analog Devices SDK
+##############################################################################
 #
-# Copyright (c) 2023 Analog Devices, Inc.
+# Copyright (C) 2023-2024 Analog Devices, Inc.
 #
-# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##############################################################################
 
 
 if(NOT TARGET_REV)

--- a/Libraries/zephyr/MAX/Source/MAX32665/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32665/CMakeLists.txt
@@ -1,0 +1,179 @@
+# Makefile - Analog Devices SDK
+#
+# Copyright (c) 2023 Analog Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+if(NOT TARGET_REV)
+  # Default version A1, not actively use in driver but requires to be defined.
+  zephyr_compile_definitions(-DTARGET_REV=0x4131)
+endif()
+
+zephyr_include_directories(
+    ${MSDK_PERIPH_SRC_DIR}/ADC
+    ${MSDK_PERIPH_SRC_DIR}/CORE1
+    ${MSDK_PERIPH_SRC_DIR}/DMA
+    ${MSDK_PERIPH_SRC_DIR}/FLC
+    ${MSDK_PERIPH_SRC_DIR}/GPIO
+    ${MSDK_PERIPH_SRC_DIR}/HTMR
+    ${MSDK_PERIPH_SRC_DIR}/I2C
+    ${MSDK_PERIPH_SRC_DIR}/ICC
+    ${MSDK_PERIPH_SRC_DIR}/LP
+    ${MSDK_PERIPH_SRC_DIR}/OWM 
+    ${MSDK_PERIPH_SRC_DIR}/PT
+    ${MSDK_PERIPH_SRC_DIR}/RPU
+    ${MSDK_PERIPH_SRC_DIR}/RTC
+    ${MSDK_PERIPH_SRC_DIR}/SDHC
+    ${MSDK_PERIPH_SRC_DIR}/SEMA
+    ${MSDK_PERIPH_SRC_DIR}/SIMO
+    ${MSDK_PERIPH_SRC_DIR}/SPI
+    ${MSDK_PERIPH_SRC_DIR}/SPIXF
+    ${MSDK_PERIPH_SRC_DIR}/SPIXR
+    ${MSDK_PERIPH_SRC_DIR}/SRCC
+    ${MSDK_PERIPH_SRC_DIR}/SYS
+    ${MSDK_PERIPH_SRC_DIR}/TMR
+    ${MSDK_PERIPH_SRC_DIR}/TPU
+    ${MSDK_PERIPH_SRC_DIR}/TRNG
+    ${MSDK_PERIPH_SRC_DIR}/UART
+    ${MSDK_PERIPH_SRC_DIR}/WDT
+    ${MSDK_PERIPH_SRC_DIR}/WUT
+)
+
+zephyr_library_sources(
+    ./max32xxx_system.c
+
+    ${MSDK_CMSIS_DIR}/Source/system_max32665.c
+
+    ${MSDK_PERIPH_SRC_DIR}/HTMR/htmr_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/HTMR/htmr_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_common.c
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/LP/lp_me14.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/PT/pt_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/PT/pt_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/RPU/rpu_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/RPU/rpu_reva.c
+    
+    
+    ${MSDK_PERIPH_SRC_DIR}/SDHC/sdhc_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/SDHC/sdhc_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/SEMA/sema_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/SEMA/sema_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/SIMO/simo_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/SIMO/simo_reva.c
+    
+     
+    ${MSDK_PERIPH_SRC_DIR}/SPIXF/spixf_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/SPIXF/spixf_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/SPIXR/spixr_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/SPIXR/spixr_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/SRCC/srcc_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/SRCC/srcc_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_assert.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_delay.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_lock.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/pins_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/sys_me14.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/TPU/tpu_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/TPU/tpu_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/WUT/wut_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/WUT/wut_reva.c
+
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_reva.c
+)
+
+if (CONFIG_UART_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_common.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_reva.c
+)
+endif()
+
+if (CONFIG_GPIO_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_common.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_reva.c
+)
+endif()
+
+if (CONFIG_SPI_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_reva1.c
+)
+endif()
+
+if (CONFIG_I2C_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_reva.c
+)
+endif()
+
+if (CONFIG_WDT_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_common.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_reva.c
+)
+endif()
+
+if (CONFIG_RTC_MAX32 OR CONFIG_COUNTER_RTC_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/RTC/rtc_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/RTC/rtc_reva.c
+)
+endif()
+
+if (CONFIG_SOC_FLASH_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_common.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_reva.c
+)
+endif()
+
+if (CONFIG_ADC_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/ADC/adc_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/ADC/adc_reva.c
+)
+endif()
+
+if (CONFIG_W1_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/OWM/owm_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/OWM/owm_reva.c
+)
+endif()
+
+if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32) 
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_common.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_reva.c
+)
+endif()
+
+if (CONFIG_ENTROPY_MAX32_TRNG)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/TRNG/trng_me14.c
+    ${MSDK_PERIPH_SRC_DIR}/TRNG/trng_revb.c
+)
+endif()

--- a/Libraries/zephyr/MAX/Source/MAX32665/max32xxx_system.c
+++ b/Libraries/zephyr/MAX/Source/MAX32665/max32xxx_system.c
@@ -1,0 +1,97 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#include "max32665.h"
+#include "mxc_sys.h"
+#include "gcr_regs.h"
+#include "icc_regs.h"
+#include "pwrseq_regs.h"
+#include "simo_regs.h"
+#include "mcr_regs.h"
+
+static int pre_init(void)
+{
+    uint32_t psc = MXC_GCR->clkcn & MXC_F_GCR_CLKCN_PSC;
+
+    /* Disable USB switch to minimize current consumption */
+    MXC_MCR->ctrl |= MXC_F_MCR_CTRL_USBSWEN_N;
+
+    /* Divide down system clock until SIMO is ready */
+    MXC_GCR->clkcn = (MXC_GCR->clkcn & ~(MXC_F_GCR_CLKCN_PSC)) | (MXC_S_GCR_CLKCN_PSC_DIV128);
+
+    while (!(MXC_SIMO->buck_out_ready & MXC_F_SIMO_BUCK_OUT_READY_BUCKOUTRDYA)) {}
+    while (!(MXC_SIMO->buck_out_ready & MXC_F_SIMO_BUCK_OUT_READY_BUCKOUTRDYB)) {}
+    while (!(MXC_SIMO->buck_out_ready & MXC_F_SIMO_BUCK_OUT_READY_BUCKOUTRDYC)) {}
+
+    /* Restore system clock divider */
+    MXC_GCR->clkcn = (MXC_GCR->clkcn & ~(MXC_F_GCR_CLKCN_PSC)) | (psc);
+
+    /* Set the proper OVR setting */
+    MXC_GCR->scon = (MXC_GCR->scon & ~(MXC_F_GCR_SCON_OVR)) | (MXC_S_GCR_SCON_OVR_1_1V);
+
+    return 0;
+}
+
+/* 
+ * This function is called during boot up.
+ */
+void max32xx_system_init(void)
+{
+    pre_init();
+
+    /* Disable SRAM ECC until it is handled on zephyr side */
+    MXC_MCR->eccen &= ~(MXC_F_MCR_ECCEN_SYSRAM0ECCEN | MXC_F_MCR_ECCEN_SYSRAM1ECCEN |
+                        MXC_F_MCR_ECCEN_SYSRAM2ECCEN | MXC_F_MCR_ECCEN_SYSRAM3ECCEN |
+                        MXC_F_MCR_ECCEN_SYSRAM4ECCEN | MXC_F_MCR_ECCEN_SYSRAM5ECCEN);
+
+    /* We'd like to switch to the fast clock, but can only do so if the 
+     * core's operating voltage (VregO_B) is high enough to support it
+     * Otherwise, we need to remain on the slow clock
+     */
+    if ((MXC_SIMO->vrego_b > 48) && (MXC_SIMO->buck_out_ready & 0x2)) {
+        // Switch to fast clock on startup
+        MXC_GCR->clkcn &= ~(MXC_S_GCR_CLKCN_PSC_DIV128);
+        MXC_SYS_Clock_Select(MXC_SYS_CLOCK_HIRC96);
+    }
+
+    // FIXME Pre-production parts: Enable TME, disable ICache Read Buffer, disable TME
+    *(uint32_t *)0x40000c00 = 1;
+    *(uint32_t *)0x4000040c = (1 << 6);
+    *(uint32_t *)0x40000c00 = 0;
+
+    // Flush and enable instruction cache
+    MXC_ICC0->invalidate = 1;
+    while (!(MXC_ICC0->cache_ctrl & MXC_F_ICC_CACHE_CTRL_RDY)) {}
+    MXC_ICC0->cache_ctrl |= MXC_F_ICC_CACHE_CTRL_EN;
+    while (!(MXC_ICC0->cache_ctrl & MXC_F_ICC_CACHE_CTRL_RDY)) {}
+
+    // Set all GPIO to 25K pullup mode by default
+    MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
+    MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO1);
+    MXC_GPIO0->vssel |= 0xFFFFFFFF;
+    MXC_GPIO0->ps |= 0xFFFFFFFF;
+    MXC_GPIO0->pad_cfg1 |= 0xFFFFFFFF;
+    MXC_GPIO0->pad_cfg2 &= ~(0xFFFFFFFF);
+    MXC_GPIO1->vssel |= 0xFFFFFFFF;
+    MXC_GPIO1->ps |= 0xFFFFFFFF;
+    MXC_GPIO1->pad_cfg1 |= 0xFFFFFFFF;
+    MXC_GPIO1->pad_cfg2 &= ~(0xFFFFFFFF);
+
+    /* Disable fast wakeup due to issues with SIMO in wakeup */
+    MXC_PWRSEQ->lpcn &= ~MXC_F_PWRSEQ_LPCN_FWKM;
+}

--- a/Libraries/zephyr/MAX/Source/MAX32670/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32670/CMakeLists.txt
@@ -1,8 +1,20 @@
-# Makefile - Analog Devices SDK
+##############################################################################
 #
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (C) 2024 Analog Devices, Inc.
 #
-# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##############################################################################
 
 
 if(NOT TARGET_REV)

--- a/Libraries/zephyr/MAX/Source/MAX32670/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32670/CMakeLists.txt
@@ -1,0 +1,117 @@
+# Makefile - Analog Devices SDK
+#
+# Copyright (c) 2024 Analog Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+if(NOT TARGET_REV)
+  # Default version A1, not actively use in driver but requires to be defined.
+  zephyr_compile_definitions(-DTARGET_REV=0x4131)
+endif()
+
+zephyr_include_directories(
+    ${MSDK_PERIPH_SRC_DIR}/DMA
+    ${MSDK_PERIPH_SRC_DIR}/FLC
+    ${MSDK_PERIPH_SRC_DIR}/GPIO
+    ${MSDK_PERIPH_SRC_DIR}/I2C
+    ${MSDK_PERIPH_SRC_DIR}/I2S
+    ${MSDK_PERIPH_SRC_DIR}/ICC
+    ${MSDK_PERIPH_SRC_DIR}/LP
+    ${MSDK_PERIPH_SRC_DIR}/RTC
+    ${MSDK_PERIPH_SRC_DIR}/SPI
+    ${MSDK_PERIPH_SRC_DIR}/SYS
+    ${MSDK_PERIPH_SRC_DIR}/TMR
+    ${MSDK_PERIPH_SRC_DIR}/TRNG
+    ${MSDK_PERIPH_SRC_DIR}/UART
+    ${MSDK_PERIPH_SRC_DIR}/WDT
+)
+
+zephyr_library_sources(
+    ./max32xxx_system.c
+
+    ${MSDK_CMSIS_DIR}/Source/system_max32670.c
+
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_common.c
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_reva.c
+
+    ${MSDK_PERIPH_SRC_DIR}/LP/lp_me15.c
+
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_assert.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_delay.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_lock.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/pins_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/sys_me15.c
+
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_reva.c
+)
+
+if (CONFIG_UART_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_common.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_revb.c
+)
+endif()
+
+if (CONFIG_GPIO_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_common.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_reva.c
+)
+endif()
+
+if (CONFIG_SPI_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_reva1.c
+)
+endif()
+
+if (CONFIG_I2C_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_reva.c
+)
+endif()
+
+if (CONFIG_WDT_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_common.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_revb.c
+)
+endif()
+
+if (CONFIG_RTC_MAX32 OR CONFIG_COUNTER_RTC_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/RTC/rtc_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/RTC/rtc_reva.c
+)
+endif()
+
+if (CONFIG_SOC_FLASH_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_common.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_reva.c
+)
+endif()
+
+if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32) 
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_common.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_revb.c
+)
+endif()
+
+if (CONFIG_ENTROPY_MAX32_TRNG)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/TRNG/trng_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/TRNG/trng_revb.c
+)
+endif()

--- a/Libraries/zephyr/MAX/Source/MAX32670/max32xxx_system.c
+++ b/Libraries/zephyr/MAX/Source/MAX32670/max32xxx_system.c
@@ -1,0 +1,34 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2024 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#include "max32670.h"
+#include "pwrseq_regs.h"
+#include "mxc_sys.h"
+#include "ecc_regs.h"
+
+/* 
+ * This function is called during boot up.
+ */
+void max32xx_system_init(void)
+{
+    /* Disable SRAM ECC until it is handled on zephyr side */
+    MXC_ECC->en &= ~MXC_F_ECC_EN_SRAM;
+
+    /* Make sure INRO is enabled. INRO should already be enabled during power up. */
+    MXC_PWRSEQ->lpcn |= MXC_F_PWRSEQ_LPCN_INRO_EN;
+}

--- a/Libraries/zephyr/MAX/Source/MAX32672/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32672/CMakeLists.txt
@@ -1,8 +1,20 @@
-# Makefile - Analog Devices SDK
+##############################################################################
 #
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (C) 2024 Analog Devices, Inc.
 #
-# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##############################################################################
 
 
 if(NOT TARGET_REV)

--- a/Libraries/zephyr/MAX/Source/MAX32672/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32672/CMakeLists.txt
@@ -1,0 +1,149 @@
+# Makefile - Analog Devices SDK
+#
+# Copyright (c) 2024 Analog Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+if(NOT TARGET_REV)
+  # Default version A1, not actively use in driver but requires to be defined.
+  zephyr_compile_definitions(-DTARGET_REV=0x4131)
+endif()
+
+zephyr_include_directories(
+    ${MSDK_PERIPH_SRC_DIR}/ADC
+    ${MSDK_PERIPH_SRC_DIR}/AES
+    ${MSDK_PERIPH_SRC_DIR}/CTB
+    ${MSDK_PERIPH_SRC_DIR}/DMA
+    ${MSDK_PERIPH_SRC_DIR}/FLC
+    ${MSDK_PERIPH_SRC_DIR}/GPIO
+    ${MSDK_PERIPH_SRC_DIR}/I2C
+    ${MSDK_PERIPH_SRC_DIR}/I2S
+    ${MSDK_PERIPH_SRC_DIR}/ICC
+    ${MSDK_PERIPH_SRC_DIR}/LP
+    ${MSDK_PERIPH_SRC_DIR}/QDEC
+    ${MSDK_PERIPH_SRC_DIR}/RTC
+    ${MSDK_PERIPH_SRC_DIR}/SPI
+    ${MSDK_PERIPH_SRC_DIR}/SYS
+    ${MSDK_PERIPH_SRC_DIR}/TMR
+    ${MSDK_PERIPH_SRC_DIR}/TRNG
+    ${MSDK_PERIPH_SRC_DIR}/UART
+    ${MSDK_PERIPH_SRC_DIR}/WDT
+)
+
+zephyr_library_sources(
+    ./max32xxx_system.c
+
+    ${MSDK_CMSIS_DIR}/Source/system_max32672.c
+
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_common.c
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_me21.c
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_reva.c
+
+    ${MSDK_PERIPH_SRC_DIR}/LP/lp_me21.c
+
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_assert.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_delay.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_lock.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/pins_me21.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/sys_me21.c
+
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_me21.c
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_reva.c
+
+    ${MSDK_PERIPH_SRC_DIR}/QDEC/qdec_me21.c
+    ${MSDK_PERIPH_SRC_DIR}/QDEC/qdec_reva.c
+)
+
+if (CONFIG_ADC_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/ADC/adc_me21.c
+    ${MSDK_PERIPH_SRC_DIR}/ADC/adc_revb.c
+)
+endif()
+
+if (CONFIG_UART_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_common.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_me21.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_revb.c
+)
+endif()
+
+if (CONFIG_GPIO_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_common.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_me21.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_reva.c
+)
+endif()
+
+if (CONFIG_SPI_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_me21.c
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_reva1.c
+)
+endif()
+
+if (CONFIG_I2C_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_me21.c
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_reva.c
+)
+endif()
+
+if (CONFIG_I2S_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/I2S/i2s_me21.c
+    ${MSDK_PERIPH_SRC_DIR}/I2S/i2s_reva.c
+)
+endif()
+
+if (CONFIG_WDT_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_common.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_me21.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_revb.c
+)
+endif()
+
+if (CONFIG_RTC_MAX32 OR CONFIG_COUNTER_RTC_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/RTC/rtc_me21.c
+    ${MSDK_PERIPH_SRC_DIR}/RTC/rtc_reva.c
+)
+endif()
+
+if (CONFIG_SOC_FLASH_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_common.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_me21.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_reva.c
+)
+endif()
+
+if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32) 
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_common.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_me21.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_revb.c
+)
+endif()
+
+if (CONFIG_ENTROPY_MAX32_TRNG)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/TRNG/trng_me21.c
+    ${MSDK_PERIPH_SRC_DIR}/TRNG/trng_revb.c
+)
+endif()
+
+if (CONFIG_CRYPTO_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/AES/aes_me21.c
+    ${MSDK_PERIPH_SRC_DIR}/AES/aes_revb.c
+
+    ${MSDK_PERIPH_SRC_DIR}/CTB/ctb_me21.c
+    ${MSDK_PERIPH_SRC_DIR}/CTB/ctb_reva.c
+    ${MSDK_PERIPH_SRC_DIR}/CTB/ctb_common.c
+)
+endif()

--- a/Libraries/zephyr/MAX/Source/MAX32672/max32xxx_system.c
+++ b/Libraries/zephyr/MAX/Source/MAX32672/max32xxx_system.c
@@ -1,0 +1,30 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2024 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#include "max32672.h"
+#include "trimsir_regs.h"
+
+/* 
+ * This function is called during boot up.
+ */
+void max32xx_system_init(void)
+{
+    /* Disable SRAM ECC until it is handled on zephyr side */
+    MXC_TRIMSIR->bb_sir2 &= ~(MXC_F_TRIMSIR_BB_SIR2_RAM0_1ECCEN | MXC_F_TRIMSIR_BB_SIR2_RAM2ECCEN |
+                              MXC_F_TRIMSIR_BB_SIR2_RAM3ECCEN);
+}

--- a/Libraries/zephyr/MAX/Source/MAX32675/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32675/CMakeLists.txt
@@ -1,8 +1,20 @@
-# Makefile - Analog Devices SDK
+##############################################################################
 #
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (C) 2024 Analog Devices, Inc.
 #
-# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##############################################################################
 
 
 if(NOT TARGET_REV)

--- a/Libraries/zephyr/MAX/Source/MAX32675/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32675/CMakeLists.txt
@@ -1,0 +1,132 @@
+# Makefile - Analog Devices SDK
+#
+# Copyright (c) 2024 Analog Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+if(NOT TARGET_REV)
+  # Default version A1, not actively use in driver but requires to be defined.
+  zephyr_compile_definitions(-DTARGET_REV=0x4131)
+endif()
+
+zephyr_include_directories(
+    ${MSDK_PERIPH_SRC_DIR}/AES
+    ${MSDK_PERIPH_SRC_DIR}/AFE
+    ${MSDK_PERIPH_SRC_DIR}/CRC
+    ${MSDK_PERIPH_SRC_DIR}/DMA
+    ${MSDK_PERIPH_SRC_DIR}/FLC
+    ${MSDK_PERIPH_SRC_DIR}/GPIO
+    ${MSDK_PERIPH_SRC_DIR}/I2C
+    ${MSDK_PERIPH_SRC_DIR}/I2S
+    ${MSDK_PERIPH_SRC_DIR}/ICC
+    ${MSDK_PERIPH_SRC_DIR}/LP
+    ${MSDK_PERIPH_SRC_DIR}/RTC
+    ${MSDK_PERIPH_SRC_DIR}/SPI
+    ${MSDK_PERIPH_SRC_DIR}/SYS
+    ${MSDK_PERIPH_SRC_DIR}/TMR
+    ${MSDK_PERIPH_SRC_DIR}/TRNG
+    ${MSDK_PERIPH_SRC_DIR}/UART
+    ${MSDK_PERIPH_SRC_DIR}/WDT
+)
+
+zephyr_library_sources(
+    ./max32xxx_system.c
+
+    ${MSDK_CMSIS_DIR}/Source/system_max32675.c
+
+    ${MSDK_PERIPH_SRC_DIR}/AES/aes_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/AES/aes_revb.c
+
+    ${MSDK_PERIPH_SRC_DIR}/CRC/crc_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/CRC/crc_reva.c
+
+    ${MSDK_PERIPH_SRC_DIR}/AFE/afe.c
+    ${MSDK_PERIPH_SRC_DIR}/AFE/afe_gpio.c
+    ${MSDK_PERIPH_SRC_DIR}/AFE/afe_timer.c
+    ${MSDK_PERIPH_SRC_DIR}/AFE/hart_uart.c
+    ${MSDK_PERIPH_SRC_DIR}/AFE/infoblock.c
+
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_common.c
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_reva.c
+
+    ${MSDK_PERIPH_SRC_DIR}/LP/lp_me15.c
+
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_assert.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_delay.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_lock.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/pins_me16.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/sys_me15.c
+
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_reva.c
+)
+
+if (CONFIG_UART_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_common.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_me16.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_revb.c
+)
+endif()
+
+if (CONFIG_GPIO_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_common.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_me16.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_reva.c
+)
+endif()
+
+if (CONFIG_SPI_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_reva1.c
+)
+endif()
+
+if (CONFIG_I2C_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_reva.c
+)
+endif()
+
+if (CONFIG_I2S_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/I2S/i2s_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/I2S/i2s_reva.c
+)
+endif()
+
+if (CONFIG_WDT_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_common.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_revb.c
+)
+endif()
+
+if (CONFIG_SOC_FLASH_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_common.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_reva.c
+)
+endif()
+
+if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32) 
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_common.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_me16.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_revb.c
+)
+endif()
+
+if (CONFIG_ENTROPY_MAX32_TRNG)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/TRNG/trng_me15.c
+    ${MSDK_PERIPH_SRC_DIR}/TRNG/trng_revb.c
+)
+endif()

--- a/Libraries/zephyr/MAX/Source/MAX32675/max32xxx_system.c
+++ b/Libraries/zephyr/MAX/Source/MAX32675/max32xxx_system.c
@@ -1,0 +1,29 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2024 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#include "max32675.h"
+#include "ecc_regs.h"
+
+/* 
+ * This function is called during boot up.
+ */
+void max32xx_system_init(void)
+{
+    /* Disable SRAM ECC until it is handled on zephyr side */
+    MXC_ECC->en &= ~MXC_F_ECC_EN_SRAM;
+}

--- a/Libraries/zephyr/MAX/Source/MAX32680/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32680/CMakeLists.txt
@@ -1,8 +1,20 @@
-# Makefile - Analog Devices SDK
+##############################################################################
 #
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (C) 2024 Analog Devices, Inc.
 #
-# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##############################################################################
 
 
 if(NOT TARGET_REV)

--- a/Libraries/zephyr/MAX/Source/MAX32680/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32680/CMakeLists.txt
@@ -1,0 +1,174 @@
+# Makefile - Analog Devices SDK
+#
+# Copyright (c) 2024 Analog Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+if(NOT TARGET_REV)
+  # Default version A1, not actively use in driver but requires to be defined.
+  zephyr_compile_definitions(-DTARGET_REV=0x4131)
+endif()
+
+zephyr_include_directories(
+    ${MSDK_PERIPH_SRC_DIR}/SYS
+    ${MSDK_PERIPH_SRC_DIR}/ADC
+    ${MSDK_PERIPH_SRC_DIR}/AES
+    ${MSDK_PERIPH_SRC_DIR}/AFE
+    ${MSDK_PERIPH_SRC_DIR}/CRC
+    ${MSDK_PERIPH_SRC_DIR}/DMA
+    ${MSDK_PERIPH_SRC_DIR}/FLC
+    ${MSDK_PERIPH_SRC_DIR}/GPIO
+    ${MSDK_PERIPH_SRC_DIR}/I2C
+    ${MSDK_PERIPH_SRC_DIR}/I2S
+    ${MSDK_PERIPH_SRC_DIR}/ICC
+    ${MSDK_PERIPH_SRC_DIR}/LP
+    ${MSDK_PERIPH_SRC_DIR}/OWM 
+    ${MSDK_PERIPH_SRC_DIR}/PT
+    ${MSDK_PERIPH_SRC_DIR}/RTC
+    ${MSDK_PERIPH_SRC_DIR}/SEMA
+    ${MSDK_PERIPH_SRC_DIR}/SIMO
+    ${MSDK_PERIPH_SRC_DIR}/SPI
+    ${MSDK_PERIPH_SRC_DIR}/TRNG
+    ${MSDK_PERIPH_SRC_DIR}/TMR
+    ${MSDK_PERIPH_SRC_DIR}/UART
+    ${MSDK_PERIPH_SRC_DIR}/WDT
+    ${MSDK_PERIPH_SRC_DIR}/WUT
+)
+
+zephyr_library_sources(
+    ./max32xxx_system.c
+
+    ${MSDK_CMSIS_DIR}/Source/system_max32680.c
+
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_assert.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_delay.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_lock.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/pins_me20.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/sys_me17.c
+
+    ${MSDK_PERIPH_SRC_DIR}/AFE/afe.c
+    ${MSDK_PERIPH_SRC_DIR}/AFE/afe_gpio.c
+    ${MSDK_PERIPH_SRC_DIR}/AFE/afe_timer.c
+    ${MSDK_PERIPH_SRC_DIR}/AFE/hart_uart.c
+    ${MSDK_PERIPH_SRC_DIR}/AFE/infoblock.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/LP/lp_me17.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/PT/pt_me20.c
+    ${MSDK_PERIPH_SRC_DIR}/PT/pt_reva.c
+        
+    ${MSDK_PERIPH_SRC_DIR}/SEMA/sema_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/SEMA/sema_reva.c
+
+    ${MSDK_PERIPH_SRC_DIR}/SIMO/simo_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/SIMO/simo_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/WUT/wut_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/WUT/wut_reva.c
+
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_reva.c
+)
+
+if (CONFIG_UART_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_common.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_revb.c
+)
+endif()
+
+if (CONFIG_GPIO_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_common.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_reva.c
+)
+endif()
+
+if (CONFIG_SPI_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_reva1.c
+)
+endif()
+
+if (CONFIG_I2C_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_reva.c
+)
+endif()
+
+if (CONFIG_WDT_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_common.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_revb.c
+)
+endif()
+
+if (CONFIG_RTC_MAX32 OR CONFIG_COUNTER_RTC_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/RTC/rtc_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/RTC/rtc_reva.c
+)
+endif()
+
+if (CONFIG_SOC_FLASH_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_common.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_reva.c
+)
+endif()
+
+if (CONFIG_ADC_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/ADC/adc_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/ADC/adc_reva.c
+)
+endif()
+
+if (CONFIG_W1_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/OWM/owm_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/OWM/owm_reva.c
+)
+endif()
+
+if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32) 
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_common.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_revb.c
+)
+endif()
+
+if (CONFIG_I2S_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/I2S/i2s_me20.c
+    ${MSDK_PERIPH_SRC_DIR}/I2S/i2s_reva.c
+)
+endif()
+
+if (CONFIG_ENTROPY_MAX32_TRNG)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/TRNG/trng_me20.c
+    ${MSDK_PERIPH_SRC_DIR}/TRNG/trng_revb.c
+)
+endif()
+
+if (CONFIG_CRYPTO_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/AES/aes_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/AES/aes_revb.c
+
+    ${MSDK_PERIPH_SRC_DIR}/CRC/crc_me17.c
+    ${MSDK_PERIPH_SRC_DIR}/CRC/crc_reva.c
+)
+endif()

--- a/Libraries/zephyr/MAX/Source/MAX32680/max32xxx_system.c
+++ b/Libraries/zephyr/MAX/Source/MAX32680/max32xxx_system.c
@@ -1,0 +1,33 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2024 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#include "max32680.h"
+#include "icc.h"
+#include "mcr_regs.h"
+
+/* 
+ * This function is called during boot up.
+ */
+void max32xx_system_init(void)
+{
+    /* Disable SRAM ECC until it is handled on zephyr side */
+    MXC_MCR->eccen &= ~MXC_F_MCR_ECCEN_RAM0;
+
+    /* Enable instruction cache */
+    MXC_ICC_Enable(MXC_ICC0);
+}

--- a/Libraries/zephyr/MAX/Source/MAX32690/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32690/CMakeLists.txt
@@ -1,8 +1,20 @@
-# Makefile - Analog Devices SDK
+##############################################################################
 #
-# Copyright (c) 2023 Analog Devices, Inc.
+# Copyright (C) 2023-2024 Analog Devices, Inc.
 #
-# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##############################################################################
 
 
 if(NOT TARGET_REV)

--- a/Libraries/zephyr/MAX/Source/MAX32690/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32690/CMakeLists.txt
@@ -1,0 +1,188 @@
+# Makefile - Analog Devices SDK
+#
+# Copyright (c) 2023 Analog Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+if(NOT TARGET_REV)
+  # Default version A1, not actively use in driver but requires to be defined.
+  zephyr_compile_definitions(-DTARGET_REV=0x4131)
+endif()
+
+zephyr_include_directories(
+    ${MSDK_PERIPH_SRC_DIR}/SYS
+    ${MSDK_PERIPH_SRC_DIR}/ADC
+    ${MSDK_PERIPH_SRC_DIR}/CAN
+    ${MSDK_PERIPH_SRC_DIR}/CTB
+    ${MSDK_PERIPH_SRC_DIR}/DMA
+    ${MSDK_PERIPH_SRC_DIR}/EMCC
+    ${MSDK_PERIPH_SRC_DIR}/FLC
+    ${MSDK_PERIPH_SRC_DIR}/GPIO
+    ${MSDK_PERIPH_SRC_DIR}/HPB
+    ${MSDK_PERIPH_SRC_DIR}/I2C
+    ${MSDK_PERIPH_SRC_DIR}/I2S
+    ${MSDK_PERIPH_SRC_DIR}/ICC
+    ${MSDK_PERIPH_SRC_DIR}/LP
+    ${MSDK_PERIPH_SRC_DIR}/LPCMP
+    ${MSDK_PERIPH_SRC_DIR}/OWM 
+    ${MSDK_PERIPH_SRC_DIR}/PT
+    ${MSDK_PERIPH_SRC_DIR}/RTC
+    ${MSDK_PERIPH_SRC_DIR}/SEMA
+    ${MSDK_PERIPH_SRC_DIR}/SPI
+    ${MSDK_PERIPH_SRC_DIR}/SPIXF
+    ${MSDK_PERIPH_SRC_DIR}/SPIXR
+    ${MSDK_PERIPH_SRC_DIR}/TRNG
+    ${MSDK_PERIPH_SRC_DIR}/TMR
+    ${MSDK_PERIPH_SRC_DIR}/UART
+    ${MSDK_PERIPH_SRC_DIR}/WDT
+    ${MSDK_PERIPH_SRC_DIR}/WUT
+)
+
+zephyr_library_sources(
+    ./max32xxx_system.c
+
+    ${MSDK_CMSIS_DIR}/Source/system_max32690.c
+
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_assert.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_delay.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_lock.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/pins_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/sys_me18.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/EMCC/emcc_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/EMCC/emcc_reva.c
+
+    ${MSDK_PERIPH_SRC_DIR}/HPB/hpb_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/HPB/hpb_reva.c
+     
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/LP/lp_me18.c
+
+    ${MSDK_PERIPH_SRC_DIR}/LPCMP/lpcmp_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/LPCMP/lpcmp_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/PT/pt_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/PT/pt_reva.c
+      
+    ${MSDK_PERIPH_SRC_DIR}/SEMA/sema_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/SEMA/sema_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/SPIXF/spixf_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/SPIXF/spixf_reva.c
+    
+    ${MSDK_PERIPH_SRC_DIR}/SPIXR/spixr_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/SPIXR/spixr_reva.c
+
+    ${MSDK_PERIPH_SRC_DIR}/WUT/wut_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/WUT/wut_reva.c
+
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_reva.c
+)
+
+if (CONFIG_UART_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_common.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_revb.c
+)
+endif()
+
+if (CONFIG_GPIO_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_common.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_reva.c
+)
+endif()
+
+if (CONFIG_SPI_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_reva1.c
+)
+endif()
+
+if (CONFIG_I2C_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_reva.c
+)
+endif()
+
+if (CONFIG_WDT_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_common.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_revb.c
+)
+endif()
+
+if (CONFIG_RTC_MAX32 OR CONFIG_COUNTER_RTC_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/RTC/rtc_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/RTC/rtc_reva.c
+)
+endif()
+
+if (CONFIG_SOC_FLASH_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_common.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_reva.c
+)
+endif()
+
+if (CONFIG_ADC_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/ADC/adc_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/ADC/adc_revb.c
+)
+endif()
+
+if (CONFIG_W1_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/OWM/owm_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/OWM/owm_reva.c
+)
+endif()
+
+if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32) 
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_common.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_revb.c
+)
+endif()
+
+if (CONFIG_I2S_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/I2S/i2s_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/I2S/i2s_reva.c
+)
+endif()
+
+if (CONFIG_ENTROPY_MAX32_TRNG)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/TRNG/trng_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/TRNG/trng_revb.c
+)
+endif()
+
+if (CONFIG_CRYPTO_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/CTB/ctb_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/CTB/ctb_reva.c
+    ${MSDK_PERIPH_SRC_DIR}/CTB/ctb_common.c
+)
+endif()
+
+if (CONFIG_CAN_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/CAN/can_me18.c
+    ${MSDK_PERIPH_SRC_DIR}/CAN/can_reva.c
+)
+endif()

--- a/Libraries/zephyr/MAX/Source/MAX32690/max32xxx_system.c
+++ b/Libraries/zephyr/MAX/Source/MAX32690/max32xxx_system.c
@@ -1,0 +1,35 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#include "max32690.h"
+#include "icc.h"
+
+/* 
+ * This function is called during boot up.
+ */
+void max32xx_system_init(void)
+{
+    *(volatile uint32_t *)0x40000c00 = 1; // Enable test mode
+    *(volatile uint32_t *)0x4000040c = (1 << 6); // Disable cache read buffer
+    *(volatile uint32_t *)0x40000c00 = 0; // Disable test mode
+
+    // Enable then disable ICC to clear the cache
+    MXC_ICC_Enable(MXC_ICC0);
+    MXC_ICC_Disable(MXC_ICC0);
+    MXC_ICC_Enable(MXC_ICC0);
+}


### PR DESCRIPTION
### Description

hal_adi is repository that used by zephyr sdk. 
By this PR the content of this repository moved in MSDK repository to centralize it.

- Add wrappers files that used to provide common interface on zephyr shim driver.
- Add CMakefies that used to build drivers 
- Update zephyr-hal.sh script to copy new files to target repository (hal_adi).

Wrapper layer added to get one common zephyr shim driver on zephyr layer.
![image](https://github.com/analogdevicesinc/msdk/assets/46590392/8de5f37d-2109-4441-a9c2-df5cd0792b1a)

It will be nice if wrap layer function been added peripheral driver in future.

hal_adi folder layout listed below. After this PR being merged MAX folder content totally will comes from MSDK.
![image](https://github.com/analogdevicesinc/msdk/assets/46590392/a49bfea9-66d0-404c-8918-0fe7bb415c06)


### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
