### PR TITLE
fix(PeriphDrivers): Fix UART DMA Callbacks for UART1+

### DIFF
--- a/Libraries/PeriphDrivers/Source/UART/uart_reva.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_reva.c
@@ -53,12 +53,10 @@ typedef struct {
 
 uart_reva_req_state_t states[MXC_UART_INSTANCES];
 
-#define DEFAULT_UART_REVA_REQ_STATE {\
-        .tx_req = NULL,\
-        .rx_req = NULL,\
-        .channelTx = -1,\
-        .channelRx = -1,\
-        .auto_dma_handlers = false\
+#define DEFAULT_UART_REVA_REQ_STATE                                       \
+    {                                                                     \
+        .tx_req = NULL, .rx_req = NULL, .channelTx = -1, .channelRx = -1, \
+        .auto_dma_handlers = false                                        \
     }
 
 bool g_is_state_initialized = false;

--- a/Libraries/PeriphDrivers/Source/UART/uart_reva.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_reva.c
@@ -64,7 +64,7 @@ bool g_is_state_initialized = false;
 /* **** Function Prototypes **** */
 
 /* Internal function for initializing the internal state array. */
-inline void MXC_UART_RevB_Init_State(void)
+void MXC_UART_RevB_Init_State(void)
 {
     uart_reva_req_state_t default_state = DEFAULT_UART_REVA_REQ_STATE;
     for (int i = 0; i < MXC_UART_INSTANCES; i++) {

--- a/Libraries/PeriphDrivers/Source/UART/uart_reva.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_reva.c
@@ -50,6 +50,7 @@ typedef struct {
     bool auto_dma_handlers;
 } uart_reva_req_state_t;
 
+// clang-format off
 uart_reva_req_state_t states[MXC_UART_INSTANCES] = {
     [0 ... MXC_UART_INSTANCES - 1] = {
         .tx_req = NULL,
@@ -59,6 +60,7 @@ uart_reva_req_state_t states[MXC_UART_INSTANCES] = {
         .auto_dma_handlers = false
     }
 };
+// clang-format on
 
 /* **** Function Prototypes **** */
 

--- a/Libraries/PeriphDrivers/Source/UART/uart_reva.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_reva.c
@@ -19,7 +19,6 @@
  ******************************************************************************/
 
 #include <stdio.h>
-#include <stdbool.h>
 #include "mxc_device.h"
 #include "mxc_assert.h"
 #include "uart.h"

--- a/Libraries/PeriphDrivers/Source/UART/uart_reva.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_reva.c
@@ -19,6 +19,7 @@
  ******************************************************************************/
 
 #include <stdio.h>
+#include <stdbool.h>
 #include "mxc_device.h"
 #include "mxc_assert.h"
 #include "uart.h"
@@ -52,7 +53,27 @@ typedef struct {
 
 uart_reva_req_state_t states[MXC_UART_INSTANCES];
 
+#define DEFAULT_UART_REVA_REQ_STATE {\
+        .tx_req = NULL,\
+        .rx_req = NULL,\
+        .channelTx = -1,\
+        .channelRx = -1,\
+        .auto_dma_handlers = false\
+    }
+
+bool g_is_state_initialized = false;
+
 /* **** Function Prototypes **** */
+
+/* Internal function for initializing the internal state array. */
+inline void MXC_UART_RevB_Init_State(void)
+{
+    uart_reva_req_state_t default_state = DEFAULT_UART_REVA_REQ_STATE;
+    for (int i = 0; i < MXC_UART_INSTANCES; i++) {
+        states[i] = default_state;
+    }
+    g_is_state_initialized = true;
+}
 
 /* ************************************************************************* */
 /* Control/Configuration functions                                           */
@@ -62,6 +83,14 @@ int MXC_UART_RevA_Init(mxc_uart_reva_regs_t *uart, unsigned int baud)
     int err;
 
     MXC_ASSERT(MXC_UART_GET_IDX((mxc_uart_regs_t *)uart) >= 0)
+
+    if (!g_is_state_initialized) {
+        // The first UART instance that is initialized will be responsible for
+        // initializing the global state array.  We do this at run-time because
+        // the number of UART instances is variable, which makes it difficult for
+        // the pre-processor to handle at compile-time.
+        MXC_UART_RevB_Init_State();
+    }
 
     // Initialize UART
     // Set RX threshold to 1 byte

--- a/Libraries/PeriphDrivers/Source/UART/uart_reva.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_reva.c
@@ -51,27 +51,17 @@ typedef struct {
     bool auto_dma_handlers;
 } uart_reva_req_state_t;
 
-uart_reva_req_state_t states[MXC_UART_INSTANCES];
-
-#define DEFAULT_UART_REVA_REQ_STATE                                       \
-    {                                                                     \
-        .tx_req = NULL, .rx_req = NULL, .channelTx = -1, .channelRx = -1, \
-        .auto_dma_handlers = false                                        \
+uart_reva_req_state_t states[MXC_UART_INSTANCES] = {
+    [0 ... MXC_UART_INSTANCES - 1] = {
+        .tx_req = NULL,
+        .rx_req = NULL,
+        .channelTx = -1,
+        .channelRx = -1,
+        .auto_dma_handlers = false
     }
-
-bool g_is_state_initialized = false;
+};
 
 /* **** Function Prototypes **** */
-
-/* Internal function for initializing the internal state array. */
-void MXC_UART_RevB_Init_State(void)
-{
-    uart_reva_req_state_t default_state = DEFAULT_UART_REVA_REQ_STATE;
-    for (int i = 0; i < MXC_UART_INSTANCES; i++) {
-        states[i] = default_state;
-    }
-    g_is_state_initialized = true;
-}
 
 /* ************************************************************************* */
 /* Control/Configuration functions                                           */
@@ -81,14 +71,6 @@ int MXC_UART_RevA_Init(mxc_uart_reva_regs_t *uart, unsigned int baud)
     int err;
 
     MXC_ASSERT(MXC_UART_GET_IDX((mxc_uart_regs_t *)uart) >= 0)
-
-    if (!g_is_state_initialized) {
-        // The first UART instance that is initialized will be responsible for
-        // initializing the global state array.  We do this at run-time because
-        // the number of UART instances is variable, which makes it difficult for
-        // the pre-processor to handle at compile-time.
-        MXC_UART_RevB_Init_State();
-    }
 
     // Initialize UART
     // Set RX threshold to 1 byte

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -51,12 +51,10 @@ typedef struct {
 
 uart_revb_req_state_t states[MXC_UART_INSTANCES];
 
-#define DEFAULT_UART_REVB_REQ_STATE {\
-        .tx_req = NULL,\
-        .rx_req = NULL,\
-        .channelTx = -1,\
-        .channelRx = -1,\
-        .auto_dma_handlers = false\
+#define DEFAULT_UART_REVB_REQ_STATE                                       \
+    {                                                                     \
+        .tx_req = NULL, .rx_req = NULL, .channelTx = -1, .channelRx = -1, \
+        .auto_dma_handlers = false                                        \
     }
 
 bool g_is_state_initialized = false;

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -48,6 +48,7 @@ typedef struct {
     bool auto_dma_handlers;
 } uart_revb_req_state_t;
 
+// clang-format off
 uart_revb_req_state_t states[MXC_UART_INSTANCES] = {
     [0 ... MXC_UART_INSTANCES - 1] = {
         .tx_req = NULL,
@@ -57,6 +58,7 @@ uart_revb_req_state_t states[MXC_UART_INSTANCES] = {
         .auto_dma_handlers = false
     }
 };
+// clang-format on
 
 /* **** Function Prototypes **** */
 

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -49,27 +49,17 @@ typedef struct {
     bool auto_dma_handlers;
 } uart_revb_req_state_t;
 
-uart_revb_req_state_t states[MXC_UART_INSTANCES];
-
-#define DEFAULT_UART_REVB_REQ_STATE                                       \
-    {                                                                     \
-        .tx_req = NULL, .rx_req = NULL, .channelTx = -1, .channelRx = -1, \
-        .auto_dma_handlers = false                                        \
+uart_revb_req_state_t states[MXC_UART_INSTANCES] = {
+    [0 ... MXC_UART_INSTANCES - 1] = {
+        .tx_req = NULL,
+        .rx_req = NULL,
+        .channelTx = -1,
+        .channelRx = -1,
+        .auto_dma_handlers = false
     }
-
-bool g_is_state_initialized = false;
+};
 
 /* **** Function Prototypes **** */
-
-/* Internal function for initializing the internal state array. */
-void MXC_UART_RevB_Init_State(void)
-{
-    uart_revb_req_state_t default_state = DEFAULT_UART_REVB_REQ_STATE;
-    for (int i = 0; i < MXC_UART_INSTANCES; i++) {
-        states[i] = default_state;
-    }
-    g_is_state_initialized = true;
-}
 
 /* ************************************************************************* */
 /* Control/Configuration functions                                           */
@@ -79,14 +69,6 @@ int MXC_UART_RevB_Init(mxc_uart_revb_regs_t *uart, unsigned int baud, mxc_uart_r
     int err;
 
     MXC_ASSERT(MXC_UART_GET_IDX((mxc_uart_regs_t *)uart) >= 0)
-
-    if (!g_is_state_initialized) {
-        // The first UART instance that is initialized will be responsible for
-        // initializing the global state array.  We do this at run-time because
-        // the number of UART instances is variable, which makes it difficult for
-        // the pre-processor to handle at compile-time.
-        MXC_UART_RevB_Init_State();
-    }
 
     // Initialize UART
     if ((err = MXC_UART_SetRXThreshold((mxc_uart_regs_t *)uart, 1)) !=

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -20,7 +20,6 @@
  ******************************************************************************/
 
 #include <stdio.h>
-#include <stdbool.h>
 #include "mxc_device.h"
 #include "mxc_assert.h"
 #include "uart.h"

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -62,7 +62,7 @@ bool g_is_state_initialized = false;
 /* **** Function Prototypes **** */
 
 /* Internal function for initializing the internal state array. */
-inline void MXC_UART_RevB_Init_State(void)
+void MXC_UART_RevB_Init_State(void)
 {
     uart_revb_req_state_t default_state = DEFAULT_UART_REVB_REQ_STATE;
     for (int i = 0; i < MXC_UART_INSTANCES; i++) {


### PR DESCRIPTION
### Description

Fixes #998 

As the internal UART state struct was only initialized per _used_ UART instance, attempting to use UART1 (or higher) with DMA auto handlers would never trigger the user's callback functions.  The state struct's DMA channel values would be initialized to 0 instead of -1, which the drivers would assume was a valid channel acquisition.

This PR fixes the bug by initializing the UART state array correctly.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
