### PR TITLE
fix(PeriphDrivers): Fix MAX32675 timer warning

### DIFF
--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me16.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me16.c
@@ -25,14 +25,14 @@
 
 int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
 {
-    uint8_t tmr_id;
+    uint8_t tmr_id = MXC_TMR_GET_IDX(tmr);
     uint8_t clockSource = MXC_TMR_CLK0;
 
     if (cfg == NULL) {
         return E_NULL_PTR;
     }
 
-    MXC_ASSERT((tmr_id = MXC_TMR_GET_IDX(tmr)) >= 0);
+    MXC_ASSERT(tmr_id >= 0);
 
     switch (cfg->clock) {
     case MXC_TMR_EXT_CLK:


### PR DESCRIPTION
### Description

This PR fix timer warning.
Incase of assert disabled below warning occur during build.
![image](https://github.com/analogdevicesinc/msdk/assets/46590392/a7b7e08b-1d53-403e-8951-fa381d2e348c)

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
