### PR TITLE
feat(PeriphDrivers): Add PinMux tool supporting functions

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32520/Source/system_max32520.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32520/Source/system_max32520.c
@@ -91,6 +91,17 @@ __weak int PreInit(void)
     return 0;
 }
 
+/* This function is called before the Board_Init function.  This weak 
+ * implementation does nothing, but you may over-ride this function in your 
+ * program if you want to configure the state of all pins prior to the 
+ * application running.  This is useful when using external tools (like a
+ * Pin Mux configuration tool) that generate code to initialize the pins.
+ */
+__weak void PinInit(void)
+{
+    /* Do nothing */
+}
+
 /* This function can be implemented by the application to initialize the board */
 __weak int Board_Init(void)
 {
@@ -139,5 +150,6 @@ __weak void SystemInit(void)
     MXC_GPIO1->pdpu_sel0 |= 0xFFFFFFFF;
     MXC_GPIO1->pdpu_sel1 &= ~(0xFFFFFFFF);
 
+    PinInit();
     Board_Init();
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32570/Source/system_max32570.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32570/Source/system_max32570.c
@@ -97,6 +97,17 @@ __weak int PreInit(void)
     return 0;
 }
 
+/* This function is called before the Board_Init function.  This weak 
+ * implementation does nothing, but you may over-ride this function in your 
+ * program if you want to configure the state of all pins prior to the 
+ * application running.  This is useful when using external tools (like a
+ * Pin Mux configuration tool) that generate code to initialize the pins.
+ */
+__weak void PinInit(void)
+{
+    /* Do nothing */
+}
+
 /* This function can be implemented by the application to initialize the board */
 __weak int Board_Init(void)
 {
@@ -138,5 +149,6 @@ __weak void SystemInit(void)
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO1);
 
+    PinInit();
     Board_Init();
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_max32572.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_max32572.c
@@ -97,6 +97,17 @@ __weak int PreInit(void)
     return 0;
 }
 
+/* This function is called before the Board_Init function.  This weak 
+ * implementation does nothing, but you may over-ride this function in your 
+ * program if you want to configure the state of all pins prior to the 
+ * application running.  This is useful when using external tools (like a
+ * Pin Mux configuration tool) that generate code to initialize the pins.
+ */
+__weak void PinInit(void)
+{
+    /* Do nothing */
+}
+
 /* This function can be implemented by the application to initialize the board */
 __weak int Board_Init(void)
 {
@@ -139,5 +150,6 @@ __weak void SystemInit(void)
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO1);
 
+    PinInit();
     Board_Init();
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32650/Source/system_max32650.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32650/Source/system_max32650.c
@@ -96,6 +96,17 @@ __weak int PreInit(void)
     return 0;
 }
 
+/* This function is called before the Board_Init function.  This weak 
+ * implementation does nothing, but you may over-ride this function in your 
+ * program if you want to configure the state of all pins prior to the 
+ * application running.  This is useful when using external tools (like a
+ * Pin Mux configuration tool) that generate code to initialize the pins.
+ */
+__weak void PinInit(void)
+{
+    /* Do nothing */
+}
+
 /* This function can be implemented by the application to initialize the board */
 __weak int Board_Init(void)
 {
@@ -177,6 +188,7 @@ __weak void SystemInit(void)
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_I2S);
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_SPIXIPR);
 
+    PinInit();
     Board_Init();
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_max32655.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_max32655.c
@@ -114,6 +114,17 @@ __weak int PreInit(void)
     return 0;
 }
 
+/* This function is called before the Board_Init function.  This weak 
+ * implementation does nothing, but you may over-ride this function in your 
+ * program if you want to configure the state of all pins prior to the 
+ * application running.  This is useful when using external tools (like a
+ * Pin Mux configuration tool) that generate code to initialize the pins.
+ */
+__weak void PinInit(void)
+{
+    /* Do nothing */
+}
+
 /* This function can be implemented by the application to initialize the board */
 __weak int Board_Init(void)
 {
@@ -164,6 +175,7 @@ __weak void SystemInit(void)
     MXC_SYS_SetClockDiv(MXC_SYS_CLOCK_DIV_1);
     SystemCoreClockUpdate();
 
+    PinInit();
     Board_Init();
 
     PalSysInit();

--- a/Libraries/CMSIS/Device/Maxim/MAX32660/Source/system_max32660.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32660/Source/system_max32660.c
@@ -97,6 +97,17 @@ __weak int PreInit(void)
     return 0;
 }
 
+/* This function is called before the Board_Init function.  This weak 
+ * implementation does nothing, but you may over-ride this function in your 
+ * program if you want to configure the state of all pins prior to the 
+ * application running.  This is useful when using external tools (like a
+ * Pin Mux configuration tool) that generate code to initialize the pins.
+ */
+__weak void PinInit(void)
+{
+    /* Do nothing */
+}
+
 /* This function can be implemented by the application to initialize the board */
 __weak int Board_Init(void)
 {
@@ -142,6 +153,7 @@ __weak void SystemInit(void)
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TMR2);
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_I2C1);
 
+    PinInit();
     Board_Init();
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32662/Source/system_max32662.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32662/Source/system_max32662.c
@@ -121,6 +121,17 @@ __weak int PreInit(void)
     return 0;
 }
 
+/* This function is called before the Board_Init function.  This weak 
+ * implementation does nothing, but you may over-ride this function in your 
+ * program if you want to configure the state of all pins prior to the 
+ * application running.  This is useful when using external tools (like a
+ * Pin Mux configuration tool) that generate code to initialize the pins.
+ */
+__weak void PinInit(void)
+{
+    /* Do nothing */
+}
+
 /* This function can be implemented by the application to initialize the board */
 __weak int Board_Init(void)
 {
@@ -161,6 +172,7 @@ __weak void SystemInit(void)
     MXC_SYS_Clock_Select(MXC_SYS_CLOCK_IPO);
     SystemCoreClockUpdate();
 
+    PinInit();
     Board_Init();
 
     __enable_irq();

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Source/system_max32665.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Source/system_max32665.c
@@ -120,6 +120,17 @@ __weak int PreInit(void)
     return 0;
 }
 
+/* This function is called before the Board_Init function.  This weak 
+ * implementation does nothing, but you may over-ride this function in your 
+ * program if you want to configure the state of all pins prior to the 
+ * application running.  This is useful when using external tools (like a
+ * Pin Mux configuration tool) that generate code to initialize the pins.
+ */
+__weak void PinInit(void)
+{
+    /* Do nothing */
+}
+
 // This function can be implemented by the application to initialize the board
 __weak int Board_Init(void)
 {
@@ -191,6 +202,7 @@ __weak void SystemInit(void)
     /* Disable fast wakeup due to issues with SIMO in wakeup */
     MXC_PWRSEQ->lpcn &= ~MXC_F_PWRSEQ_LPCN_FWKM;
 
+    PinInit();
     Board_Init();
 
     PalSysInit();

--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Source/system_max32670.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Source/system_max32670.c
@@ -102,6 +102,17 @@ __weak int PreInit(void)
     return 0;
 }
 
+/* This function is called before the Board_Init function.  This weak 
+ * implementation does nothing, but you may over-ride this function in your 
+ * program if you want to configure the state of all pins prior to the 
+ * application running.  This is useful when using external tools (like a
+ * Pin Mux configuration tool) that generate code to initialize the pins.
+ */
+__weak void PinInit(void)
+{
+    /* Do nothing */
+}
+
 /* This function can be implemented by the application to initialize the board */
 __weak int Board_Init(void)
 {
@@ -148,6 +159,7 @@ __weak void SystemInit(void)
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO1);
 
+    PinInit();
     Board_Init();
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Source/system_max32672.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Source/system_max32672.c
@@ -115,6 +115,17 @@ __weak int PreInit(void)
     return 0;
 }
 
+/* This function is called before the Board_Init function.  This weak 
+ * implementation does nothing, but you may over-ride this function in your 
+ * program if you want to configure the state of all pins prior to the 
+ * application running.  This is useful when using external tools (like a
+ * Pin Mux configuration tool) that generate code to initialize the pins.
+ */
+__weak void PinInit(void)
+{
+    /* Do nothing */
+}
+
 /* This function can be implemented by the application to initialize the board */
 __weak int Board_Init(void)
 {
@@ -154,5 +165,6 @@ __weak void SystemInit(void)
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO1);
 
+    PinInit();
     Board_Init();
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Source/system_max32675.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Source/system_max32675.c
@@ -117,6 +117,17 @@ __weak int PreInit(void)
     return 0;
 }
 
+/* This function is called before the Board_Init function.  This weak 
+ * implementation does nothing, but you may over-ride this function in your 
+ * program if you want to configure the state of all pins prior to the 
+ * application running.  This is useful when using external tools (like a
+ * Pin Mux configuration tool) that generate code to initialize the pins.
+ */
+__weak void PinInit(void)
+{
+    /* Do nothing */
+}
+
 /* This function can be implemented by the application to initialize the board */
 __weak int Board_Init(void)
 {
@@ -156,6 +167,7 @@ __weak void SystemInit(void)
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO1);
 
+    PinInit();
     Board_Init();
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_max32680.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_max32680.c
@@ -101,6 +101,17 @@ __weak int PreInit(void)
     return 0;
 }
 
+/* This function is called before the Board_Init function.  This weak 
+ * implementation does nothing, but you may over-ride this function in your 
+ * program if you want to configure the state of all pins prior to the 
+ * application running.  This is useful when using external tools (like a
+ * Pin Mux configuration tool) that generate code to initialize the pins.
+ */
+__weak void PinInit(void)
+{
+    /* Do nothing */
+}
+
 /* This function can be implemented by the application to initialize the board */
 __weak int Board_Init(void)
 {
@@ -143,6 +154,7 @@ __weak void SystemInit(void)
     MXC_SYS_SetClockDiv(MXC_SYS_CLOCK_DIV_1);
     SystemCoreClockUpdate();
 
+    PinInit();
     Board_Init();
 
     PalSysInit();

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_max32690.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_max32690.c
@@ -100,6 +100,17 @@ __weak int PreInit(void)
     return 0;
 }
 
+/* This function is called before the Board_Init function.  This weak 
+ * implementation does nothing, but you may over-ride this function in your 
+ * program if you want to configure the state of all pins prior to the 
+ * application running.  This is useful when using external tools (like a
+ * Pin Mux configuration tool) that generate code to initialize the pins.
+ */
+__weak void PinInit(void)
+{
+    /* Do nothing */
+}
+
 /* This function can be implemented by the application to initialize the board */
 __weak int Board_Init(void)
 {
@@ -150,6 +161,7 @@ __weak void SystemInit(void)
 
     PalSysInit();
 
+    PinInit();
     Board_Init();
 
     __enable_irq();

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_max78000.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_max78000.c
@@ -97,6 +97,17 @@ __weak int PreInit(void)
     return 0;
 }
 
+/* This function is called before the Board_Init function.  This weak 
+ * implementation does nothing, but you may over-ride this function in your 
+ * program if you want to configure the state of all pins prior to the 
+ * application running.  This is useful when using external tools (like a
+ * Pin Mux configuration tool) that generate code to initialize the pins.
+ */
+__weak void PinInit(void)
+{
+    /* Do nothing */
+}
+
 /* This function can be implemented by the application to initialize the board */
 __weak int Board_Init(void)
 {
@@ -131,5 +142,6 @@ __weak void SystemInit(void)
 
     SystemCoreClockUpdate();
 
+    PinInit();
     Board_Init();
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_max78002.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_max78002.c
@@ -102,6 +102,17 @@ __weak int PreInit(void)
     return 0;
 }
 
+/* This function is called before the Board_Init function.  This weak 
+ * implementation does nothing, but you may over-ride this function in your 
+ * program if you want to configure the state of all pins prior to the 
+ * application running.  This is useful when using external tools (like a
+ * Pin Mux configuration tool) that generate code to initialize the pins.
+ */
+__weak void PinInit(void)
+{
+    /* Do nothing */
+}
+
 /* This function can be implemented by the application to initialize the board */
 __weak int Board_Init(void)
 {
@@ -133,5 +144,6 @@ __weak void SystemInit(void)
 
     SystemCoreClockUpdate();
 
+    PinInit();
     Board_Init();
 }

--- a/Libraries/PeriphDrivers/Include/MAX32520/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32520/gpio.h
@@ -190,6 +190,14 @@ typedef enum {
     MXC_GPIO_INT_BOTH ///< Interrupt triggers on either edge
 } mxc_gpio_int_pol_t;
 
+/**
+ * @brief   Enumeration type for the pin configuration lock mechanism.
+ */
+typedef enum {
+    MXC_GPIO_CONFIG_UNLOCKED = 0, /**< Allow changing pins' configuration. */
+    MXC_GPIO_CONFIG_LOCKED, /**< Ignore changes to a pin's configuration. */
+} mxc_gpio_config_lock_t;
+
 /* **** Function Prototypes **** */
 
 /**
@@ -372,6 +380,20 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port);
  * @param[in]  mask   Pins in the GPIO port that will be set to the voltage.
  */
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask);
+
+/**
+ * @brief      Enables/Disables the lock on all pins' configurations.  If 
+ *             locked, any changes to a pin's configuration made through the
+ *             MXC_GPIO_Config function will be ignored.
+ *
+ * @param      locked  Determines if changes will be allowed. */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked);
+
+/**
+ * @brief      Reads the current lock state on pin configuration.
+ *
+ * @returns    The lock state. */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void);
 
 /**@} end of group gpio */
 

--- a/Libraries/PeriphDrivers/Include/MAX32570/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/gpio.h
@@ -190,6 +190,14 @@ typedef enum {
     MXC_GPIO_INT_BOTH ///< Interrupt triggers on either edge
 } mxc_gpio_int_pol_t;
 
+/**
+ * @brief   Enumeration type for the pin configuration lock mechanism.
+ */
+typedef enum {
+    MXC_GPIO_CONFIG_UNLOCKED = 0, /**< Allow changing pins' configuration. */
+    MXC_GPIO_CONFIG_LOCKED, /**< Ignore changes to a pin's configuration. */
+} mxc_gpio_config_lock_t;
+
 /* **** Function Prototypes **** */
 
 /**
@@ -372,6 +380,20 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port);
  * @param[in]  mask   Pins in the GPIO port that will be set to the voltage.
  */
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask);
+
+/**
+ * @brief      Enables/Disables the lock on all pins' configurations.  If 
+ *             locked, any changes to a pin's configuration made through the
+ *             MXC_GPIO_Config function will be ignored.
+ *
+ * @param      locked  Determines if changes will be allowed. */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked);
+
+/**
+ * @brief      Reads the current lock state on pin configuration.
+ *
+ * @returns    The lock state. */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void);
 
 /**@} end of group gpio */
 

--- a/Libraries/PeriphDrivers/Include/MAX32572/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/gpio.h
@@ -191,6 +191,14 @@ typedef enum {
     MXC_GPIO_INT_BOTH ///< Interrupt triggers on either edge
 } mxc_gpio_int_pol_t;
 
+/**
+ * @brief   Enumeration type for the pin configuration lock mechanism.
+ */
+typedef enum {
+    MXC_GPIO_CONFIG_UNLOCKED = 0, /**< Allow changing pins' configuration. */
+    MXC_GPIO_CONFIG_LOCKED, /**< Ignore changes to a pin's configuration. */
+} mxc_gpio_config_lock_t;
+
 /* **** Function Prototypes **** */
 
 /**
@@ -373,6 +381,20 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port);
  * @param[in]  mask   Pins in the GPIO port that will be set to the voltage.
  */
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask);
+
+/**
+ * @brief      Enables/Disables the lock on all pins' configurations.  If 
+ *             locked, any changes to a pin's configuration made through the
+ *             MXC_GPIO_Config function will be ignored.
+ *
+ * @param      locked  Determines if changes will be allowed. */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked);
+
+/**
+ * @brief      Reads the current lock state on pin configuration.
+ *
+ * @returns    The lock state. */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void);
 
 /**@} end of group gpio */
 

--- a/Libraries/PeriphDrivers/Include/MAX32650/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/gpio.h
@@ -180,6 +180,14 @@ typedef enum {
     MXC_GPIO_INT_BOTH /**< Interrupt triggers on either edge */
 } mxc_gpio_int_pol_t;
 
+/**
+ * @brief   Enumeration type for the pin configuration lock mechanism.
+ */
+typedef enum {
+    MXC_GPIO_CONFIG_UNLOCKED = 0, /**< Allow changing pins' configuration. */
+    MXC_GPIO_CONFIG_LOCKED, /**< Ignore changes to a pin's configuration. */
+} mxc_gpio_config_lock_t;
+
 /* **** Function Prototypes **** */
 
 /**
@@ -366,6 +374,20 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port);
  * @param[in]  mask   Pins in the GPIO port that will be set to the voltage.
  */
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask);
+
+/**
+ * @brief      Enables/Disables the lock on all pins' configurations.  If 
+ *             locked, any changes to a pin's configuration made through the
+ *             MXC_GPIO_Config function will be ignored.
+ *
+ * @param      locked  Determines if changes will be allowed. */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked);
+
+/**
+ * @brief      Reads the current lock state on pin configuration.
+ *
+ * @returns    The lock state. */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void);
 
 /**@} end of group gpio */
 

--- a/Libraries/PeriphDrivers/Include/MAX32655/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/gpio.h
@@ -190,6 +190,14 @@ typedef enum {
     MXC_GPIO_INT_BOTH /**< Interrupt triggers on either edge */
 } mxc_gpio_int_pol_t;
 
+/**
+ * @brief   Enumeration type for the pin configuration lock mechanism.
+ */
+typedef enum {
+    MXC_GPIO_CONFIG_UNLOCKED = 0, /**< Allow changing pins' configuration. */
+    MXC_GPIO_CONFIG_LOCKED, /**< Ignore changes to a pin's configuration. */
+} mxc_gpio_config_lock_t;
+
 /* **** Function Prototypes **** */
 
 /**
@@ -368,6 +376,20 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port);
  * @param[in]  mask   Pins in the GPIO port that will be set to the voltage.
  */
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask);
+
+/**
+ * @brief      Enables/Disables the lock on all pins' configurations.  If 
+ *             locked, any changes to a pin's configuration made through the
+ *             MXC_GPIO_Config function will be ignored.
+ *
+ * @param      locked  Determines if changes will be allowed. */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked);
+
+/**
+ * @brief      Reads the current lock state on pin configuration.
+ *
+ * @returns    The lock state. */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void);
 
 /**@} end of group gpio */
 

--- a/Libraries/PeriphDrivers/Include/MAX32660/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/gpio.h
@@ -169,6 +169,14 @@ typedef enum {
     MXC_GPIO_INT_BOTH ///< Interrupt triggers on either edge
 } mxc_gpio_int_pol_t;
 
+/**
+ * @brief   Enumeration type for the pin configuration lock mechanism.
+ */
+typedef enum {
+    MXC_GPIO_CONFIG_UNLOCKED = 0, /**< Allow changing pins' configuration. */
+    MXC_GPIO_CONFIG_LOCKED, /**< Ignore changes to a pin's configuration. */
+} mxc_gpio_config_lock_t;
+
 /* **** Function Prototypes **** */
 
 /**
@@ -349,6 +357,20 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port);
  * @param[in]  mask   Pins in the GPIO port that will be set to the voltage.
  */
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask);
+
+/**
+ * @brief      Enables/Disables the lock on all pins' configurations.  If 
+ *             locked, any changes to a pin's configuration made through the
+ *             MXC_GPIO_Config function will be ignored.
+ *
+ * @param      locked  Determines if changes will be allowed. */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked);
+
+/**
+ * @brief      Reads the current lock state on pin configuration.
+ *
+ * @returns    The lock state. */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void);
 
 /**@} end of group gpio */
 

--- a/Libraries/PeriphDrivers/Include/MAX32662/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/gpio.h
@@ -189,6 +189,14 @@ typedef enum {
     MXC_GPIO_INT_BOTH /**< Interrupt triggers on either edge */
 } mxc_gpio_int_pol_t;
 
+/**
+ * @brief   Enumeration type for the pin configuration lock mechanism.
+ */
+typedef enum {
+    MXC_GPIO_CONFIG_UNLOCKED = 0, /**< Allow changing pins' configuration. */
+    MXC_GPIO_CONFIG_LOCKED, /**< Ignore changes to a pin's configuration. */
+} mxc_gpio_config_lock_t;
+
 /* **** Function Prototypes **** */
 
 /**
@@ -367,6 +375,20 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port);
  * @param[in]  mask   Pins in the GPIO port that will be set to the voltage.
  */
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask);
+
+/**
+ * @brief      Enables/Disables the lock on all pins' configurations.  If 
+ *             locked, any changes to a pin's configuration made through the
+ *             MXC_GPIO_Config function will be ignored.
+ *
+ * @param      locked  Determines if changes will be allowed. */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked);
+
+/**
+ * @brief      Reads the current lock state on pin configuration.
+ *
+ * @returns    The lock state. */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void);
 
 /**@} end of group gpio */
 

--- a/Libraries/PeriphDrivers/Include/MAX32665/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/gpio.h
@@ -189,6 +189,14 @@ typedef enum {
     MXC_GPIO_INT_BOTH /**< Interrupt triggers on either edge */
 } mxc_gpio_int_pol_t;
 
+/**
+ * @brief   Enumeration type for the pin configuration lock mechanism.
+ */
+typedef enum {
+    MXC_GPIO_CONFIG_UNLOCKED = 0, /**< Allow changing pins' configuration. */
+    MXC_GPIO_CONFIG_LOCKED, /**< Ignore changes to a pin's configuration. */
+} mxc_gpio_config_lock_t;
+
 /* **** Function Prototypes **** */
 
 /**
@@ -371,6 +379,20 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port);
  * @param[in]  mask   Pins in the GPIO port that will be set to the voltage.
  */
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask);
+
+/**
+ * @brief      Enables/Disables the lock on all pins' configurations.  If 
+ *             locked, any changes to a pin's configuration made through the
+ *             MXC_GPIO_Config function will be ignored.
+ *
+ * @param      locked  Determines if changes will be allowed. */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked);
+
+/**
+ * @brief      Reads the current lock state on pin configuration.
+ *
+ * @returns    The lock state. */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void);
 
 /**@} end of group gpio */
 

--- a/Libraries/PeriphDrivers/Include/MAX32670/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/gpio.h
@@ -190,6 +190,14 @@ typedef enum {
     MXC_GPIO_INT_BOTH ///< Interrupt triggers on either edge
 } mxc_gpio_int_pol_t;
 
+/**
+ * @brief   Enumeration type for the pin configuration lock mechanism.
+ */
+typedef enum {
+    MXC_GPIO_CONFIG_UNLOCKED = 0, /**< Allow changing pins' configuration. */
+    MXC_GPIO_CONFIG_LOCKED, /**< Ignore changes to a pin's configuration. */
+} mxc_gpio_config_lock_t;
+
 /* **** Function Prototypes **** */
 
 /**
@@ -370,6 +378,20 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port);
  * @param[in]  mask   Pins in the GPIO port that will be set to the voltage.
  */
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask);
+
+/**
+ * @brief      Enables/Disables the lock on all pins' configurations.  If 
+ *             locked, any changes to a pin's configuration made through the
+ *             MXC_GPIO_Config function will be ignored.
+ *
+ * @param      locked  Determines if changes will be allowed. */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked);
+
+/**
+ * @brief      Reads the current lock state on pin configuration.
+ *
+ * @returns    The lock state. */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void);
 
 /**@} end of group gpio */
 

--- a/Libraries/PeriphDrivers/Include/MAX32672/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/gpio.h
@@ -190,6 +190,14 @@ typedef enum {
     MXC_GPIO_INT_BOTH ///< Interrupt triggers on either edge
 } mxc_gpio_int_pol_t;
 
+/**
+ * @brief   Enumeration type for the pin configuration lock mechanism.
+ */
+typedef enum {
+    MXC_GPIO_CONFIG_UNLOCKED = 0, /**< Allow changing pins' configuration. */
+    MXC_GPIO_CONFIG_LOCKED, /**< Ignore changes to a pin's configuration. */
+} mxc_gpio_config_lock_t;
+
 /* **** Function Prototypes **** */
 
 /**
@@ -370,6 +378,20 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port);
  * @param[in]  mask   Pins in the GPIO port that will be set to the voltage.
  */
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask);
+
+/**
+ * @brief      Enables/Disables the lock on all pins' configurations.  If 
+ *             locked, any changes to a pin's configuration made through the
+ *             MXC_GPIO_Config function will be ignored.
+ *
+ * @param      locked  Determines if changes will be allowed. */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked);
+
+/**
+ * @brief      Reads the current lock state on pin configuration.
+ *
+ * @returns    The lock state. */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void);
 
 /**@} end of group gpio */
 

--- a/Libraries/PeriphDrivers/Include/MAX32675/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/gpio.h
@@ -190,6 +190,14 @@ typedef enum {
     MXC_GPIO_INT_BOTH ///< Interrupt triggers on either edge
 } mxc_gpio_int_pol_t;
 
+/**
+ * @brief   Enumeration type for the pin configuration lock mechanism.
+ */
+typedef enum {
+    MXC_GPIO_CONFIG_UNLOCKED = 0, /**< Allow changing pins' configuration. */
+    MXC_GPIO_CONFIG_LOCKED, /**< Ignore changes to a pin's configuration. */
+} mxc_gpio_config_lock_t;
+
 /* **** Function Prototypes **** */
 
 /**
@@ -370,6 +378,20 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port);
  * @param[in]  mask   Pins in the GPIO port that will be set to the voltage.
  */
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask);
+
+/**
+ * @brief      Enables/Disables the lock on all pins' configurations.  If 
+ *             locked, any changes to a pin's configuration made through the
+ *             MXC_GPIO_Config function will be ignored.
+ *
+ * @param      locked  Determines if changes will be allowed. */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked);
+
+/**
+ * @brief      Reads the current lock state on pin configuration.
+ *
+ * @returns    The lock state. */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void);
 
 /**@} end of group gpio */
 

--- a/Libraries/PeriphDrivers/Include/MAX32680/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/gpio.h
@@ -190,6 +190,14 @@ typedef enum {
     MXC_GPIO_INT_BOTH /**< Interrupt triggers on either edge */
 } mxc_gpio_int_pol_t;
 
+/**
+ * @brief   Enumeration type for the pin configuration lock mechanism.
+ */
+typedef enum {
+    MXC_GPIO_CONFIG_UNLOCKED = 0, /**< Allow changing pins' configuration. */
+    MXC_GPIO_CONFIG_LOCKED, /**< Ignore changes to a pin's configuration. */
+} mxc_gpio_config_lock_t;
+
 /* **** Function Prototypes **** */
 
 /**
@@ -368,6 +376,20 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port);
  * @param[in]  mask   Pins in the GPIO port that will be set to the voltage.
  */
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask);
+
+/**
+ * @brief      Enables/Disables the lock on all pins' configurations.  If 
+ *             locked, any changes to a pin's configuration made through the
+ *             MXC_GPIO_Config function will be ignored.
+ *
+ * @param      locked  Determines if changes will be allowed. */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked);
+
+/**
+ * @brief      Reads the current lock state on pin configuration.
+ *
+ * @returns    The lock state. */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void);
 
 /**@} end of group gpio */
 

--- a/Libraries/PeriphDrivers/Include/MAX32690/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/gpio.h
@@ -191,6 +191,15 @@ typedef enum {
     MXC_GPIO_INT_BOTH /**< Interrupt triggers on either edge */
 } mxc_gpio_int_pol_t;
 
+/**
+ * @brief   Enumeration type for the pin configuration lock mechanism.
+ */
+typedef enum {
+    MXC_GPIO_CONFIG_UNLOCKED = 0, /**< Allow changing pins' configuration. */
+    MXC_GPIO_CONFIG_LOCKED, /**< Ignore changes to a pin's configuration. */
+} mxc_gpio_config_lock_t;
+
+
 /* **** Function Prototypes **** */
 
 /**
@@ -369,6 +378,20 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port);
  * @param[in]  mask   Pins in the GPIO port that will be set to the voltage.
  */
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask);
+
+/**
+ * @brief      Enables/Disables the lock on all pins' configurations.  If 
+ *             locked, any changes to a pin's configuration made through the
+ *             MXC_GPIO_Config function will be ignored.
+ *
+ * @param      locked  Determines if changes will be allowed. */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked);
+
+/**
+ * @brief      Reads the current lock state on pin configuration.
+ *
+ * @returns    The lock state. */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void);
 
 /**@} end of group gpio */
 

--- a/Libraries/PeriphDrivers/Include/MAX32690/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/gpio.h
@@ -199,7 +199,6 @@ typedef enum {
     MXC_GPIO_CONFIG_LOCKED, /**< Ignore changes to a pin's configuration. */
 } mxc_gpio_config_lock_t;
 
-
 /* **** Function Prototypes **** */
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX78000/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/gpio.h
@@ -190,6 +190,14 @@ typedef enum {
     MXC_GPIO_INT_BOTH /**< Interrupt triggers on either edge */
 } mxc_gpio_int_pol_t;
 
+/**
+ * @brief   Enumeration type for the pin configuration lock mechanism.
+ */
+typedef enum {
+    MXC_GPIO_CONFIG_UNLOCKED = 0, /**< Allow changing pins' configuration. */
+    MXC_GPIO_CONFIG_LOCKED, /**< Ignore changes to a pin's configuration. */
+} mxc_gpio_config_lock_t;
+
 /* **** Function Prototypes **** */
 
 /**
@@ -370,6 +378,20 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port);
  * @param[in]  mask   Pins in the GPIO port that will be set to the voltage.
  */
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask);
+
+/**
+ * @brief      Enables/Disables the lock on all pins' configurations.  If 
+ *             locked, any changes to a pin's configuration made through the
+ *             MXC_GPIO_Config function will be ignored.
+ *
+ * @param      locked  Determines if changes will be allowed. */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked);
+
+/**
+ * @brief      Reads the current lock state on pin configuration.
+ *
+ * @returns    The lock state. */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void);
 
 /**@} end of group gpio */
 

--- a/Libraries/PeriphDrivers/Include/MAX78002/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/gpio.h
@@ -190,6 +190,14 @@ typedef enum {
     MXC_GPIO_INT_BOTH /**< Interrupt triggers on either edge */
 } mxc_gpio_int_pol_t;
 
+/**
+ * @brief   Enumeration type for the pin configuration lock mechanism.
+ */
+typedef enum {
+    MXC_GPIO_CONFIG_UNLOCKED = 0, /**< Allow changing pins' configuration. */
+    MXC_GPIO_CONFIG_LOCKED, /**< Ignore changes to a pin's configuration. */
+} mxc_gpio_config_lock_t;
+
 /* **** Function Prototypes **** */
 
 /**
@@ -368,6 +376,20 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port);
  * @param[in]  mask   Pins in the GPIO port that will be set to the voltage.
  */
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask);
+
+/**
+ * @brief      Enables/Disables the lock on all pins' configurations.  If 
+ *             locked, any changes to a pin's configuration made through the
+ *             MXC_GPIO_Config function will be ignored.
+ *
+ * @param      locked  Determines if changes will be allowed. */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked);
+
+/**
+ * @brief      Reads the current lock state on pin configuration.
+ *
+ * @returns    The lock state. */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void);
 
 /**@} end of group gpio */
 

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_ai85.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_ai85.c
@@ -109,8 +109,7 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 
     MXC_GPIO_Init(1 << port);
 
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_ai85.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_ai85.c
@@ -109,6 +109,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 
     MXC_GPIO_Init(1 << port);
 
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Configure the vssel
     error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
     if (error != E_NO_ERROR) {
@@ -412,4 +418,16 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port)
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask)
 {
     return MXC_GPIO_RevA_SetDriveStrength((mxc_gpio_reva_regs_t *)port, drvstr, mask);
+}
+
+/* ************************************************************************** */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked)
+{
+    MXC_GPIO_Common_SetConfigLock(locked);
+}
+
+/* ************************************************************************** */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void)
+{
+    return MXC_GPIO_Common_GetConfigLock();
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_ai87.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_ai87.c
@@ -109,8 +109,7 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 
     MXC_GPIO_Init(1 << port);
 
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_ai87.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_ai87.c
@@ -109,6 +109,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 
     MXC_GPIO_Init(1 << port);
 
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Configure the vssel
     error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
     if (error != E_NO_ERROR) {
@@ -412,4 +418,16 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port)
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask)
 {
     return MXC_GPIO_RevA_SetDriveStrength((mxc_gpio_reva_regs_t *)port, drvstr, mask);
+}
+
+/* ************************************************************************** */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked)
+{
+    MXC_GPIO_Common_SetConfigLock(locked);
+}
+
+/* ************************************************************************** */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void)
+{
+    return MXC_GPIO_Common_GetConfigLock();
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_common.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_common.c
@@ -29,6 +29,7 @@
 static void (*callback[MXC_CFG_GPIO_INSTANCES][MXC_CFG_GPIO_PINS_PORT])(void *);
 static void *cbparam[MXC_CFG_GPIO_INSTANCES][MXC_CFG_GPIO_PINS_PORT];
 static uint8_t initialized = 0;
+static mxc_gpio_config_lock_t cfg_lock = MXC_GPIO_CONFIG_UNLOCKED;
 
 /* **** Functions **** */
 int MXC_GPIO_Common_Init(uint32_t portmask)
@@ -93,4 +94,14 @@ void MXC_GPIO_Common_Handler(unsigned int port)
         pin++;
         stat >>= 1;
     }
+}
+
+void MXC_GPIO_Common_SetConfigLock(mxc_gpio_config_lock_t locked)
+{
+    cfg_lock = locked;
+}
+
+mxc_gpio_config_lock_t MXC_GPIO_Common_GetConfigLock(void)
+{
+    return cfg_lock;
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_common.h
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_common.h
@@ -35,6 +35,8 @@ int MXC_GPIO_Common_Init(uint32_t portmask);
 void MXC_GPIO_Common_RegisterCallback(const mxc_gpio_cfg_t *cfg, mxc_gpio_callback_fn callback,
                                       void *cbdata);
 void MXC_GPIO_Common_Handler(unsigned int port);
+void MXC_GPIO_Common_SetConfigLock(mxc_gpio_config_lock_t locked);
+mxc_gpio_config_lock_t MXC_GPIO_Common_GetConfigLock(void);
 
 /**@} end of group gpio */
 

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_es17.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_es17.c
@@ -74,8 +74,7 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_es17.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_es17.c
@@ -74,6 +74,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Configure the vssel
     error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
     if (error != E_NO_ERROR) {
@@ -218,4 +224,14 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port)
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask)
 {
     return MXC_GPIO_RevA_SetDriveStrength((mxc_gpio_reva_regs_t *)port, drvstr, mask);
+}
+
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked)
+{
+    MXC_GPIO_Common_SetConfigLock(locked);
+}
+
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void)
+{
+    return MXC_GPIO_Common_GetConfigLock();
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me10.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me10.c
@@ -101,6 +101,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int err;
     mxc_gpio_regs_t *gpio = cfg->port;
 
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Configure the vssel
     err = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
     if (err != E_NO_ERROR) {
@@ -258,4 +264,16 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port)
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask)
 {
     return MXC_GPIO_RevA_SetDriveStrength((mxc_gpio_reva_regs_t *)port, drvstr, mask);
+}
+
+/* ************************************************************************** */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked)
+{
+    MXC_GPIO_Common_SetConfigLock(locked);
+}
+
+/* ************************************************************************** */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void)
+{
+    return MXC_GPIO_Common_GetConfigLock();
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me10.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me10.c
@@ -101,8 +101,7 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int err;
     mxc_gpio_regs_t *gpio = cfg->port;
 
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me11.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me11.c
@@ -62,8 +62,7 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me11.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me11.c
@@ -62,6 +62,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Configure the vssel
     error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
     if (error != E_NO_ERROR) {
@@ -222,4 +228,14 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port)
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask)
 {
     return MXC_GPIO_RevA_SetDriveStrength((mxc_gpio_reva_regs_t *)port, drvstr, mask);
+}
+
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked)
+{
+    MXC_GPIO_Common_SetConfigLock(locked);
+}
+
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void)
+{
+    return MXC_GPIO_Common_GetConfigLock();
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me12.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me12.c
@@ -69,6 +69,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     port = MXC_GPIO_GET_IDX(cfg->port);
     MXC_GPIO_Init(1 << port);
 
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Configure the vssel
     error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
     if (error != E_NO_ERROR) {
@@ -216,4 +222,16 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port)
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask)
 {
     return MXC_GPIO_RevA_SetDriveStrength((mxc_gpio_reva_regs_t *)port, drvstr, mask);
+}
+
+/* ************************************************************************** */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked)
+{
+    MXC_GPIO_Common_SetConfigLock(locked);
+}
+
+/* ************************************************************************** */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void)
+{
+    return MXC_GPIO_Common_GetConfigLock();
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me12.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me12.c
@@ -69,8 +69,7 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     port = MXC_GPIO_GET_IDX(cfg->port);
     MXC_GPIO_Init(1 << port);
 
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me13.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me13.c
@@ -98,6 +98,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Configure the vssel
     error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
     if (error != E_NO_ERROR) {
@@ -242,4 +248,14 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port)
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask)
 {
     return MXC_GPIO_RevA_SetDriveStrength((mxc_gpio_reva_regs_t *)port, drvstr, mask);
+}
+
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked)
+{
+    MXC_GPIO_Common_SetConfigLock(locked);
+}
+
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void)
+{
+    return MXC_GPIO_Common_GetConfigLock();
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me13.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me13.c
@@ -98,8 +98,7 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me14.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me14.c
@@ -78,6 +78,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Configure the vssel
     error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
     if (error != E_NO_ERROR) {
@@ -235,4 +241,16 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port)
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask)
 {
     return MXC_GPIO_RevA_SetDriveStrength((mxc_gpio_reva_regs_t *)port, drvstr, mask);
+}
+
+/* ************************************************************************** */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked)
+{
+    MXC_GPIO_Common_SetConfigLock(locked);
+}
+
+/* ************************************************************************** */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void)
+{
+    return MXC_GPIO_Common_GetConfigLock();
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me14.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me14.c
@@ -78,8 +78,7 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me15.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me15.c
@@ -73,8 +73,7 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me15.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me15.c
@@ -73,6 +73,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Configure alternate function
     error = MXC_GPIO_RevA_SetAF((mxc_gpio_reva_regs_t *)gpio, cfg->func, cfg->mask);
 
@@ -196,4 +202,14 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port)
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask)
 {
     return MXC_GPIO_RevA_SetDriveStrength((mxc_gpio_reva_regs_t *)port, drvstr, mask);
+}
+
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked)
+{
+    MXC_GPIO_Common_SetConfigLock(locked);
+}
+
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void)
+{
+    return MXC_GPIO_Common_GetConfigLock();
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me16.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me16.c
@@ -75,8 +75,7 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me16.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me16.c
@@ -75,6 +75,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Configure alternate function
     error = MXC_GPIO_RevA_SetAF((mxc_gpio_reva_regs_t *)gpio, cfg->func, cfg->mask);
     if (error != E_NO_ERROR) {
@@ -197,4 +203,14 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port)
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask)
 {
     return MXC_GPIO_RevA_SetDriveStrength((mxc_gpio_reva_regs_t *)port, drvstr, mask);
+}
+
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked)
+{
+    MXC_GPIO_Common_SetConfigLock(locked);
+}
+
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void)
+{
+    return MXC_GPIO_Common_GetConfigLock();
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me17.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me17.c
@@ -109,8 +109,7 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 
     MXC_GPIO_Init(1 << port);
 
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me17.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me17.c
@@ -109,6 +109,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 
     MXC_GPIO_Init(1 << port);
 
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Configure the vssel
     error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
     if (error != E_NO_ERROR) {
@@ -412,4 +418,16 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port)
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask)
 {
     return MXC_GPIO_RevA_SetDriveStrength((mxc_gpio_reva_regs_t *)port, drvstr, mask);
+}
+
+/* ************************************************************************** */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked)
+{
+    MXC_GPIO_Common_SetConfigLock(locked);
+}
+
+/* ************************************************************************** */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void)
+{
+    return MXC_GPIO_Common_GetConfigLock();
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
@@ -138,6 +138,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     // Initialize callback function pointers
     MXC_GPIO_Init(1 << port);
 
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Configure the vssel
     if (port < 4) {
         error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
@@ -442,4 +448,16 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port)
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask)
 {
     return MXC_GPIO_RevA_SetDriveStrength((mxc_gpio_reva_regs_t *)port, drvstr, mask);
+}
+
+/* ************************************************************************** */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked)
+{
+    MXC_GPIO_Common_SetConfigLock(locked);
+}
+
+/* ************************************************************************** */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void)
+{
+    return MXC_GPIO_Common_GetConfigLock();
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
@@ -138,8 +138,7 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     // Initialize callback function pointers
     MXC_GPIO_Init(1 << port);
 
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me20.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me20.c
@@ -81,6 +81,13 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     port = MXC_GPIO_GET_IDX(cfg->port);
 
     if (cfg->port == MXC_GPIO3) {
+    
+        if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+        {
+            // Configuration is locked.  Ignore any attempts to change it.
+            return E_NO_ERROR;
+        }
+
         if (cfg->mask & MXC_GPIO_PIN_0) {
             switch (cfg->func) {
             case MXC_GPIO_FUNC_IN:
@@ -140,6 +147,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
         return E_NO_ERROR;
     } else {
         MXC_GPIO_Init(1 << port);
+    }
+
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
     }
 
     // Configure the vssel
@@ -367,4 +380,16 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port)
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask)
 {
     return MXC_GPIO_RevA_SetDriveStrength((mxc_gpio_reva_regs_t *)port, drvstr, mask);
+}
+
+/* ************************************************************************** */
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked)
+{
+    MXC_GPIO_Common_SetConfigLock(locked);
+}
+
+/* ************************************************************************** */
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void)
+{
+    return MXC_GPIO_Common_GetConfigLock();
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me20.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me20.c
@@ -81,9 +81,7 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     port = MXC_GPIO_GET_IDX(cfg->port);
 
     if (cfg->port == MXC_GPIO3) {
-    
-        if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-        {
+        if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
             // Configuration is locked.  Ignore any attempts to change it.
             return E_NO_ERROR;
         }
@@ -149,8 +147,7 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
         MXC_GPIO_Init(1 << port);
     }
 
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me21.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me21.c
@@ -76,6 +76,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     port = MXC_GPIO_GET_IDX(cfg->port);
     MXC_GPIO_Init(1 << port);
 
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Configure alternate function
     error = MXC_GPIO_RevA_SetAF((mxc_gpio_reva_regs_t *)gpio, cfg->func, cfg->mask);
     if (error != E_NO_ERROR) {
@@ -198,4 +204,14 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port)
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask)
 {
     return MXC_GPIO_RevA_SetDriveStrength((mxc_gpio_reva_regs_t *)port, drvstr, mask);
+}
+
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked)
+{
+    MXC_GPIO_Common_SetConfigLock(locked);
+}
+
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void)
+{
+    return MXC_GPIO_Common_GetConfigLock();
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me21.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me21.c
@@ -76,8 +76,7 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     port = MXC_GPIO_GET_IDX(cfg->port);
     MXC_GPIO_Init(1 << port);
 
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me55.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me55.c
@@ -76,8 +76,7 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me55.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me55.c
@@ -76,6 +76,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Configure the vssel
     error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
     if (error != E_NO_ERROR) {
@@ -220,4 +226,14 @@ uint32_t MXC_GPIO_GetWakeEn(mxc_gpio_regs_t *port)
 int MXC_GPIO_SetDriveStrength(mxc_gpio_regs_t *port, mxc_gpio_drvstr_t drvstr, uint32_t mask)
 {
     return MXC_GPIO_RevA_SetDriveStrength((mxc_gpio_reva_regs_t *)port, drvstr, mask);
+}
+
+void MXC_GPIO_SetConfigLock(mxc_gpio_config_lock_t locked)
+{
+    MXC_GPIO_Common_SetConfigLock(locked);
+}
+
+mxc_gpio_config_lock_t MXC_GPIO_GetConfigLock(void)
+{
+    return MXC_GPIO_Common_GetConfigLock();
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_reva.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_reva.c
@@ -121,6 +121,12 @@ uint32_t MXC_GPIO_RevA_GetFlags(mxc_gpio_reva_regs_t *port)
 
 int MXC_GPIO_RevA_SetVSSEL(mxc_gpio_reva_regs_t *port, mxc_gpio_vssel_t vssel, uint32_t mask)
 {
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Configure the vssel
     switch (vssel) {
     case MXC_GPIO_VSSEL_VDDIO:
@@ -140,6 +146,12 @@ int MXC_GPIO_RevA_SetVSSEL(mxc_gpio_reva_regs_t *port, mxc_gpio_vssel_t vssel, u
 
 int MXC_GPIO_RevA_SetAF(mxc_gpio_reva_regs_t *port, mxc_gpio_func_t func, uint32_t mask)
 {
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     //This is required for new devices going forward.
     port->inen |= mask;
 
@@ -226,6 +238,12 @@ uint32_t MXC_GPIO_RevA_GetWakeEn(mxc_gpio_reva_regs_t *port)
 int MXC_GPIO_RevA_SetDriveStrength(mxc_gpio_reva_regs_t *port, mxc_gpio_drvstr_t drvstr,
                                    uint32_t mask)
 {
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Configure the drive strength.
     switch (drvstr) {
     case MXC_GPIO_DRVSTR_0:

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_reva.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_reva.c
@@ -121,8 +121,7 @@ uint32_t MXC_GPIO_RevA_GetFlags(mxc_gpio_reva_regs_t *port)
 
 int MXC_GPIO_RevA_SetVSSEL(mxc_gpio_reva_regs_t *port, mxc_gpio_vssel_t vssel, uint32_t mask)
 {
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }
@@ -146,8 +145,7 @@ int MXC_GPIO_RevA_SetVSSEL(mxc_gpio_reva_regs_t *port, mxc_gpio_vssel_t vssel, u
 
 int MXC_GPIO_RevA_SetAF(mxc_gpio_reva_regs_t *port, mxc_gpio_func_t func, uint32_t mask)
 {
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }
@@ -238,8 +236,7 @@ uint32_t MXC_GPIO_RevA_GetWakeEn(mxc_gpio_reva_regs_t *port)
 int MXC_GPIO_RevA_SetDriveStrength(mxc_gpio_reva_regs_t *port, mxc_gpio_drvstr_t drvstr,
                                    uint32_t mask)
 {
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_revb.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_revb.c
@@ -31,8 +31,7 @@ int MXC_GPIO_RevB_Config(const mxc_gpio_cfg_t *cfg, uint8_t psMask)
 {
     mxc_gpio_regs_t *gpio = cfg->port;
 
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }
@@ -204,8 +203,7 @@ uint32_t MXC_GPIO_RevB_GetFlags(mxc_gpio_regs_t *port)
 
 int MXC_GPIO_RevB_SetVSSEL(mxc_gpio_regs_t *port, mxc_gpio_vssel_t vssel, uint32_t mask)
 {
-    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
-    {
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
         // Configuration is locked.  Ignore any attempts to change it.
         return E_NO_ERROR;
     }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_revb.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_revb.c
@@ -31,6 +31,12 @@ int MXC_GPIO_RevB_Config(const mxc_gpio_cfg_t *cfg, uint8_t psMask)
 {
     mxc_gpio_regs_t *gpio = cfg->port;
 
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Set the GPIO type
     switch (cfg->func) {
     case MXC_GPIO_FUNC_IN:
@@ -198,6 +204,12 @@ uint32_t MXC_GPIO_RevB_GetFlags(mxc_gpio_regs_t *port)
 
 int MXC_GPIO_RevB_SetVSSEL(mxc_gpio_regs_t *port, mxc_gpio_vssel_t vssel, uint32_t mask)
 {
+    if(MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED)
+    {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
     // Configure the vssel
     switch (vssel) {
     case MXC_GPIO_VSSEL_VDDIO:


### PR DESCRIPTION
## Add PinMux Tool Support

### Description

Tools like a PinMux Configuration tool need a single entry point or function for configuring all the necessary pins.  The current paradigm in the peripheral drivers is to initialize any pins associated with a particular peripheral at the time the peripheral's initialization function is called.  This could override any settings previously set by the PinMux tool.  This PR addresses this problem in the following way:

* Add a global variable to allow locking the pin cofiguration state (Alternate function selection, input/output mode, pull strength/direction selection, voltage level selection, and drive strength).  Default state of this variable is UNLOCKED.
* Add MXC_GPIO_Set/GetConfigLock() functions to read and modify this variable.
* Add code to the MXC_GPIO_Config function that checks the global variable to see if it should actually perform the configuration.  If the configuration is LOCKED, the function simply returns E_NO_ERROR.
* Implement a weak function (called PinInit) that is called as part of SystemInit just prior to Board_Init that does nothing.  The PinMux tool can then output code that overrides this function.  The new code would initialize all pins to their appropriate settings and call MXC_GPIO_SetConfigLock(LOCKED) prior to exiting.

### Advantages
* Backwards compatible with any existing customer code.  Anyone that hasn’t used the PinMux tool’s code will notice no difference.
* Only requires changing the GPIO_Config and SystemInit functions.  No need to touch the Init function of all the peripherals.  (Although, we should update the function documentation of each to describe which parameters, e.g. mapping, are ignored when the GPIO configuration is locked).
* Code still has the option of reconfiguring pins after the PinMux code is run.  They just need to unlock the gpio config before attempting to do so.  This doesn’t happen frequently, but there are times when customers need to switch between two configurations.
### Disadvantages
* Some function parameters in the periph’s init functions will be ignored.  This could look a bit clunky to users.
