### PR TITLE
fix(Tools): Update Keil support for ECC enabled versions of the MAX32675

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Source/system_max32675.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Source/system_max32675.c
@@ -166,6 +166,12 @@ __weak void SystemInit(void)
 
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO1);
+	
+	/* Various revisions of the MAX32675 have different startup frequencies. 
+	   Calling SystemCoreClockUpdate will examine the part's registers to 
+	   determine the correct initial value for the SystemCoreClock variable.
+	 */
+	SystemCoreClockUpdate();
 
     PinInit();
     Board_Init();

--- a/Tools/Keil/MAX32675.sct
+++ b/Tools/Keil/MAX32675.sct
@@ -1,0 +1,23 @@
+LR_IROM1 0x10000000 0x60000
+{
+  ER_IROM1 0x10000000 0x60000
+  {
+    *.o (RESET, +First)
+    *(InRoot$$Sections)
+    .ANY (+RO)
+    .ANY (+XO)
+  }
+  
+  PAD_IROM1 +0 ALIGN 16 EMPTY 0
+  {
+    ; This empty region forces the previous region to 
+    ;  always be a multiple of 16 bytes.  This is 
+    ;  necessary for devices where flash ECC is enabled.
+  }
+
+  RW_IRAM1 0x20000000 0x00028000  
+  {
+    .ANY (+RW +ZI)
+  }
+}
+

--- a/Tools/Keil/project_wizard/README.md
+++ b/Tools/Keil/project_wizard/README.md
@@ -23,7 +23,7 @@ To properly setup your project using the Project Wizard App, follow these steps:
     - `Pack Installer` menu location: ![Pack Installer Location](https://github.com/analogdevicesinc/msdk/blob/feat/keil_project_wizard/Tools/Keil/project_wizard/docs/pack_installer_location.png)
 5. Find `Maxim` -> `MAX32675 Family` and select the `MAX32675`.
 6. Open the `Packs` Tab (usually on the right half column) and expand `Device Specific`.
-7. Install the `Maxim::MAX32675` v1.3.0 pack file.
+7. Install the `Maxim::MAX32675` v1.3.1 pack file.
 8. Close Keil.
 9. Run the Project Wizard App located in the cloned MSDK repository - located in `msdk/Tools/Keil/project_wizard/project_wizard.exe`.
 10. Fill in desired project settings in the opened GUI.
@@ -41,13 +41,16 @@ To properly setup your project using the Project Wizard App, follow these steps:
     - Press `ALT+F7` for macro shortcut to `Options for Target...`. 
 14. In the `Target` Tab -> `Code Generation` section -> `ARM Compiler` options, select `Use default compiler version 6`.
 15. In the `C/C++ (AC6)` Tab -> `Language / COde Generation` section -> `Language C:` options, select `c99`.
-16. In the `Debug` Tab -> Top right corner, select the `CMSIS-DAP Debugger` or the board's supported debugger adapter.
+16. In the `Linker` Tab, uncheck `Use Memory Layout from Target Dialog`.
+17. Use the browse button (`...`) next to the `Scatter File` text box to select the `MAX32675.sct` file located in the `Tools/Keil/` folder of the MSDK repository you cloned in step #2.
+18. In the `Debug` Tab -> Top right corner, select the `CMSIS-DAP Debugger` or the board's supported debugger adapter.
     - (Optional) Press the `Run to main()` checkbox right underneath the debugger adapter selector.
-17. In the `Utilities` Tab, press the `Settings` button in the `Configure Flash Menu Command` section. A `Target Driver Setup` window should open.
-18. In the `Flash Download` Tab, click the `Erase Full Chip` option in the `Download Function` section.
-19. In the `Debug` Tab, within the sections `Debug` -> `Connect & Reset Options`, select the `Reset:` option to `VECTRESET`.
-20. Press `OK` to save everything.
-21. Build and load the project. Enjoy!
+19. In the `Utilities` Tab, press the `Settings` button in the `Configure Flash Menu Command` section. A `Target Driver Setup` window should open.
+20. In the `Flash Download` Tab, click the `Erase Full Chip` option in the `Download Function` section.
+21. In the `RAM for Algorithm`, set the `Size` field to `0x3000`.
+22. In the `Debug` Tab, within the sections `Debug` -> `Connect & Reset Options`, select the `Reset:` option to `VECTRESET`.
+23. Press `OK` to save everything.
+24. Build and load the project. Enjoy!
 
 ### Support
 


### PR DESCRIPTION
## Update Keil support for ECC enabled versions of the MAX32675

### This PR addresses issues with downloading code to the latest version of the MAX32675 which has flash ECC enabled by default.  These changes were made:

* A linker file (*.sct) to be used with MAX32675 projects was added that forces the binary to be an even multiple of 16 bytes.
* The flash algorithm used by Keil (*.FLM) was modified to load in chunks equal to the size of one flash page (0x2000).
* The instructions for setting up a Keil project were updated to add the selection of the new linker file and to adjust the working space size for the flash algorithm.

