### PR TITLE
feat(CMSIS): Update MAX32657 CMSIS with TrustZone support

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
@@ -278,6 +278,8 @@ ifeq "$(MSECURITY_MODE)" "SECURE"
 # https://developer.arm.com/documentation/ecm0359818/latest
 PROJ_CFLAGS += -mcmse
 
+PROJ_AFLAGS += -DIS_SECURE_ENVRIONMENT
+
 # Tell the linker we are building a secure project.  This defines the "SECURE_LINK" symbol which the
 # linker uses to set the secure FLASH/SRAM memory address ranges.
 PROJ_LDFLAGS += -Xlinker --defsym=SECURE_LINK=1

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.h
@@ -625,7 +625,11 @@ We may want to handle GET_IRQ better...
 /******************************************************************************/
 /*                                                                        DMA */
 #define MXC_DMA_CHANNELS (4)
+#if IS_SECURE_ENVIRONMENT
 #define MXC_DMA_INSTANCES (2)
+#else
+#define MXC_DMA_INSTANCES (1)
+#endif
 
 /* Non-secure Mapping */
 #define MXC_BASE_DMA0_NS ((uint32_t)0x40028000UL)

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.h
@@ -59,7 +59,6 @@
 /* ================================================================================ */
 
 // clang-format off
-// TODO(ME30): Secure vs non-secure interrupt vectors
 typedef enum {
     NonMaskableInt_IRQn = -14,
     HardFault_IRQn = -13,
@@ -97,10 +96,10 @@ typedef enum {
     DMA0_CH1_IRQn,          /* 0x21  0x0084  33: DMA0 Channel 1 */
     DMA0_CH2_IRQn,          /* 0x22  0x0088  34: DMA0 Channel 2 */
     DMA0_CH3_IRQn,          /* 0x23  0x008C  35: DMA0 Channel 3 */
-    DMA1_CH0_IRQn,          /* 0x24  0x0090  36: DMA1 Channel 0 */
-    DMA1_CH1_IRQn,          /* 0x25  0x0094  37: DMA1 Channel 1 */
-    DMA1_CH2_IRQn,          /* 0x26  0x0098  38: DMA1 CHannel 2 */
-    DMA1_CH3_IRQn,          /* 0x27  0x009C  39: DMA1 Channel 3 */
+    DMA1_CH0_IRQn,          /* 0x24  0x0090  36: DMA1 Channel 0 (Secure) */
+    DMA1_CH1_IRQn,          /* 0x25  0x0094  37: DMA1 Channel 1 (Secure) */
+    DMA1_CH2_IRQn,          /* 0x26  0x0098  38: DMA1 CHannel 2 (Secure) */
+    DMA1_CH3_IRQn,          /* 0x27  0x009C  39: DMA1 Channel 3 (Secure) */
     WUT0_IRQn,              /* 0x28  0x00A0  40: Wakeup Timer 0 */
     WUT1_IRQn,              /* 0x29  0x00A4  41: Wakeup TImer 1 */
     GPIOWAKE_IRQn,          /* 0x2A  0x00A8  42: GPIO Wakeup */
@@ -233,8 +232,10 @@ typedef enum {
 #define MXC_SIR_S ((mxc_sir_regs_t *)MXC_BASE_SIR_S)
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_SIR MXC_BASE_SIR_S
 #define MXC_SIR MXC_SIR_S
 #else
+#define MXC_BASE_SIR MXC_BASE_SIR_NS
 #define MXC_SIR MXC_SIR_NS
 #endif
 
@@ -250,8 +251,10 @@ typedef enum {
 #define MXC_FCR_S ((mxc_fcr_regs_t *)MXC_BASE_FCR_S)
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_FCR MXC_BASE_FCR_S
 #define MXC_FCR MXC_FCR_S
 #else
+#define MXC_BASE_FCR MXC_BASE_FCR_NS
 #define MXC_FCR MXC_FCR_NS
 #endif
 
@@ -268,8 +271,10 @@ typedef enum {
 #define MXC_WDT_S ((mxc_wdt_regs_t *)MXC_BASE_WDT_S)
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_WDT MXC_BASE_WDT_S
 #define MXC_WDT MXC_WDT_S
 #else
+#define MXC_BASE_WDT MXC_BASE_WDT_NS
 #define MXC_WDT MXC_WDT_NS
 #endif
 
@@ -278,15 +283,17 @@ typedef enum {
 
 /* Non-secure Mapping */
 #define MXC_BASE_SVM_NS ((uint32_t)0x40004800UL)
-#define MXC_SVM_NS //TODO(ME30): Add SVM controller registers.
+#define MXC_SVM_NS 0 //TODO(ME30): Add SVM controller registers.
 
 /* Secure Mapping */
 #define MXC_BASE_SVM_S ((uint32_t)0x50004800UL)
-#define MXC_SVM_S //TODO(ME30): Add SVM controller registers.
+#define MXC_SVM_S 0 //TODO(ME30): Add SVM controller registers.
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_SVM MXC_BASE_SVM_S
 #define MXC_SVM MXC_SVM_S //TODO(ME30): Add SVM controller registers
 #else
+#define MXC_BASE_SVM MXC_BASE_SVM_NS
 #define MXC_SVM MXC_SVM_NS
 #endif
 
@@ -295,15 +302,17 @@ typedef enum {
 
 /* Non-secure Mapping */
 #define MXC_BASE_BOOST_NS ((uint32_t)0x40004C00UL)
-#define MXC_BOOST_NS //TODO(ME30): Add Boost controller registers.
+#define MXC_BOOST_NS 0 //TODO(ME30): Add Boost controller registers.
 
 /* Secure Mapping */
 #define MXC_BASE_BOOST_S ((uint32_t)0x50004C00UL)
-#define MXC_BOOST_S //TODO(ME30): Add Boost controller registers.
+#define MXC_BOOST_S 0 //TODO(ME30): Add Boost controller registers.
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_BOOST MXC_BASE_BOOST_S
 #define MXC_BOOST MXC_BOOST_S
 #else
+#define MXC_BASE_BOOST MXC_BASE_BOOST_NS
 #define MXC_BOOST MXC_BOOST_NS
 #endif
 
@@ -319,8 +328,10 @@ typedef enum {
 #define MXC_TRIMSIR_S ((mxc_trimsir_regs_t *)MXC_BASE_TRIMSIR_S)
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_TRIMSIR MXC_BASE_TRIMSIR_S
 #define MXC_TRIMSIR MXC_TRIMSIR_S
 #else
+#define MXC_BASE_TRIMSIR MXC_BASE_TRIMSIR_NS
 #define MXC_TRIMSIR MXC_TRIMSIR_NS
 #endif
 
@@ -336,8 +347,10 @@ typedef enum {
 #define MXC_RTC_S ((mxc_rtc_regs_t *)MXC_BASE_RTC_S)
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_RTC MXC_BASE_RTC_S
 #define MXC_RTC MXC_RTC_S
 #else
+#define MXC_BASE_RTC MXC_BASE_RTC_NS
 #define MXC_RTC MXC_RTC_NS
 #endif
 
@@ -358,10 +371,14 @@ typedef enum {
 #define MXC_WUT1_S ((mxc_wut_regs_t *)MXC_BASE_WUT1_S)
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_WUT0 MXC_BASE_WUT0_S
 #define MXC_WUT0 MXC_WUT0_S
+#define MXC_BASE_WUT1 MXC_BASE_WUT1_S
 #define MXC_WUT1 MXC_WUT1_S
 #else
+#define MXC_BASE_WUT0 MXC_BASE_WUT0_NS
 #define MXC_WUT0 MXC_WUT0_NS
+#define MXC_BASE_WUT1 MXC_BASE_WUT1_NS
 #define MXC_WUT1 MXC_WUT1_NS
 #endif
 
@@ -377,8 +394,10 @@ typedef enum {
 #define MXC_PWRSEQ_S ((mxc_pwrseq_regs_t *)MXC_BASE_PWRSEQ_S)
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_PWRSEQ MXC_BASE_PWRSEQ_S
 #define MXC_PWRSEQ MXC_PWRSEQ_S
 #else
+#define MXC_BASE_PWRSEQ MXC_BASE_PWRSEQ_NS
 #define MXC_PWRSEQ MXC_PWRSEQ_NS
 #endif
 
@@ -394,9 +413,11 @@ typedef enum {
 #define MXC_MCR_S ((mxc_mcr_regs_t *)MXC_BASE_MCR_S)
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_MCR MXC_BASE_MCR_S
 #define MXC_MCR MXC_MCR_S
 #else
-#define MXC_MCR MXC_MCR_S
+#define MXC_BASE_MCR MXC_BASE_MCR_NS
+#define MXC_MCR MXC_MCR_NS
 #endif
 
 /******************************************************************************/
@@ -411,8 +432,10 @@ typedef enum {
 #define MXC_AES_S ((mxc_aes_regs_t *)MXC_BASE_AES_NS)
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_AES MXC_BASE_AES_S
 #define MXC_AES MXC_AES_S
 #else
+#define MXC_BASE_AES MXC_BASE_AES_NS
 #define MXC_AES MXC_AES_NS
 #endif
 
@@ -428,8 +451,10 @@ typedef enum {
 #define MXC_AESKEYS_S ((mxc_aeskeys_regs_t *)MXC_BASE_AESKEYS_S)
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_AESKEYS MXC_BASE_AESKEYS_S
 #define MXC_AESKEYS MXC_AESKEYS_S
 #else
+#define MXC_BASE_AESKEYS MXC_BASE_AESKEYS_NS
 #define MXC_AESKEYS MXC_AESKEYS_NS
 #endif
 
@@ -452,8 +477,10 @@ typedef enum {
 #define MXC_BASE_GPIO0 MXC_BASE_GPIO0_S
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_GPIO0 MXC_BASE_GPIO0_S
 #define MXC_GPIO0 MXC_GPIO0_S
 #else
+#define MXC_BASE_GPIO0 MXC_BASE_GPIO0_NS
 #define MXC_GPIO0 MXC_GPIO0_NS
 #endif
 
@@ -480,8 +507,10 @@ We may want to handle GET_IRQ better...
 #define MXC_CRC_S ((mxc_crc_regs_t *)MXC_BASE_CRC_S)
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_CRC MXC_BASE_CRC_S
 #define MXC_CRC MXC_CRC_S
 #else
+#define MXC_BASE_CRC MXC_BASE_CRC_NS
 #define MXC_CRC MXC_CRC_NS
 #endif
 
@@ -506,24 +535,6 @@ We may want to handle GET_IRQ better...
 #define MXC_TMR4_NS ((mxc_tmr_regs_t *)MXC_BASE_TMR4_NS)
 #define MXC_BASE_TMR5_NS ((uint32_t)0x40081000UL)
 #define MXC_TMR5_NS ((mxc_tmr_regs_t *)MXC_BASE_TMR5_NS)
-
-#define MXC_TMR_NS_GET_BASE(i)     \
-    ((i) == 0 ? MXC_BASE_TMR0_NS : \
-     (i) == 1 ? MXC_BASE_TMR1_NS : \
-     (i) == 2 ? MXC_BASE_TMR2_NS : \
-     (i) == 3 ? MXC_BASE_TMR3_NS : \
-     (i) == 4 ? MXC_BASE_TMR4_NS : \
-     (i) == 5 ? MXC_BASE_TMR5_NS : \
-                0)
-
-#define MXC_TMR_NS_GET_TMR(i) \
-    ((i) == 0 ? MXC_TMR0_NS : \
-     (i) == 1 ? MXC_TMR1_NS : \
-     (i) == 2 ? MXC_TMR2_NS : \
-     (i) == 3 ? MXC_TMR3_NS : \
-     (i) == 4 ? MXC_TMR4_NS : \
-     (i) == 5 ? MXC_TMR5_NS : \
-                0)
 
 /* Secure Mapping */
 #define MXC_BASE_TMR0_S ((uint32_t)0x50010000UL)
@@ -555,7 +566,16 @@ We may want to handle GET_IRQ better...
 #define MXC_TMR5 MXC_TMR5_NS
 #endif
 
-#define MXC_TMR_S_GET_TMR(i) \
+#define MXC_TMR_GET_BASE(i)     \
+    ((i) == 0 ? MXC_BASE_TMR0 : \
+     (i) == 1 ? MXC_BASE_TMR1 : \
+     (i) == 2 ? MXC_BASE_TMR2 : \
+     (i) == 3 ? MXC_BASE_TMR3 : \
+     (i) == 4 ? MXC_BASE_TMR4 : \
+     (i) == 5 ? MXC_BASE_TMR5 : \
+                0)
+
+#define MXC_TMR_GET_TMR(i) \
     ((i) == 0 ? MXC_TMR0 : \
      (i) == 1 ? MXC_TMR1 : \
      (i) == 2 ? MXC_TMR2 : \
@@ -574,19 +594,13 @@ We may want to handle GET_IRQ better...
                            0)
 
 #define MXC_TMR_GET_IDX(p) \
-    ((p) == MXC_TMR0_NS ? 0 : \
-     (p) == MXC_TMR1_NS ? 1 : \
-     (p) == MXC_TMR2_NS ? 2 : \
-     (p) == MXC_TMR3_NS ? 3 : \
-     (p) == MXC_TMR4_NS ? 4 : \
-     (p) == MXC_TMR5_NS ? 5 : \
-     (p) == MXC_TMR0_S ? 0 : \
-     (p) == MXC_TMR1_S ? 1 : \
-     (p) == MXC_TMR2_S ? 2 : \
-     (p) == MXC_TMR3_S ? 3 : \
-     (p) == MXC_TMR4_S ? 4 : \
-     (p) == MXC_TMR5_S ? 5 : \
-                       -1)
+    ((p) == MXC_TMR0 ? 0 : \
+     (p) == MXC_TMR1 ? 1 : \
+     (p) == MXC_TMR2 ? 2 : \
+     (p) == MXC_TMR3 ? 3 : \
+     (p) == MXC_TMR4 ? 4 : \
+     (p) == MXC_TMR5 ? 5 : \
+                      -1)
 
 /******************************************************************************/
 /*                                                                        I3C */
@@ -601,52 +615,70 @@ We may want to handle GET_IRQ better...
 #define MXC_I3C_S ((mxc_i2c_regs_t *)MXC_BASE_I3C_S)
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_I3C MXC_BASE_I3C_S
 #define MXC_I3C MXC_I3C_S
 #else
+#define MXC_BASE_I3C MXC_BASE_I3C_NS
 #define MXC_I3C MXC_I3C_NS
 #endif
 
 /******************************************************************************/
 /*                                                                        DMA */
 #define MXC_DMA_CHANNELS (4)
-#define MXC_DMA_INSTANCES (1)
-// ^ Note: We have 2 DMA instances in hardware, but they are secure vs non-secure
-// instances.  Therefore we treat the part as if there is only 1.
+#define MXC_DMA_INSTANCES (2)
 
 /* Non-secure Mapping */
 #define MXC_BASE_DMA0_NS ((uint32_t)0x40028000UL)
 #define MXC_DMA0_NS ((mxc_dma_regs_t *)MXC_BASE_DMA0_NS)
-/* DMA0 instance only for secure mode. */
 
 /* Secure Mapping */
 // TODO(ME30): Is there actuall a secure mapping for DMA0?
+//             -Yes, DMA0 can be accessed from secure mode. Realizing this, I think
+//                  we would still have to define two DMA instances.
+//                  DMA0 can only access the non-secure mappings of the peripherals,
+//                  but DMA0 can be accessed in both Non-secure and Secure code.
+//                  DMA1 can access both secure and non-secure addresses of the peripherals,
+//                  but DMA1 can Only be accessed in Secure code.
 #define MXC_BASE_DMA0_S ((uint32_t)0x50028000UL)
 #define MXC_DMA0_S ((mxc_dma_regs_t *)MXC_BASE_DMA0_S)
 #define MXC_BASE_DMA1_S ((uint32_t)0x50035000UL)
 #define MXC_DMA1_S ((mxc_dma_regs_t *)MXC_BASE_DMA1_S)
 
+#if IS_SECURE_ENVIRONMENT
 #define MXC_BASE_DMA0 MXC_BASE_DMA0_S
-#define MXC_DMA0 MXC_DMA0_NS
+#define MXC_DMA0 MXC_DMA0_S
 #define MXC_BASE_DMA1 MXC_BASE_DMA1_S
 #define MXC_DMA1 MXC_DMA1_S
 
-#if IS_SECURE_ENVIRONMENT
-#define MXC_DMA MXC_DMA1_S
-#define MXC_DMA_CH_GET_IRQ(i)             \
+#define MXC_DMA1_CH_GET_IRQ(i)                \
     ((IRQn_Type)(((i) == 0) ? DMA1_CH0_IRQn : \
                  ((i) == 1) ? DMA1_CH1_IRQn : \
                  ((i) == 2) ? DMA1_CH2_IRQn : \
                  ((i) == 3) ? DMA1_CH3_IRQn : \
                               0))
+
 #else
-#define MXC_DMA MXC_DMA0_NS
-#define MXC_DMA_CH_GET_IRQ(i)             \
+#define MXC_BASE_DMA0 MXC_BASE_DMA0_NS
+#define MXC_DMA0 MXC_DMA0_NS
+// TODO(DMA1): Not entirely show how to handle access to MXC_DMA1 in non-secure mode.
+//                  A secure fault should be generated when non-secure code accesses
+//                  a secure peripheral mapping, so it'd be best if a build time warning
+//                  or error was thrown when using MXCX_DMA1.
+#define MXC_BASE_DMA1 0
+#define MXC_DMA1 0
+
+/* DMA1 IRQs not usable in Non-Secure state. */
+#define MXC_DMA1_CH_GET_IRQ(i) ((IRQn_Type)(0))
+#endif // IS_SECURE_ENVIRONMENT
+
+#define MXC_DMA_GET_BASE(i) ((i) == MXC_BASE_DMA0 ? 0 : (p) == MXC_BASE_DMA1 ? 1 : -1)
+
+#define MXC_DMA0_CH_GET_IRQ(i)                \
     ((IRQn_Type)(((i) == 0) ? DMA0_CH0_IRQn : \
                  ((i) == 1) ? DMA0_CH1_IRQn : \
                  ((i) == 2) ? DMA0_CH2_IRQn : \
                  ((i) == 3) ? DMA0_CH3_IRQn : \
                               0))
-#endif
 
 #define MXC_DMA_GET_IDX(p) ((p) == MXC_DMA0 ? 0 : (p) == MXC_DMA1 ? 1 : -1)
 
@@ -662,19 +694,22 @@ We may want to handle GET_IRQ better...
 #define MXC_BASE_FLC_S MXC_BASE_FLC
 #define MXC_FLC_S MXC_FLC
 
-// Note(JC): There is only one flash instance, but some bottom-level RevX implementations
-// depend on MXC_FLC_GET_FLC
-#define MXC_FLC_GET_FLC(i) MXC_FLC
+/**
+ *  There is only one flash instance, but some bottom-level RevX implementations
+ *  depend on MXC_FLC_GET_FLC
+ */
+#define MXC_FLC_GET_FLC(i) ((i) == 0 ? MXC_FLC : 0)
 
 /******************************************************************************/
 /*                                                  Internal Cache Controller */
 #define MXC_ICC_INSTANCES (1)
 
 /* Secure Mapping Only */
-#define MXC_BASE_ICC_S ((uint32_t)0x5002A000UL)
+#define MXC_BASE_ICC ((uint32_t)0x5002A000UL)
 #define MXC_ICC ((mxc_icc_regs_t *)MXC_BASE_ICC_S)
 
 /* Added for consistency and explicitness */
+#define MXC_BASE_ICC_S MXC_BASE_ICC
 #define MXC_ICC_S MXC_ICC
 
 /******************************************************************************/
@@ -691,11 +726,14 @@ We may want to handle GET_IRQ better...
 #define MXC_UART_S ((mxc_uart_regs_t *)MXC_BASE_UART_S)
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_UART MXC_BASE_UART_S
 #define MXC_UART MXC_UART_S
 #else
+#define MXC_BASE_UART MXC_BASE_UART_NS
 #define MXC_UART MXC_UART_NS
 #endif
 
+#define MXC_UART_GET_BASE(i) ((i) == 0 ? MXC_BASE_UART : 0)
 #define MXC_UART_GET_UART(i) ((i) == 0 ? MXC_UART : 0)
 #define MXC_UART_GET_IRQ(i) (IRQn_Type)((i) == 0 ? UART0_IRQn : 0)
 #define MXC_UART_GET_IDX(p) ((p) == MXC_UART_NS ? 0 : (p) == MXC_UART_S ? 0 : -1)
@@ -710,19 +748,19 @@ We may want to handle GET_IRQ better...
 #define MXC_BASE_SPI_NS ((uint32_t)0x40046000UL)
 #define MXC_SPI_NS ((mxc_spi_regs_t *)MXC_BASE_SPI_NS)
 
-#define MXC_SPI_NS_GET_BASE(i) ((i) == 0 ? MXC_BASE_SPI_NS : 0)
-#define MXC_SPI_NS_GET_SPI(i) ((i) == 0 ? MXC_SPI_NS : 0)
-
 /* Secure Mapping */
 #define MXC_BASE_SPI_S ((uint32_t)0x50046000UL)
 #define MXC_SPI_S ((mxc_spi_regs_t *)MXC_BASE_SPI_S)
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_SPI MXC_BASE_SPI_S
 #define MXC_SPI MXC_SPI_S
 #else
+#define MXC_BASE_SPI MXC_BASE_SPI_S
 #define MXC_SPI MXC_SPI_NS
 #endif
 
+#define MXC_SPI_GET_BASE(i) ((i) == 0 ? MXC_BASE_SPI : 0)
 #define MXC_SPI_GET_SPI(i) ((i) == 0 ? MXC_SPI : 0)
 #define MXC_SPI_GET_IRQ(i) (IRQn_Type)((i) == 0 ? SPI_IRQn : 0)
 #define MXC_SPI_GET_IDX(p) ((p) == MXC_SPI_NS ? 0 : (p) == MXC_SPI_S ? 0 : -1)
@@ -739,8 +777,10 @@ We may want to handle GET_IRQ better...
 #define MXC_TRNG_S ((mxc_trng_regs_t *)MXC_BASE_TRNG_S)
 
 #if IS_SECURE_ENVIRONMENT
+#define MXC_BASE_TRNG MXC_BASE_TRNG_S
 #define MXC_TRNG MXC_TRNG_S
 #else
+#define MXC_BASE_TRNG MXC_BASE_TRNG_NS
 #define MXC_TRNG MXC_TRNG_NS
 #endif
 
@@ -758,8 +798,10 @@ We may want to handle GET_IRQ better...
 
 #if IS_SECURE_ENVIRONMENT
 // TODO(ME30): Does this have registers?
+#define MXC_BASE_BTLE MXC_BASE_BTLE_S
 #define MXC_BTLE MXC_BTLE_S
 #else
+#define MXC_BASE_BTLE MXC_BASE_BTLE_NS
 #define MXC_BTLE MXC_BTLE_NS
 #endif
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.h
@@ -474,8 +474,6 @@ typedef enum {
 #define MXC_BASE_GPIO0_S ((uint32_t)0x50008000UL)
 #define MXC_GPIO0_S ((mxc_gpio_regs_t *)MXC_BASE_GPIO0_S)
 
-#define MXC_BASE_GPIO0 MXC_BASE_GPIO0_S
-
 #if IS_SECURE_ENVIRONMENT
 #define MXC_BASE_GPIO0 MXC_BASE_GPIO0_S
 #define MXC_GPIO0 MXC_GPIO0_S
@@ -654,11 +652,15 @@ We may want to handle GET_IRQ better...
 #define MXC_BASE_DMA1 MXC_BASE_DMA1_S
 #define MXC_DMA1 MXC_DMA1_S
 
-#define MXC_DMA1_CH_GET_IRQ(i)                \
-    ((IRQn_Type)(((i) == 0) ? DMA1_CH0_IRQn : \
-                 ((i) == 1) ? DMA1_CH1_IRQn : \
-                 ((i) == 2) ? DMA1_CH2_IRQn : \
-                 ((i) == 3) ? DMA1_CH3_IRQn : \
+#define MXC_DMA_CH_GET_IRQ(p, i)                \
+    ((IRQn_Type)(((p) == MXC_DMA0 && (i) == 0) ? DMA0_CH0_IRQn : \
+                 ((p) == MXC_DMA0 && (i) == 1) ? DMA0_CH1_IRQn : \
+                 ((p) == MXC_DMA0 && (i) == 2) ? DMA0_CH2_IRQn : \
+                 ((p) == MXC_DMA0 && (i) == 3) ? DMA0_CH3_IRQn : \
+                 ((p) == MXC_DMA1 && (i) == 0) ? DMA1_CH0_IRQn : \
+                 ((p) == MXC_DMA1 && (i) == 1) ? DMA1_CH1_IRQn : \
+                 ((p) == MXC_DMA1 && (i) == 2) ? DMA1_CH2_IRQn : \
+                 ((p) == MXC_DMA1 && (i) == 3) ? DMA1_CH3_IRQn : \
                               0))
 
 #else
@@ -672,17 +674,15 @@ We may want to handle GET_IRQ better...
 #define MXC_DMA1 0
 
 /* DMA1 IRQs not usable in Non-Secure state. */
-#define MXC_DMA1_CH_GET_IRQ(i) ((IRQn_Type)(0))
+#define MXC_DMA_CH_GET_IRQ(p, i)                \
+    ((IRQn_Type)(((p) == MXC_DMA0 && (i) == 0) ? DMA0_CH0_IRQn : \
+                 ((p) == MXC_DMA0 && (i) == 1) ? DMA0_CH1_IRQn : \
+                 ((p) == MXC_DMA0 && (i) == 2) ? DMA0_CH2_IRQn : \
+                 ((p) == MXC_DMA0 && (i) == 3) ? DMA0_CH3_IRQn : \
+                              0))
 #endif // IS_SECURE_ENVIRONMENT
 
 #define MXC_DMA_GET_BASE(i) ((i) == MXC_BASE_DMA0 ? 0 : (p) == MXC_BASE_DMA1 ? 1 : -1)
-
-#define MXC_DMA0_CH_GET_IRQ(i)                \
-    ((IRQn_Type)(((i) == 0) ? DMA0_CH0_IRQn : \
-                 ((i) == 1) ? DMA0_CH1_IRQn : \
-                 ((i) == 2) ? DMA0_CH2_IRQn : \
-                 ((i) == 3) ? DMA0_CH3_IRQn : \
-                              0))
 
 #define MXC_DMA_GET_IDX(p) ((p) == MXC_DMA0 ? 0 : (p) == MXC_DMA1 ? 1 : -1)
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/partition_max32657.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/partition_max32657.h
@@ -1,0 +1,1281 @@
+/*************************************************************************//**
+ * @file     partition_max32657.h
+ * @brief    CMSIS-Core(M) Device Initial Setup for Secure/Non-Secure Zones for
+ *           MAX32657
+ * @version  V1.0.0
+ * @date     20. January 2021
+ *****************************************************************************/
+/*
+ * Copyright (c) 2009-2021 Arm Limited. All rights reserved.
+ *
+ * Portions Copyright (C) 2024 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LIBRARIES_CMSIS_DEVICE_MAXIM_MAX32657_SOURCE_GCC_PARTITION_MAX32657_H_
+#define LIBRARIES_CMSIS_DEVICE_MAXIM_MAX32657_SOURCE_GCC_PARTITION_MAX32657_H_
+
+#include "max32657.h"
+
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> -----------------
+*/
+
+/*
+// <Initialize Security Attribution Unit (SAU) CTRL register
+*/
+#define SAU_INIT_CTRL          1
+
+/*
+//   <q> Enable SAU
+//   <i> Value for SAU->CTRL register bit ENABLE
+*/
+#define SAU_INIT_CTRL_ENABLE   1
+
+/*
+//   <o> When SAU is disabled
+//     <0=> All Memory is Secure
+//     <1=> All Memory is Non-Secure
+//   <i> Value for SAU->CTRL register bit ALLNS
+//   <i> When all Memory is Non-Secure (ALLNS is 1), IDAU can override memory map configuration.
+*/
+#define SAU_INIT_CTRL_ALLNS  0
+
+/*
+// </e>
+*/
+
+/*
+// <h>Initialize Security Attribution Unit (SAU) Address Regions
+// <i>SAU configuration specifies regions to be one of:
+// <i> - Secure and Non-Secure Callable
+// <i> - Non-Secure
+// <i>Note: All memory regions not configured by SAU are Secure
+*/
+/**
+ *  Analog Devices, Inc.
+ *  4 Regions in the MAX32657.
+ *    1. Non-Secure Flash
+ *    2. Secure Flash
+ *    3. Non-Secure SRAM
+ *    4. Secure SRAM
+ * 
+ *  Finer grain control can be achieved depending on the application
+ *  requirements by updating the regions of this file.
+ *  
+ *    Non-Secure Flash (1MB)  0x0100.0000 - 0x010F.FFFF
+ *    Non-Secure SRAM0 (32kB) 0x2000.0000 - 0x2000.7FFF
+ *    Non-Secure SRAM1 (32kB) 0x2000.8000 - 0x2000.FFFF
+ *    Non-Secure SRAM2 (64kB) 0x2001.0000 - 0x2001.FFFF
+ *    Non-Secure SRAM3 (64kB) 0x2002.0000 - 0x2002.FFFF
+ *    Non-Secure SRAM4 (64kB) 0x2003.0000 - 0x2003.FFFF
+ * 
+ *    Secure Flash (1MB)      0x1100.0000 - 0x110F.FFFF
+ *    Secure SRAM0 (32kB)     0x3000.0000 - 0x3000.7FFF
+ *    Secure SRAM1 (32kB)     0x3000.8000 - 0x3000.FFFF
+ *    Secure SRAM2 (64kB)     0x3001.0000 - 0x3001.FFFF
+ *    Secure SRAM3 (64kB)     0x3002.0000 - 0x3002.FFFF
+ *    Secure SRAM4 (64kB)     0x3003.0000 - 0x3003.FFFF
+ */
+#define SAU_REGIONS_MAX     4                 /* Max. number of SAU regions */
+
+/*
+//   <e>Initialize SAU Region 0 (Secure Flash)
+//   <i> Setup SAU Region 0 memory attributes   
+*/
+#define SAU_INIT_REGION0    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START0     0x11000000      /* start address of SAU region 0 (ROM) */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END0       0x110FFFFF      /* end address of SAU region 0 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC0       1
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 1 (Non-Secure Flash)
+//   <i> Setup SAU Region 1 memory attributes
+*/
+#define SAU_INIT_REGION1    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START1     0x01000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END1       0x010FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC1       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 2 (Secure SRAM)
+//   <i> Setup SAU Region 2 memory attributes
+*/
+#define SAU_INIT_REGION2    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START2     0x30000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END2       0x3003FFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC2       1
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 3 (Non-Secure SRAM)
+//   <i> Setup SAU Region 3 memory attributes
+*/
+#define SAU_INIT_REGION3    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START3     0x20000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END3       0x2003FFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC3       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 4
+//   <i> Setup SAU Region 4 memory attributes
+*/
+#define SAU_INIT_REGION4    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START4     0x00000000      /* start address of SAU region 4 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END4       0x00000000      /* end address of SAU region 4 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC4       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 5
+//   <i> Setup SAU Region 5 memory attributes
+*/
+#define SAU_INIT_REGION5    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START5     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END5       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC5       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 6
+//   <i> Setup SAU Region 6 memory attributes
+*/
+#define SAU_INIT_REGION6    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START6     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END6       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC6       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 7
+//   <i> Setup SAU Region 7 memory attributes
+*/
+#define SAU_INIT_REGION7    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START7     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END7       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC7       0
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+/*
+// <e>Setup behaviour of Sleep and Exception Handling
+*/
+#define SCB_CSR_AIRCR_INIT  1
+
+/*
+//   <o> Deep Sleep can be enabled by
+//     <0=>Secure and Non-Secure state
+//     <1=>Secure state only
+//   <i> Value for SCB->CSR register bit DEEPSLEEPS
+*/
+#define SCB_CSR_DEEPSLEEPS_VAL  1
+
+/*
+//   <o>System reset request accessible from
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for SCB->AIRCR register bit SYSRESETREQS
+*/
+#define SCB_AIRCR_SYSRESETREQS_VAL  1
+
+/*
+//   <o>Priority of Non-Secure exceptions is
+//     <0=> Not altered
+//     <1=> Lowered to 0x80-0xFF
+//   <i> Value for SCB->AIRCR register bit PRIS
+*/
+#define SCB_AIRCR_PRIS_VAL      1
+
+/*
+//   <o>BusFault, HardFault, and NMI target
+//     <0=> Secure state
+//     <1=> Non-Secure state
+//   <i> Value for SCB->AIRCR register bit BFHFNMINS
+*/
+#define SCB_AIRCR_BFHFNMINS_VAL 0
+
+/*
+// </e>
+*/
+
+/*
+// <e>Setup behaviour of Floating Point and Vector Unit (FPU/MVE)
+*/
+#define TZ_FPU_NS_USAGE 1
+
+/*
+// <o>Floating Point and Vector Unit usage
+//     <0=> Secure state only
+//     <3=> Secure and Non-Secure state
+//   <i> Value for SCB->NSACR register bits CP10, CP11
+*/
+#define SCB_NSACR_CP10_11_VAL       3
+
+/*
+// <o>Treat floating-point registers as Secure
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit TS
+*/
+#define FPU_FPCCR_TS_VAL            0
+
+/*
+// <o>Clear on return (CLRONRET) accessibility
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for FPU->FPCCR register bit CLRONRETS
+*/
+#define FPU_FPCCR_CLRONRETS_VAL     0
+
+/*
+// <o>Clear floating-point caller saved registers on exception return
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit CLRONRET
+*/
+#define FPU_FPCCR_CLRONRET_VAL      1
+
+/*
+// </e>
+*/
+
+/*
+// <h>Setup Interrupt Target
+*/
+
+/*
+//   <e>Initialize ITNS 0 (Interrupts 0..31)
+*/
+#define NVIC_INIT_ITNS0    1
+
+/*
+// Interrupts 0..31
+//   <o.0>  ICE Unlock                      <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Watchdog Timer                  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Real Time Clock                 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  True Random Number Generator    <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Timer 0                         <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Timer 1                         <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Timer 2                         <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Timer 3                         <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Timer 4                         <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Timer 5                         <0=> Secure state <1=> Non-Secure state
+//   <o.10> I3C                             <0=> Secure state <1=> Non-Secure state
+//   <o.11> UART                            <0=> Secure state <1=> Non-Secure state
+//   <o.12> SPI                             <0=> Secure state <1=> Non-Secure state
+//   <o.13> Flash Controller                <0=> Secure state <1=> Non-Secure state
+//   <o.14> GPIO0                           <0=> Secure state <1=> Non-Secure state
+//   <o.15> Reserved (15)                   <0=> Secure state <1=> Non-Secure state
+//   <o.16> DMA0 Channel 0                  <0=> Secure state <1=> Non-Secure state
+//   <o.17> DMA0 Channel 1                  <0=> Secure state <1=> Non-Secure state
+//   <o.18> DMA0 Channel 2                  <0=> Secure state <1=> Non-Secure state
+//   <o.19> DMA0 Channel 3                  <0=> Secure state <1=> Non-Secure state
+//   <o.20> DMA1 Channel 0                  <0=> Secure state <1=> Non-Secure state
+//   <o.21> DMA1 Channel 1                  <0=> Secure state <1=> Non-Secure state
+//   <o.22> DMA1 Channel 2                  <0=> Secure state <1=> Non-Secure state
+//   <o.23> DMA1 Channel 3                  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Wakeup Timer 0                  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Wakeup Timer 1                  <0=> Secure state <1=> Non-Secure state
+//   <o.26> GPIO Wake                       <0=> Secure state <1=> Non-Secure state
+//   <o.27> CRC                             <0=> Secure state <1=> Non-Secure state
+//   <o.28> AES                             <0=> Secure state <1=> Non-Secure state
+//   <o.29> ERFO Ready                      <0=> Secure state <1=> Non-Secure state
+//   <o.30> Boost Controller                <0=> Secure state <1=> Non-Secure state
+//   <o.31> ECC                             <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS0_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 1 (Interrupts 32..63)
+*/
+#define NVIC_INIT_ITNS1    1
+
+/*
+// Interrupts 32..63
+//   <o.0>  BTLE XXXX0                      <0=> Secure state <1=> Non-Secure state
+//   <o.1>  BTLE XXXX1                      <0=> Secure state <1=> Non-Secure state
+//   <o.2>  BTLE XXXX2                      <0=> Secure state <1=> Non-Secure state
+//   <o.3>  BTLE XXXX3                      <0=> Secure state <1=> Non-Secure state
+//   <o.4>  BTLE XXXX4                      <0=> Secure state <1=> Non-Secure state
+//   <o.5>  BTLE XXXX5                      <0=> Secure state <1=> Non-Secure state
+//   <o.6>  BTLE XXXX6                      <0=> Secure state <1=> Non-Secure state
+//   <o.7>  BTLE XXXX7                      <0=> Secure state <1=> Non-Secure state
+//   <o.8>  BTLE XXXX8                      <0=> Secure state <1=> Non-Secure state
+//   <o.9>  BTLE XXXX9                      <0=> Secure state <1=> Non-Secure state
+//   <o.10> BTLE XXXXA                      <0=> Secure state <1=> Non-Secure state
+//   <o.11> BTLE XXXXB                      <0=> Secure state <1=> Non-Secure state
+//   <o.12> BTLE XXXXC                      <0=> Secure state <1=> Non-Secure state
+//   <o.13> BTLE XXXXD                      <0=> Secure state <1=> Non-Secure state
+//   <o.14> BTLE XXXXE                      <0=> Secure state <1=> Non-Secure state
+//   <o.15> Reserved (47)                   <0=> Secure state <1=> Non-Secure state
+//   <o.16> MPC Combined (Secure)           <0=> Secure state <1=> Non-Secure state
+//   <o.17> PPC Combined (Secure)           <0=> Secure state <1=> Non-Secure state
+//   <o.18> Reserved (50)                   <0=> Secure state <1=> Non-Secure state
+//   <o.19> Reserved (51)                   <0=> Secure state <1=> Non-Secure state
+//   <o.20> Reserved (52)                   <0=> Secure state <1=> Non-Secure state
+//   <o.21> Reserved (53)                   <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS1_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 2 (Interrupts 64..95)
+*/
+#define NVIC_INIT_ITNS2    0
+
+/*
+// Interrupts 64..95
+//   <o.0>  Interrupt 64  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 65  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 66  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 67  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 68  <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 69  <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 70  <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 71  <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 72  <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 73  <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 74  <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 75  <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 76  <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 77  <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 78  <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 79  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 80  <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 81  <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 82  <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 83  <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 84  <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 85  <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 86  <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 87  <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 88  <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 89  <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 90  <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 91  <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 92  <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 93  <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 94  <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 95  <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS2_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 3 (Interrupts 96..127)
+*/
+#define NVIC_INIT_ITNS3    0
+
+/*
+// Interrupts 96..127
+//   <o.0>  Interrupt 96  <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 97  <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 98  <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 99  <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 100 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 101 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 102 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 103 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 104 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 105 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 106 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 107 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 108 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 109 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 110 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 111 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 112 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 113 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 114 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 115 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 116 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 117 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 118 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 119 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 120 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 121 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 122 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 123 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 124 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 125 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 126 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 127 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS3_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 4 (Interrupts 128..159)
+*/
+#define NVIC_INIT_ITNS4    0
+
+/*
+// Interrupts 128..159
+//   <o.0>  Interrupt 128 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 129 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 130 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 131 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 132 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 133 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 134 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 135 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 136 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 137 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 138 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 139 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 140 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 141 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 142 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 143 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 144 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 145 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 146 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 147 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 148 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 149 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 150 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 151 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 152 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 153 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 154 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 155 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 156 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 157 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 158 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 159 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS4_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 5 (Interrupts 160..191)
+*/
+#define NVIC_INIT_ITNS5    0
+
+/*
+// Interrupts 160..191
+//   <o.0>  Interrupt 160 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 161 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 162 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 163 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 164 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 165 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 166 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 167 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 168 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 169 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 170 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 171 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 172 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 173 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 174 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 175 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 176 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 177 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 178 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 179 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 180 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 181 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 182 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 183 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 184 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 185 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 186 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 187 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 188 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 189 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 190 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 191 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS5_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 6 (Interrupts 192..223)
+*/
+#define NVIC_INIT_ITNS6    0
+
+/*
+// Interrupts 192..223
+//   <o.0>  Interrupt 192 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 193 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 194 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 195 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 196 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 197 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 198 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 199 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 200 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 201 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 202 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 203 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 204 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 205 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 206 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 207 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 208 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 209 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 210 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 211 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 212 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 213 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 214 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 215 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 216 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 217 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 218 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 219 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 220 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 221 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 222 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 223 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS6_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 7 (Interrupts 224..255)
+*/
+#define NVIC_INIT_ITNS7    0
+
+/*
+// Interrupts 224..255
+//   <o.0>  Interrupt 224 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 225 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 226 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 227 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 228 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 229 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 230 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 231 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 232 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 233 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 234 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 235 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 236 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 237 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 238 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 239 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 240 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 241 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 242 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 243 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 244 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 245 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 246 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 247 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 248 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 249 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 250 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 251 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 252 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 253 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 254 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 255 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS7_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 8 (Interrupts 256..287)
+*/
+#define NVIC_INIT_ITNS8    0
+
+/*
+// Interrupts 256..287
+//   <o.0>  Interrupt 256 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 257 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 258 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 259 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 260 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 261 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 262 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 263 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 264 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 265 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 266 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 267 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 268 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 269 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 270 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 271 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 272 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 273 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 274 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 275 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 276 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 277 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 278 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 279 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 280 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 281 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 282 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 283 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 284 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 285 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 286 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 287 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS8_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 9 (Interrupts 288..319)
+*/
+#define NVIC_INIT_ITNS9    0
+
+/*
+// Interrupts 288..319
+//   <o.0>  Interrupt 288 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 289 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 290 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 291 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 292 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 293 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 294 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 295 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 296 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 297 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 298 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 299 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 300 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 301 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 302 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 303 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 304 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 305 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 306 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 307 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 308 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 309 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 310 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 311 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 312 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 313 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 314 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 315 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 316 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 317 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 318 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 319 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS9_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 10 (Interrupts 320..351)
+*/
+#define NVIC_INIT_ITNS10   0
+
+/*
+// Interrupts 320..351
+//   <o.0>  Interrupt 320 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 321 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 322 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 323 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 324 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 325 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 326 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 327 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 328 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 329 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 330 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 331 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 332 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 333 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 334 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 335 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 336 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 337 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 338 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 339 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 340 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 341 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 342 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 343 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 344 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 345 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 346 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 347 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 348 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 349 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 350 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 351 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS10_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 11 (Interrupts 352..383)
+*/
+#define NVIC_INIT_ITNS11   0
+
+/*
+// Interrupts 352..383
+//   <o.0>  Interrupt 352 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 353 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 354 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 355 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 356 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 357 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 358 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 359 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 360 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 361 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 362 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 363 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 364 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 365 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 366 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 367 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 368 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 369 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 370 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 371 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 372 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 373 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 374 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 375 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 376 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 377 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 378 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 379 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 380 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 381 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 382 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 383 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS11_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 12 (Interrupts 384..415)
+*/
+#define NVIC_INIT_ITNS12   0
+
+/*
+// Interrupts 384..415
+//   <o.0>  Interrupt 384 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 385 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 386 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 387 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 388 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 389 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 390 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 391 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 392 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 393 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 394 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 395 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 396 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 397 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 398 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 399 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 400 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 401 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 402 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 403 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 404 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 405 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 406 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 407 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 408 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 409 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 410 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 411 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 412 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 413 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 414 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 415 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS12_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 13 (Interrupts 416..447)
+*/
+#define NVIC_INIT_ITNS13   0
+
+/*
+// Interrupts 416..447
+//   <o.0>  Interrupt 416 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 417 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 418 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 419 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 420 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 421 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 422 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 423 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 424 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 425 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 426 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 427 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 428 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 429 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 430 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 431 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 432 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 433 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 434 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 435 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 436 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 437 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 438 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 439 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 440 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 441 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 442 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 443 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 444 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 445 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 446 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 447 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS13_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 14 (Interrupts 448..479)
+*/
+#define NVIC_INIT_ITNS14   0
+
+/*
+// Interrupts 448..479
+//   <o.0>  Interrupt 448 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 449 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 450 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 451 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 452 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 453 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 454 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 455 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 456 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 457 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 458 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 459 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 460 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 461 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 462 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 463 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 464 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 465 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 466 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 467 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 468 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 469 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 470 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 471 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 472 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 473 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 474 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 475 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 476 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 477 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 478 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 479 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS14_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 15 (Interrupts 480..511)
+*/
+#define NVIC_INIT_ITNS15   0
+
+/*
+// Interrupts 480..511
+//   <o.0>  Interrupt 480 <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Interrupt 481 <0=> Secure state <1=> Non-Secure state
+//   <o.2>  Interrupt 482 <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Interrupt 483 <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Interrupt 484 <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Interrupt 485 <0=> Secure state <1=> Non-Secure state
+//   <o.6>  Interrupt 486 <0=> Secure state <1=> Non-Secure state
+//   <o.7>  Interrupt 487 <0=> Secure state <1=> Non-Secure state
+//   <o.8>  Interrupt 488 <0=> Secure state <1=> Non-Secure state
+//   <o.9>  Interrupt 489 <0=> Secure state <1=> Non-Secure state
+//   <o.10> Interrupt 490 <0=> Secure state <1=> Non-Secure state
+//   <o.11> Interrupt 491 <0=> Secure state <1=> Non-Secure state
+//   <o.12> Interrupt 492 <0=> Secure state <1=> Non-Secure state
+//   <o.13> Interrupt 493 <0=> Secure state <1=> Non-Secure state
+//   <o.14> Interrupt 494 <0=> Secure state <1=> Non-Secure state
+//   <o.15> Interrupt 495 <0=> Secure state <1=> Non-Secure state
+//   <o.16> Interrupt 496 <0=> Secure state <1=> Non-Secure state
+//   <o.17> Interrupt 497 <0=> Secure state <1=> Non-Secure state
+//   <o.18> Interrupt 498 <0=> Secure state <1=> Non-Secure state
+//   <o.19> Interrupt 499 <0=> Secure state <1=> Non-Secure state
+//   <o.20> Interrupt 500 <0=> Secure state <1=> Non-Secure state
+//   <o.21> Interrupt 501 <0=> Secure state <1=> Non-Secure state
+//   <o.22> Interrupt 502 <0=> Secure state <1=> Non-Secure state
+//   <o.23> Interrupt 503 <0=> Secure state <1=> Non-Secure state
+//   <o.24> Interrupt 504 <0=> Secure state <1=> Non-Secure state
+//   <o.25> Interrupt 505 <0=> Secure state <1=> Non-Secure state
+//   <o.26> Interrupt 506 <0=> Secure state <1=> Non-Secure state
+//   <o.27> Interrupt 507 <0=> Secure state <1=> Non-Secure state
+//   <o.28> Interrupt 508 <0=> Secure state <1=> Non-Secure state
+//   <o.29> Interrupt 509 <0=> Secure state <1=> Non-Secure state
+//   <o.30> Interrupt 510 <0=> Secure state <1=> Non-Secure state
+//   <o.31> Interrupt 511 <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS15_VAL     0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+
+
+/*
+    max 128 SAU regions.
+    SAU regions are defined in partition.h
+ */
+
+#define SAU_INIT_REGION(n) \
+    SAU->RNR  =  (n                                     & SAU_RNR_REGION_Msk); \
+    SAU->RBAR =  (SAU_INIT_START##n                     & SAU_RBAR_BADDR_Msk); \
+    SAU->RLAR =  (SAU_INIT_END##n                       & SAU_RLAR_LADDR_Msk) | \
+                ((SAU_INIT_NSC##n << SAU_RLAR_NSC_Pos)  & SAU_RLAR_NSC_Msk)   | 1U
+
+/**
+  \brief   Setup a SAU Region
+  \details Writes the region information contained in SAU_Region to the
+           registers SAU_RNR, SAU_RBAR, and SAU_RLAR
+ */
+__STATIC_INLINE void TZ_SAU_Setup (void)
+{
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+
+  #if defined (SAU_INIT_REGION0) && (SAU_INIT_REGION0 == 1U)
+    SAU_INIT_REGION(0);
+  #endif
+
+  #if defined (SAU_INIT_REGION1) && (SAU_INIT_REGION1 == 1U)
+    SAU_INIT_REGION(1);
+  #endif
+
+  #if defined (SAU_INIT_REGION2) && (SAU_INIT_REGION2 == 1U)
+    SAU_INIT_REGION(2);
+  #endif
+
+  #if defined (SAU_INIT_REGION3) && (SAU_INIT_REGION3 == 1U)
+    SAU_INIT_REGION(3);
+  #endif
+
+  #if defined (SAU_INIT_REGION4) && (SAU_INIT_REGION4 == 1U)
+    SAU_INIT_REGION(4);
+  #endif
+
+  #if defined (SAU_INIT_REGION5) && (SAU_INIT_REGION5 == 1U)
+    SAU_INIT_REGION(5);
+  #endif
+
+  #if defined (SAU_INIT_REGION6) && (SAU_INIT_REGION6 == 1U)
+    SAU_INIT_REGION(6);
+  #endif
+
+  #if defined (SAU_INIT_REGION7) && (SAU_INIT_REGION7 == 1U)
+    SAU_INIT_REGION(7);
+  #endif
+
+  /* repeat this for all possible SAU regions */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+
+  #if defined (SAU_INIT_CTRL) && (SAU_INIT_CTRL == 1U)
+    SAU->CTRL = ((SAU_INIT_CTRL_ENABLE << SAU_CTRL_ENABLE_Pos) & SAU_CTRL_ENABLE_Msk) |
+                ((SAU_INIT_CTRL_ALLNS  << SAU_CTRL_ALLNS_Pos)  & SAU_CTRL_ALLNS_Msk)   ;
+  #endif
+
+  #if defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U)
+    SCB->SCR   = (SCB->SCR   & ~(SCB_SCR_SLEEPDEEPS_Msk    )) |
+                   ((SCB_CSR_DEEPSLEEPS_VAL     << SCB_SCR_SLEEPDEEPS_Pos)     & SCB_SCR_SLEEPDEEPS_Msk);
+
+    SCB->AIRCR = (SCB->AIRCR & ~(SCB_AIRCR_VECTKEY_Msk   | SCB_AIRCR_SYSRESETREQS_Msk |
+                                 SCB_AIRCR_BFHFNMINS_Msk | SCB_AIRCR_PRIS_Msk          ))                    |
+                   ((0x05FAU                    << SCB_AIRCR_VECTKEY_Pos)      & SCB_AIRCR_VECTKEY_Msk)      |
+                   ((SCB_AIRCR_SYSRESETREQS_VAL << SCB_AIRCR_SYSRESETREQS_Pos) & SCB_AIRCR_SYSRESETREQS_Msk) |
+                   ((SCB_AIRCR_PRIS_VAL         << SCB_AIRCR_PRIS_Pos)         & SCB_AIRCR_PRIS_Msk)         |
+                   ((SCB_AIRCR_BFHFNMINS_VAL    << SCB_AIRCR_BFHFNMINS_Pos)    & SCB_AIRCR_BFHFNMINS_Msk);
+  #endif /* defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U) */
+
+  #if (((defined (__FPU_USED) && (__FPU_USED == 1U))              || \
+        (defined (__ARM_FEATURE_MVE) && (__ARM_FEATURE_MVE > 0))) && \
+       (defined (TZ_FPU_NS_USAGE) && (TZ_FPU_NS_USAGE == 1U)))
+
+    SCB->NSACR = (SCB->NSACR & ~(SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk)) |
+                   ((SCB_NSACR_CP10_11_VAL << SCB_NSACR_CP10_Pos) & (SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk));
+
+    FPU->FPCCR = (FPU->FPCCR & ~(FPU_FPCCR_TS_Msk | FPU_FPCCR_CLRONRETS_Msk | FPU_FPCCR_CLRONRET_Msk)) |
+                   ((FPU_FPCCR_TS_VAL        << FPU_FPCCR_TS_Pos       ) & FPU_FPCCR_TS_Msk       ) |
+                   ((FPU_FPCCR_CLRONRETS_VAL << FPU_FPCCR_CLRONRETS_Pos) & FPU_FPCCR_CLRONRETS_Msk) |
+                   ((FPU_FPCCR_CLRONRET_VAL  << FPU_FPCCR_CLRONRET_Pos ) & FPU_FPCCR_CLRONRET_Msk );
+  #endif
+
+  #if defined (NVIC_INIT_ITNS0) && (NVIC_INIT_ITNS0 == 1U)
+    NVIC->ITNS[0] = NVIC_INIT_ITNS0_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS1) && (NVIC_INIT_ITNS1 == 1U)
+    NVIC->ITNS[1] = NVIC_INIT_ITNS1_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS2) && (NVIC_INIT_ITNS2 == 1U)
+    NVIC->ITNS[2] = NVIC_INIT_ITNS2_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS3) && (NVIC_INIT_ITNS3 == 1U)
+    NVIC->ITNS[3] = NVIC_INIT_ITNS3_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS4) && (NVIC_INIT_ITNS4 == 1U)
+    NVIC->ITNS[4] = NVIC_INIT_ITNS4_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS5) && (NVIC_INIT_ITNS5 == 1U)
+    NVIC->ITNS[5] = NVIC_INIT_ITNS5_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS6) && (NVIC_INIT_ITNS6 == 1U)
+    NVIC->ITNS[6] = NVIC_INIT_ITNS6_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS7) && (NVIC_INIT_ITNS7 == 1U)
+    NVIC->ITNS[7] = NVIC_INIT_ITNS7_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS8) && (NVIC_INIT_ITNS8 == 1U)
+    NVIC->ITNS[8] = NVIC_INIT_ITNS8_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS9) && (NVIC_INIT_ITNS9 == 1U)
+    NVIC->ITNS[9] = NVIC_INIT_ITNS9_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS10) && (NVIC_INIT_ITNS10 == 1U)
+    NVIC->ITNS[10] = NVIC_INIT_ITNS10_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS11) && (NVIC_INIT_ITNS11 == 1U)
+    NVIC->ITNS[11] = NVIC_INIT_ITNS11_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS12) && (NVIC_INIT_ITNS12 == 1U)
+    NVIC->ITNS[12] = NVIC_INIT_ITNS12_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS13) && (NVIC_INIT_ITNS13 == 1U)
+    NVIC->ITNS[13] = NVIC_INIT_ITNS13_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS14) && (NVIC_INIT_ITNS14 == 1U)
+    NVIC->ITNS[14] = NVIC_INIT_ITNS14_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS15) && (NVIC_INIT_ITNS15 == 1U)
+    NVIC->ITNS[15] = NVIC_INIT_ITNS15_VAL;
+  #endif
+
+  /* repeat this for all possible ITNS elements */
+
+}
+
+#endif // LIBRARIES_CMSIS_DEVICE_MAXIM_MAX32657_SOURCE_PARTITION_MAX32657_H_

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/partition_max32657.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/partition_max32657.h
@@ -30,6 +30,8 @@
 
 #include "max32657.h"
 
+#if IS_SECURE_ENVIRONMENT
+
 /*
 //-------- <<< Use Configuration Wizard in Context Menu >>> -----------------
 */
@@ -1277,5 +1279,7 @@ __STATIC_INLINE void TZ_SAU_Setup (void)
   /* repeat this for all possible ITNS elements */
 
 }
+
+#endif // IS_SECURE_EVIRONMENT
 
 #endif // LIBRARIES_CMSIS_DEVICE_MAXIM_MAX32657_SOURCE_PARTITION_MAX32657_H_

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Source/GCC/max32657.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Source/GCC/max32657.ld
@@ -36,7 +36,7 @@ SECTIONS {
     {
         _text = .;
         KEEP(*(.isr_vector))
-        EXCLUDE_FILE (*riscv.o) *(.text*)    /* Program code (exclude RISCV code) */
+        *(.text*)    /* Program code */
         *(.rodata*)  /* read-only data: "const" */
 
         KEEP(*(.init))
@@ -61,19 +61,20 @@ SECTIONS {
         _etext = .;
     } > FLASH_S
 
+    /*
+     * Secure Gatway (SG) veneers.
+     *  All SG veneers are placed in the special output section .gnu.sgstubs.
+     */
+    .gnu.sgstubs :
+    {
+        _sg_veneers = .;
+        KEEP(*(.gnu.sgstubs*))
+        _esg_veneers = .;
+    } > FLASH_S
+
     .ARM.extab :
     {
         *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } > FLASH_S
-
-    /* Binary import */
-    .bin_storage :
-    {
-       FILL(0xFF)
-      _bin_start_ = .;
-      KEEP(*(.bin_storage_img))
-      _bin_end_ = .;
-      . = ALIGN(4);
     } > FLASH_S
     
     .rom_code :
@@ -149,17 +150,34 @@ SECTIONS {
         _ebss = ALIGN(., 4);
     } > SRAM_S
 
-    /* Set stack top to end of RAM, and stack limit move down by
-     * size of stack_dummy section */
+    /**
+     *  Stack Seal section is required for secure builds. Stack sealing protects
+     *  secure stack from illegal access by non-secure code.
+     */
+    .stackseal (COPY):
+    {
+        . = ALIGN(8);
+        __StackSeal = .;
+        . = . + 8;
+        . = ALIGN(8);
+    } > SRAM_S
+
+    /**
+     *   Set stack top to end of RAM, and stack limit move down by
+     *      size of stack_dummy section.
+     */
     __StackTop = ORIGIN(SRAM_S) + LENGTH(SRAM_S);
     __StackLimit = __StackTop - SIZEOF(.stack_dummy);
 
-    /* .stack_dummy section doesn't contains any symbols. It is only
-     * used for linker to calculate size of stack sections, and assign
-     * values to stack symbols later */
+    /**
+     *  .stack_dummy section doesn't contains any symbols. It is only
+     *  used for linker to calculate size of stack sections, and assign
+     *  values to stack symbols later.
+     */
     .stack_dummy (COPY):
     {
         *(.stack*)
+        *(.stackseal*)
     } > SRAM_S
 
     .heap (COPY):
@@ -173,5 +191,4 @@ SECTIONS {
 
     /* Check if data + heap + stack exceeds RAM limit */
     ASSERT(__StackLimit >= _ebss, "region RAM overflowed with stack")
-
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Source/GCC/max32657.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Source/GCC/max32657.ld
@@ -185,7 +185,7 @@ SECTIONS {
      */
     .stack_dummy (COPY):
     {
-        *(.stack*)\
+        *(.stack*)
 #if SECURE_LINK
         *(.stackseal*)
 #endif

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Source/GCC/max32657.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Source/GCC/max32657.ld
@@ -70,14 +70,12 @@ SECTIONS {
      * Secure Gatway (SG) veneers.
      *  All SG veneers are placed in the special output section .gnu.sgstubs.
      */
-#if SECURE_LINK
     .gnu.sgstubs :
     {
         _sg_veneers = .;
-        KEEP(*(.gnu.sgstubs*))
+        *(.gnu.sgstubs*)
         _esg_veneers = .;
     } > FLASH
-#endif
 
     .ARM.extab :
     {
@@ -161,7 +159,6 @@ SECTIONS {
      *  Stack Seal section is required for secure builds. Stack sealing protects
      *  secure stack from illegal access by non-secure code.
      */
-#if SECURE_LINK
     .stackseal (COPY):
     {
         . = ALIGN(8);
@@ -169,7 +166,6 @@ SECTIONS {
         . = . + 8;
         . = ALIGN(8);
     } > SRAM
-#endif
 
     /**
      *   Set stack top to end of RAM, and stack limit move down by
@@ -185,10 +181,8 @@ SECTIONS {
      */
     .stack_dummy (COPY):
     {
-        *(.stack*)
-#if SECURE_LINK
+        KEEP(*(.stack*))
         *(.stackseal*)
-#endif
     } > SRAM
 
     .heap (COPY):

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Source/GCC/startup_max32657.S
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Source/GCC/startup_max32657.S
@@ -24,26 +24,31 @@
     .section .stack
     .align 3
 #ifdef __STACK_SIZE
-    .equ    Stack_Size, __STACK_SIZE
+    .equ      Stack_Size, __STACK_SIZE
 #else
     // Default stack size (192KB)
-    .equ    Stack_Size, 0x00030000
+    .equ      Stack_Size, 0x00030000
 #endif
     .globl    __StackTop
     .globl    __StackLimit
+#if IS_SECURE_ENVIRONMENT
+    // __StackSeal defined in linker script
+    .equ      __STACK_SEAL,  __StackSeal
+    .globl    __StackSeal
+#endif
 __StackLimit:
     .space    Stack_Size
-    .size __StackLimit, . - __StackLimit
+    .size     __StackLimit, . - __StackLimit
 __StackTop:
-    .size __StackTop, . - __StackTop
+    .size     __StackTop, . - __StackTop
 
     .section .heap
     .align 3
 #ifdef __HEAP_SIZE
-    .equ    Heap_Size, __HEAP_SIZE
+    .equ      Heap_Size, __HEAP_SIZE
 #else
     // Default heap size (64KB)
-    .equ    Heap_Size, 0x00010000
+    .equ      Heap_Size, 0x00010000
 #endif
     .globl    __HeapBase
     .globl    __HeapLimit
@@ -60,26 +65,84 @@ __HeapLimit:
     .align 9 /* must be aligned to 512 byte boundary. VTOR requirement */
     .globl __isr_vector
 __isr_vector:
-    .long    __StackTop            /* Top of Stack */
-    .long    Reset_Handler         /* Reset Handler */
-    .long    NMI_Handler           /* NMI Handler */
-    .long    HardFault_Handler     /* Hard Fault Handler */
-    .long    MemManage_Handler     /* MPU Fault Handler */
-    .long    BusFault_Handler      /* Bus Fault Handler */
-    .long    UsageFault_Handler    /* Usage Fault Handler */
-    .long    0                     /* Reserved */
-    .long    0                     /* Reserved */
-    .long    0                     /* Reserved */
-    .long    0                     /* Reserved */
-    .long    SVC_Handler           /* SVCall Handler */
-    .long    DebugMon_Handler      /* Debug Monitor Handler */
-    .long    0                     /* Reserved */
-    .long    PendSV_Handler        /* PendSV Handler */
-    .long    SysTick_Handler       /* SysTick Handler */
+    .long    __StackTop                 /* Top of Stack */
+    .long    Reset_Handler              /* Reset Handler */
+    .long    NMI_Handler                /* NMI Handler */
+    .long    HardFault_Handler          /* Hard Fault Handler */
+    .long    MemManage_Handler          /* MPU Fault Handler */
+    .long    BusFault_Handler           /* Bus Fault Handler */
+    .long    UsageFault_Handler         /* Usage Fault Handler */
+    .long    0                          /* Reserved */
+    .long    0                          /* Reserved */
+    .long    0                          /* Reserved */
+    .long    0                          /* Reserved */
+    .long    SVC_Handler                /* SVCall Handler */
+    .long    DebugMon_Handler           /* Debug Monitor Handler */
+    .long    0                          /* Reserved */
+    .long    PendSV_Handler             /* PendSV Handler */
+    .long    SysTick_Handler            /* SysTick Handler */
 
-    // TODO: Add device-specific interrupt table
-    /* Device-specific Interrupts */
-    .long RSVXX_IRQHandler             /* 0xXX  0xXXXX  XX: Reserved */
+    /* Device-specific Interrupts                                           */
+    /*                                     CMSIS Interrupt Number           */
+    /*                                     ||||          ||                 */
+    /*                                     ||||  Offset  ||                 */
+    /*                                     vvvv  vvvvvv  vv                 */
+
+    .long ICE_IRQHandler                /* 0x10  0x0040  16: ICE Unlock */
+    .long WDT_IRQHandler                /* 0x11  0x0044  17: Watchdog Timer */
+    .long RTC_IRQHandler                /* 0x12  0x0048  18: RTC */
+    .long TRNG_IRQHandler               /* 0x13  0x004C  19: True Random Number Generator */
+    .long TMR0_IRQHandler               /* 0x14  0x0050  20: Timer 0 */
+    .long TMR1_IRQHandler               /* 0x15  0x0054  21: Timer 1 */
+    .long TMR2_IRQHandler               /* 0x16  0x0058  22: Timer 2 */
+    .long TMR3_IRQHandler               /* 0x17  0x005C  23: Timer 3 */
+    .long TMR4_IRQHandler               /* 0x18  0x0060  24: Timer 4 */
+    .long TMR5_IRQHandler               /* 0x19  0x0064  25: Timer 5 */
+    .long I3C_IRQHandler                /* 0x1A  0x0068  26: I3C */
+    .long UART_IRQHandler               /* 0x1B  0x006C  27: UART */
+    .long SPI_IRQHandler                /* 0x1C  0x0070  28: SPI */
+    .long FLC_IRQHandler                /* 0x1D  0x0074  29: FLC */
+    .long GPIO0_IRQHandler              /* 0x1E  0x0078  30: GPIO0 */
+    .long RSV15_IRQHandler              /* 0x1F  0x007C  31: Reserved */
+    .long DMA0_CH0_IRQHandler           /* 0x20  0x0080  32: DMA0 Channel 0 */
+    .long DMA0_CH1_IRQHandler           /* 0x21  0x0084  33: DMA0 Channel 1 */
+    .long DMA0_CH2_IRQHandler           /* 0x22  0x0088  34: DMA0 Channel 2 */
+    .long DMA0_CH3_IRQHandler           /* 0x23  0x008C  35: DMA0 Channel 3 */
+    .long DMA1_CH0_IRQHandler           /* 0x24  0x0090  36: DMA1 Channel 0 */
+    .long DMA1_CH1_IRQHandler           /* 0x25  0x0094  37: DMA1 Channel 1 */
+    .long DMA1_CH2_IRQHandler           /* 0x26  0x0098  38: DMA1 Channel 2 */
+    .long DMA1_CH3_IRQHandler           /* 0x27  0x009C  39: DMA1 Channel 3 */
+    .long WUT0_IRQHandler               /* 0x28  0x00A0  40: Wakeup Timer 0 */
+    .long WUT1_IRQHandler               /* 0x29  0x00A4  41: Wakeup Timer 1 */
+    .long GPIOWAKE_IRQHandler           /* 0x2A  0x00A8  42: GPIO Wakeup */
+    .long CRC_IRQHandler                /* 0x2B  0x00AC  43: CRC */
+    .long AES_IRQHandler                /* 0x2C  0x00B0  44: AES */
+    .long ERFO_IRQHandler               /* 0x2D  0x00B4  45: ERFO Ready */
+    .long BOOST_IRQHandler              /* 0x2E  0x00B8  46: Boost Controller */
+    .long ECC_IRQHandler                /* 0x2F  0x00BC  47: ECC */
+/* TODO(Bluetooth): Confirm BTLE IRQ Handler Names */
+    .long BTLE_XXXX0_IRQHandler         /* 0x30  0x00C0  48: BTLE XXXX0 */
+    .long BTLE_XXXX1_IRQHandler         /* 0x31  0x00C4  49: BTLE XXXX1 */
+    .long BTLE_XXXX2_IRQHandler         /* 0x32  0x00C8  50: BTLE XXXX2 */
+    .long BTLE_XXXX3_IRQHandler         /* 0x33  0x00CC  51: BTLE XXXX3 */
+    .long BTLE_XXXX4_IRQHandler         /* 0x34  0x00D0  52: BTLE XXXX4 */
+    .long BTLE_XXXX5_IRQHandler         /* 0x35  0x00D4  53: BTLE XXXX5 */
+    .long BTLE_XXXX6_IRQHandler         /* 0x36  0x00D8  54: BTLE XXXX6 */
+    .long BTLE_XXXX7_IRQHandler         /* 0x37  0x00DC  55: BTLE XXXX7 */
+    .long BTLE_XXXX8_IRQHandler         /* 0x38  0x00E0  56: BTLE XXXX8 */
+    .long BTLE_XXXX9_IRQHandler         /* 0x39  0x00E4  57: BTLE XXXX9 */
+    .long BTLE_XXXXA_IRQHandler         /* 0x3A  0x00E8  58: BTLE XXXXA */
+    .long BTLE_XXXXB_IRQHandler         /* 0x3B  0x00EC  59: BTLE XXXXB */
+    .long BTLE_XXXXC_IRQHandler         /* 0x3C  0x00F0  60: BTLE XXXXC */
+    .long BTLE_XXXXD_IRQHandler         /* 0x3D  0x00F4  61: BTLE XXXXD */
+    .long BTLE_XXXXE_IRQHandler         /* 0x3E  0x00F8  62: BTLE XXXXE */
+    .long RSV47_IRQHandler              /* 0x3F  0x00FC  63: Reserved */
+    .long MPC_IRQHandler                /* 0x40  0x0100  64: MPC Combined (Secure) */
+    .long PPC_IRQHandler                /* 0x44  0x0104  65: PPC Combined (Secure) */
+    .long RSV50_IRQHandler              /* 0x48  0x0108  66: Reserved */
+    .long RSV51_IRQHandler              /* 0x49  0x010C  67: Reserved */
+    .long RSV52_IRQHandler              /* 0x4A  0x0110  68: Reserved */
+    .long RSV53_IRQHandler              /* 0x4B  0x0114  69: Reserved */
 
     .text 	
     .thumb
@@ -90,6 +153,19 @@ __isr_vector:
 Reset_Handler:
     ldr r0, =__StackTop
     mov sp, r0
+
+#if IS_SECURE_ENVIRONMENT
+    /* Set limit on Main and Process SP */
+    ldr r0, =__STACK_LIMIT
+    msr msplim, r0
+    msr psplim, r0
+
+    /* Set up Stack Sealing - using predefined stack seal value */
+    ldr r0, =__STACK_SEAL
+    ldr r1, =0xFEF5EDA5U
+    /* Store seal value twice as a double word for redundancy */
+    strd r1, r1, [r0, #0]
+#endif
 
     /* PreInit runs before any RAM initialization. Example usage: DDR setup, etc. */
     ldr     r0, =PreInit
@@ -177,7 +253,6 @@ Reset_Handler:
     .size    \handler_name, . - \handler_name
     .endm
 
-    // TODO: Update to match arch-specific handlers above
     def_irq_handler    NMI_Handler
     def_irq_handler    HardFault_Handler
     def_irq_handler    MemManage_Handler
@@ -189,7 +264,65 @@ Reset_Handler:
     def_irq_handler    SysTick_Handler
     def_irq_handler    Default_Handler
 
-    // TODO: Add default device-specific handlers to match above
-    /* Device-specific Interrupts */
-    def_irq_handler RSVXX_IRQHandler             /* 0xXX  0xXXXX  XX: Reserved */
+    /* Device-specific Interrupts                                                     */
+    /*                                               CMSIS Interrupt Number           */
+    /*                                               ||||          ||                 */
+    /*                                               ||||  Offset  ||                 */
+    /*                                               vvvv  vvvvvv  vv                 */
+
+    def_irq_handler ICE_IRQHandler                /* 0x10  0x0040  16: ICE Unlock */
+    def_irq_handler WDT_IRQHandler                /* 0x11  0x0044  17: Watchdog Timer */
+    def_irq_handler RTC_IRQHandler                /* 0x12  0x0048  18: RTC */
+    def_irq_handler TRNG_IRQHandler               /* 0x13  0x004C  19: True Random Number Generator */
+    def_irq_handler TMR0_IRQHandler               /* 0x14  0x0050  20: Timer 0 */
+    def_irq_handler TMR1_IRQHandler               /* 0x15  0x0054  21: Timer 1 */
+    def_irq_handler TMR2_IRQHandler               /* 0x16  0x0058  22: Timer 2 */
+    def_irq_handler TMR3_IRQHandler               /* 0x17  0x005C  23: Timer 3 */
+    def_irq_handler TMR4_IRQHandler               /* 0x18  0x0060  24: Timer 4 */
+    def_irq_handler TMR5_IRQHandler               /* 0x19  0x0064  25: Timer 5 */
+    def_irq_handler I3C_IRQHandler                /* 0x1A  0x0068  26: I3C */
+    def_irq_handler UART_IRQHandler               /* 0x1B  0x006C  27: UART */
+    def_irq_handler SPI_IRQHandler                /* 0x1C  0x0070  28: SPI */
+    def_irq_handler FLC_IRQHandler                /* 0x1D  0x0074  29: FLC */
+    def_irq_handler GPIO0_IRQHandler              /* 0x1E  0x0078  30: GPIO0 */
+    def_irq_handler RSV15_IRQHandler              /* 0x1F  0x007C  31: Reserved */
+    def_irq_handler DMA0_CH0_IRQHandler           /* 0x20  0x0080  32: DMA0 Channel 0 */
+    def_irq_handler DMA0_CH1_IRQHandler           /* 0x21  0x0084  33: DMA0 Channel 1 */
+    def_irq_handler DMA0_CH2_IRQHandler           /* 0x22  0x0088  34: DMA0 Channel 2 */
+    def_irq_handler DMA0_CH3_IRQHandler           /* 0x23  0x008C  35: DMA0 Channel 3 */
+    def_irq_handler DMA1_CH0_IRQHandler           /* 0x24  0x0090  36: DMA1 Channel 0 */
+    def_irq_handler DMA1_CH1_IRQHandler           /* 0x25  0x0094  37: DMA1 Channel 1 */
+    def_irq_handler DMA1_CH2_IRQHandler           /* 0x26  0x0098  38: DMA1 Channel 2 */
+    def_irq_handler DMA1_CH3_IRQHandler           /* 0x27  0x009C  39: DMA1 Channel 3 */
+    def_irq_handler WUT0_IRQHandler               /* 0x28  0x00A0  40: Wakeup Timer 0 */
+    def_irq_handler WUT1_IRQHandler               /* 0x29  0x00A4  41: Wakeup Timer 1 */
+    def_irq_handler GPIOWAKE_IRQHandler           /* 0x2A  0x00A8  42: GPIO Wakeup */
+    def_irq_handler CRC_IRQHandler                /* 0x2B  0x00AC  43: CRC */
+    def_irq_handler AES_IRQHandler                /* 0x2C  0x00B0  44: AES */
+    def_irq_handler ERFO_IRQHandler               /* 0x2D  0x00B4  45: ERFO Ready */
+    def_irq_handler BOOST_IRQHandler              /* 0x2E  0x00B8  46: Boost Controller */
+    def_irq_handler ECC_IRQHandler                /* 0x2F  0x00BC  47: ECC */
+/* TODO(Bluetooth): Confirm BTLE IRQ Handler Names */
+    def_irq_handler BTLE_XXXX0_IRQHandler         /* 0x30  0x00C0  48: BTLE XXXX0 */
+    def_irq_handler BTLE_XXXX1_IRQHandler         /* 0x31  0x00C4  49: BTLE XXXX1 */
+    def_irq_handler BTLE_XXXX2_IRQHandler         /* 0x32  0x00C8  50: BTLE XXXX2 */
+    def_irq_handler BTLE_XXXX3_IRQHandler         /* 0x33  0x00CC  51: BTLE XXXX3 */
+    def_irq_handler BTLE_XXXX4_IRQHandler         /* 0x34  0x00D0  52: BTLE XXXX4 */
+    def_irq_handler BTLE_XXXX5_IRQHandler         /* 0x35  0x00D4  53: BTLE XXXX5 */
+    def_irq_handler BTLE_XXXX6_IRQHandler         /* 0x36  0x00D8  54: BTLE XXXX6 */
+    def_irq_handler BTLE_XXXX7_IRQHandler         /* 0x37  0x00DC  55: BTLE XXXX7 */
+    def_irq_handler BTLE_XXXX8_IRQHandler         /* 0x38  0x00E0  56: BTLE XXXX8 */
+    def_irq_handler BTLE_XXXX9_IRQHandler         /* 0x39  0x00E4  57: BTLE XXXX9 */
+    def_irq_handler BTLE_XXXXA_IRQHandler         /* 0x3A  0x00E8  58: BTLE XXXXA */
+    def_irq_handler BTLE_XXXXB_IRQHandler         /* 0x3B  0x00EC  59: BTLE XXXXB */
+    def_irq_handler BTLE_XXXXC_IRQHandler         /* 0x3C  0x00F0  60: BTLE XXXXC */
+    def_irq_handler BTLE_XXXXD_IRQHandler         /* 0x3D  0x00F4  61: BTLE XXXXD */
+    def_irq_handler BTLE_XXXXE_IRQHandler         /* 0x3E  0x00F8  62: BTLE XXXXE */
+    def_irq_handler RSV47_IRQHandler              /* 0x3F  0x00FC  63: Reserved */
+    def_irq_handler MPC_IRQHandler                /* 0x40  0x0100  64: MPC Combined (Secure) */
+    def_irq_handler PPC_IRQHandler                /* 0x44  0x0104  65: PPC Combined (Secure) */
+    def_irq_handler RSV50_IRQHandler              /* 0x48  0x0108  66: Reserved */
+    def_irq_handler RSV51_IRQHandler              /* 0x49  0x010C  67: Reserved */
+    def_irq_handler RSV52_IRQHandler              /* 0x4A  0x0110  68: Reserved */
+    def_irq_handler RSV53_IRQHandler              /* 0x4B  0x0114  69: Reserved */
     .end

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Source/system_max32657.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Source/system_max32657.c
@@ -157,6 +157,9 @@ __weak void SystemInit(void)
     /* Enable interrupts */
     __enable_irq();
 
+    // TODO(ICC): Enable the internal cache controller after testing.
+    // MXC_ICC_Enable();
+
     /* Change system clock source to the main high-speed clock */
     MXC_SYS_Clock_Select(MXC_SYS_CLOCK_IPO);
     MXC_SYS_SetClockDiv(MXC_SYS_CLOCK_DIV_1);

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Source/system_max32657.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Source/system_max32657.c
@@ -27,7 +27,7 @@
 
 extern void (*const __isr_vector[])(void);
 
-uint32_t SystemCoreClock = IPO_FREQ;
+uint32_t SystemCoreClock = IPO_FREQ; // Part defaults to IPO on startup
 
 /*
     The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
@@ -122,7 +122,6 @@ __weak int Board_Init(void)
  */
 __weak void SystemInit(void)
 {
-
 #if defined(__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
     SCB->VTOR = (uint32_t)__isr_vector;
 #endif /* __VTOR_PRESENT check */

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Source/system_max32657.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Source/system_max32657.c
@@ -16,6 +16,7 @@
  *
  ******************************************************************************/
 
+#include <stdint.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -63,8 +64,11 @@ __weak void SystemCoreClockUpdate(void)
     case MXC_S_GCR_CLKCTRL_SYSCLK_SEL_IBRO:
         base_freq = IBRO_FREQ;
         break;
-    // case MXC_S_GCR_CLKCTRL_SYSCLK_SEL_ERTCO:
-    //     base_freq = ERTCO_FREQ;
+    case MXC_S_GCR_CLKCTRL_SYSCLK_SEL_ERTCO:
+        base_freq = ERTCO_FREQ;
+        break;
+    // case MXC_S_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK:
+    //     base_freq = EXTCLK_FREQ;
     //     break;
     // TODO(JC): ^^^ Uncomment when EXTCLK register definition is added
     default:

--- a/Libraries/PeriphDrivers/Include/MAX32657/aes.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/aes.h
@@ -27,6 +27,7 @@
 /***** Includes *****/
 #include "aes_regs.h"
 #include "aeskeys_regs.h"
+#include "dma_regs.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -89,9 +90,10 @@ typedef struct _mxc_aes_cipher_req_t {
 /**
  * @brief   Enable portions of the AES
  *
+ * @param   dma   DMA instance used for AES
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
  */
-int MXC_AES_Init(void);
+int MXC_AES_Init(mxc_dma_regs_t *dma);
 
 /**
  * @brief   Enable AES Interrupts
@@ -213,18 +215,20 @@ int MXC_AES_Decrypt(mxc_aes_req_t *req);
  * 
  * @param   src_addr  source address
  * @param   len       number of words of data
+ * @param   dma       DMA instance to configue for AES
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes. 
  */
-int MXC_AES_TXDMAConfig(void *src_addr, int len);
+int MXC_AES_TXDMAConfig(void *src_addr, int len, mxc_dma_regs_t *dma);
 
 /**
  * @brief   Perform AES RX using DMA. Configures DMA request and receives data from AES FIFO.
  * 
  * @param   dest_addr destination address
  * @param   len       number of words of data
+ * @param   dma       DMA instance to configure for AES
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes. 
  */
-int MXC_AES_RXDMAConfig(void *dest_addr, int len);
+int MXC_AES_RXDMAConfig(void *dest_addr, int len, mxc_dma_regs_t *dma);
 
 /**
  * @brief   Perform encryption or decryption using DMA 

--- a/Libraries/PeriphDrivers/Include/MAX32657/crc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/crc.h
@@ -26,6 +26,7 @@
 
 /***** Includes *****/
 #include "crc_regs.h"
+#include "dma_regs.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -63,10 +64,10 @@ typedef enum { CRC_LSB_FIRST, CRC_MSB_FIRST } mxc_crc_bitorder_t;
 /**
  * @brief   Enable portions of the CRC
  *
- *
+ * @param   dma   DMA Instance used for CRC calculation
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
  */
-int MXC_CRC_Init(void);
+int MXC_CRC_Init(mxc_dma_regs_t *dma);
 
 /**
  * @brief   Disable and reset portions of the CRC

--- a/Libraries/PeriphDrivers/Include/MAX32657/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/dma.h
@@ -193,25 +193,30 @@ typedef mxc_dma_srcdst_t (*mxc_dma_trans_chain_t)(mxc_dma_srcdst_t dest);
  *             if you wish to manage clock and gpio related things in upper level instead of here.
  *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
  *             By this flag this function will remove clock and gpio related codes from file.
+ * @param      dma  Pointer to selected DMA instance's registers.
+ * 
  * @return     #E_NO_ERROR if successful
  */
-int MXC_DMA_Init(void);
+int MXC_DMA_Init(mxc_dma_regs_t *dma);
 
 /**
  * @brief      De-Initialize DMA resources.
+ * 
+ * @param      dma  Pointer to selected DMA instance's registers.
  */
-void MXC_DMA_DeInit(void);
+void MXC_DMA_DeInit(mxc_dma_regs_t *dma);
 
 /**
  * @brief      Request DMA channel
  * @details    Returns a handle to the first free DMA channel, which can be used via API calls
  *             or direct access to channel registers using the MXC_DMA_GetCHRegs(int ch) function.
+ * @param      dma  Pointer to selected DMA instance's registers.
  * @return     Non-negative channel handle (inclusive of zero).
  * @return     #E_NONE_AVAIL    All channels in use.
  * @return     #E_BAD_STATE     DMA is not initialized, call MXC_DMA_Init() first.
  * @return     #E_BUSY          DMA is currently busy (locked), try again later.
  */
-int MXC_DMA_AcquireChannel(void);
+int MXC_DMA_AcquireChannel(mxc_dma_regs_t *dma);
 
 /**
  * @brief      Release DMA channel
@@ -360,19 +365,21 @@ int MXC_DMA_ChannelClearFlags(int ch, int flags);
  * @brief      Enable channel interrupt
  * @note       Each channel has two interrupts (complete, and count to zero)
                which must also be enabled with MXC_DMA_SetChannelInterruptEn()
+ * @param      dma  DMA instance used for the DMA channel registers.
  * @param      ch   DMA channel to enable interrupts for.
  * @return     #E_BAD_PARAM if an unused or invalid channel handle, 
  *             #E_NO_ERROR otherwise, \ref MXC_Error_Codes
  */
-int MXC_DMA_EnableInt(int ch);
+int MXC_DMA_EnableInt(mxc_dma_regs_t *dma, int ch);
 
 /**
  * @brief      Disable channel interrupt
+ * @param      dma  DMA instance used for the DMA channel registers.
  * @param      ch   DMA channel to disable interrupts for.
  * @return     #E_BAD_PARAM if an unused or invalid channel handle, 
  *             #E_NO_ERROR otherwise, \ref MXC_Error_Codes 
  */
-int MXC_DMA_DisableInt(int ch);
+int MXC_DMA_DisableInt(mxc_dma_regs_t *dma, int ch);
 
 /**
  * @brief      Start transfer
@@ -402,10 +409,11 @@ mxc_dma_ch_regs_t *MXC_DMA_GetCHRegs(int ch);
 
 /**
  * @brief      Interrupt handler function
+ * @param 	   dma 	Pointer to DMA registers.
  * @details    Call this function as the ISR for each DMA channel under driver control.
  *             Interrupt flags for channel ch will be automatically cleared before return.
  */
-void MXC_DMA_Handler(void);
+void MXC_DMA_Handler(mxc_dma_regs_t *dma);
 
 /*************************/
 /* High Level Functions  */
@@ -416,6 +424,7 @@ void MXC_DMA_Handler(void);
  * @note       The user must have the DMA interrupt enabled and call
  *             MXC_DMA_Handler() from the ISR.
  *
+ * @param 	   dma 	Pointer to DMA registers.
  * @param      dest     pointer to destination memory
  * @param      src      pointer to source memory
  * @param      len      number of bytes to copy
@@ -423,20 +432,22 @@ void MXC_DMA_Handler(void);
  *
  * @return     see \ref MXC_Error_Codes
  */
-int MXC_DMA_MemCpy(void *dest, void *src, int len, mxc_dma_complete_cb_t callback);
+int MXC_DMA_MemCpy(mxc_dma_regs_t *dma, void *dest, void *src, int len,
+                   mxc_dma_complete_cb_t callback);
 
 /**
  * @brief      Performs a memcpy, using DMA, optionally asynchronous
  * @note       The user must have the DMA interrupt enabled and call
  *             MXC_DMA_Handler() from the ISR.
  *
+ * @param 	   dma 	Pointer to DMA registers.
  * @param      config   The channel config struct
  * @param      firstSrcDst  The source, destination, and count for the first transfer
  * @param      callback function is called when transfer is complete
  *
  * @return     see \ref MXC_Error_Codes
  */
-int MXC_DMA_DoTransfer(mxc_dma_config_t config, mxc_dma_srcdst_t firstSrcDst,
+int MXC_DMA_DoTransfer(mxc_dma_regs_t *dma, mxc_dma_config_t config, mxc_dma_srcdst_t firstSrcDst,
                        mxc_dma_trans_chain_t callback);
 /**
  * For other functional uses of DMA (UART, SPI, etc) see the appropriate peripheral driver

--- a/Libraries/PeriphDrivers/Include/MAX32657/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/spi.h
@@ -32,6 +32,7 @@
 #include "gpio.h"
 #include "mxc_pins.h"
 #include "mxc_lock.h"
+#include "dma_regs.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -595,11 +596,12 @@ int MXC_SPI_MasterTransactionAsync(mxc_spi_req_t *req);
  * possible. The channel will be reset and returned to the system at the end of
  * the transaction.
  *
- * @param   req             Pointer to details of the transaction
+ * @param   req     Pointer to details of the transaction
+ * @param   dma     DMA instance to use for SPI DMA
  *
  * @return  See \ref MXC_Error_Codes for the list of error return codes.
  */
-int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req);
+int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req, mxc_dma_regs_t *dma);
 
 /**
  * @brief   Performs a blocking SPI transaction.
@@ -642,10 +644,11 @@ int MXC_SPI_SlaveTransactionAsync(mxc_spi_req_t *req);
  * the transaction.
  *
  * @param   req             Pointer to details of the transaction
+ * @param   dma             DMA instance to use for SPI DMA
  *
  * @return  See \ref MXC_Error_Codes for the list of error return codes.
  */
-int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req);
+int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req, mxc_dma_regs_t *dma);
 
 /**
  * @brief   Sets the TX data to transmit as a 'dummy' byte

--- a/Libraries/PeriphDrivers/Include/MAX32657/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/uart.h
@@ -31,6 +31,7 @@
 #include <stdbool.h>
 #include "uart_regs.h"
 #include "mxc_sys.h"
+#include "dma_regs.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -377,14 +378,15 @@ unsigned int MXC_UART_ReadRXFIFO(mxc_uart_regs_t *uart, unsigned char *bytes, un
 /**
  * @brief   Unloads bytes from the receive FIFO user DMA for longer reads.
  *
- * @param   uart         Pointer to UART registers (selects the UART block used.)
+ * @param   uart        Pointer to UART registers (selects the UART block used).
+ * @param   dma         Pointer to DMA registers (selects the DMA block used for UART DMA).
  * @param   bytes       The buffer to read the data into.
  * @param   len         The number of bytes to read.
  * @param   callback    The function to call when the read is complete
  *
  * @return  See \ref MXC_Error_Codes for a list of return values
  */
-int MXC_UART_ReadRXFIFODMA(mxc_uart_regs_t *uart, unsigned char *bytes, unsigned int len,
+int MXC_UART_ReadRXFIFODMA(mxc_uart_regs_t *uart, mxc_dma_regs_t *dma, unsigned char *bytes, unsigned int len,
                            mxc_uart_dma_complete_cb_t callback);
 
 /**
@@ -410,14 +412,15 @@ unsigned int MXC_UART_WriteTXFIFO(mxc_uart_regs_t *uart, unsigned char *bytes, u
 /**
  * @brief   Loads bytes into the transmit FIFO using DMA for longer writes
  *
- * @param   uart         Pointer to UART registers (selects the UART block used.)
+ * @param   uart        Pointer to UART registers (selects the UART block used).
+ * @param   dma         Pointer to DMA registers (selects the DMA block used for UART DMA).
  * @param   bytes       The buffer containing the bytes to write
  * @param   len         The number of bytes to write.
  * @param   callback    The function to call when the write is complete
  *
  * @return  See \ref MXC_Error_Codes for a list of return values
  */
-int MXC_UART_WriteTXFIFODMA(mxc_uart_regs_t *uart, unsigned char *bytes, unsigned int len,
+int MXC_UART_WriteTXFIFODMA(mxc_uart_regs_t *uart, mxc_dma_regs_t *dma, unsigned char *bytes, unsigned int len,
                             mxc_uart_dma_complete_cb_t callback);
 
 /**
@@ -602,10 +605,11 @@ int MXC_UART_TransactionAsync(mxc_uart_req_t *req);
  *          returned to the system at the end of the transaction.
  *
  * @param   req             Pointer to details of the transaction
+ * @param   dma             Pointer to DMA registers used for UART DMA
  *
  * @return  See \ref MXC_Error_Codes for the list of error return codes.
  */
-int MXC_UART_TransactionDMA(mxc_uart_req_t *req);
+int MXC_UART_TransactionDMA(mxc_uart_req_t *req, mxc_dma_regs_t *dma);
 
 /**
  * @brief   The processing function for DMA transactions.

--- a/Libraries/PeriphDrivers/Source/AES/aes_ai87.c
+++ b/Libraries/PeriphDrivers/Source/AES/aes_ai87.c
@@ -138,12 +138,12 @@ int MXC_AES_Decrypt(mxc_aes_req_t *req)
 
 int MXC_AES_TXDMAConfig(void *src_addr, int len)
 {
-    return MXC_AES_RevB_TXDMAConfig(src_addr, len);
+    return MXC_AES_RevB_TXDMAConfig(src_addr, len, MXC_DMA);
 }
 
 int MXC_AES_RXDMAConfig(void *dest_addr, int len)
 {
-    return MXC_AES_RevB_RXDMAConfig(dest_addr, len);
+    return MXC_AES_RevB_RXDMAConfig(dest_addr, len, MXC_DMA);
 }
 
 int MXC_AES_GenericAsync(mxc_aes_req_t *req, uint8_t enc)

--- a/Libraries/PeriphDrivers/Source/AES/aes_me12.c
+++ b/Libraries/PeriphDrivers/Source/AES/aes_me12.c
@@ -131,12 +131,12 @@ int MXC_AES_Decrypt(mxc_aes_req_t *req)
 
 int MXC_AES_TXDMAConfig(void *src_addr, int len)
 {
-    return MXC_AES_RevB_TXDMAConfig(src_addr, len);
+    return MXC_AES_RevB_TXDMAConfig(src_addr, len, MXC_DMA);
 }
 
 int MXC_AES_RXDMAConfig(void *dest_addr, int len)
 {
-    return MXC_AES_RevB_RXDMAConfig(dest_addr, len);
+    return MXC_AES_RevB_RXDMAConfig(dest_addr, len, MXC_DMA);
 }
 
 int MXC_AES_GenericAsync(mxc_aes_req_t *req, uint8_t enc)

--- a/Libraries/PeriphDrivers/Source/AES/aes_me15.c
+++ b/Libraries/PeriphDrivers/Source/AES/aes_me15.c
@@ -155,12 +155,12 @@ int MXC_AES_Decrypt(mxc_aes_req_t *req)
 
 int MXC_AES_TXDMAConfig(void *src_addr, int len)
 {
-    return MXC_AES_RevB_TXDMAConfig(src_addr, len);
+    return MXC_AES_RevB_TXDMAConfig(src_addr, len, MXC_DMA);
 }
 
 int MXC_AES_RXDMAConfig(void *dest_addr, int len)
 {
-    return MXC_AES_RevB_RXDMAConfig(dest_addr, len);
+    return MXC_AES_RevB_RXDMAConfig(dest_addr, len, MXC_DMA);
 }
 
 int MXC_AES_GenericAsync(mxc_aes_req_t *req, uint8_t enc)

--- a/Libraries/PeriphDrivers/Source/AES/aes_me17.c
+++ b/Libraries/PeriphDrivers/Source/AES/aes_me17.c
@@ -132,12 +132,12 @@ int MXC_AES_Decrypt(mxc_aes_req_t *req)
 
 int MXC_AES_TXDMAConfig(void *src_addr, int len)
 {
-    return MXC_AES_RevB_TXDMAConfig(src_addr, len);
+    return MXC_AES_RevB_TXDMAConfig(src_addr, len, MXC_DMA);
 }
 
 int MXC_AES_RXDMAConfig(void *dest_addr, int len)
 {
-    return MXC_AES_RevB_RXDMAConfig(dest_addr, len);
+    return MXC_AES_RevB_RXDMAConfig(dest_addr, len, MXC_DMA);
 }
 
 int MXC_AES_GenericAsync(mxc_aes_req_t *req, uint8_t enc)

--- a/Libraries/PeriphDrivers/Source/AES/aes_me21.c
+++ b/Libraries/PeriphDrivers/Source/AES/aes_me21.c
@@ -126,12 +126,12 @@ int MXC_AES_Decrypt(mxc_aes_req_t *req)
 
 int MXC_AES_TXDMAConfig(void *src_addr, int len)
 {
-    return MXC_AES_RevB_TXDMAConfig(src_addr, len);
+    return MXC_AES_RevB_TXDMAConfig(src_addr, len, MXC_DMA);
 }
 
 int MXC_AES_RXDMAConfig(void *dest_addr, int len)
 {
-    return MXC_AES_RevB_RXDMAConfig(dest_addr, len);
+    return MXC_AES_RevB_RXDMAConfig(dest_addr, len, MXC_DMA);
 }
 
 int MXC_AES_GenericAsync(mxc_aes_req_t *req, uint8_t enc)

--- a/Libraries/PeriphDrivers/Source/AES/aes_me30.c
+++ b/Libraries/PeriphDrivers/Source/AES/aes_me30.c
@@ -23,19 +23,20 @@
 #include "aes_revb.h"
 #include "trng.h"
 #include "trng_revb.h"
+#include "dma.h"
 
 /* ************************************************************************* */
 /* Global Control/Configuration functions                                    */
 /* ************************************************************************* */
 
-int MXC_AES_Init(void)
+int MXC_AES_Init(mxc_dma_regs_t *dma)
 {
 #ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_AES);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
 #endif
 
-    return MXC_AES_RevB_Init((mxc_aes_revb_regs_t *)MXC_AES);
+    return MXC_AES_RevB_Init((mxc_aes_revb_regs_t *)MXC_AES, dma);
 }
 
 void MXC_AES_EnableInt(uint32_t interrupt)
@@ -123,14 +124,14 @@ int MXC_AES_Decrypt(mxc_aes_req_t *req)
     return MXC_AES_RevB_Decrypt((mxc_aes_revb_regs_t *)MXC_AES, (mxc_aes_revb_req_t *)req);
 }
 
-int MXC_AES_TXDMAConfig(void *src_addr, int len)
+int MXC_AES_TXDMAConfig(void *src_addr, int len, mxc_dma_regs_t *dma)
 {
-    return MXC_AES_RevB_TXDMAConfig(src_addr, len);
+    return MXC_AES_RevB_TXDMAConfig(src_addr, len, dma);
 }
 
-int MXC_AES_RXDMAConfig(void *dest_addr, int len)
+int MXC_AES_RXDMAConfig(void *dest_addr, int len, mxc_dma_regs_t *dma)
 {
-    return MXC_AES_RevB_RXDMAConfig(dest_addr, len);
+    return MXC_AES_RevB_RXDMAConfig(dest_addr, len, dma);
 }
 
 int MXC_AES_GenericAsync(mxc_aes_req_t *req, uint8_t enc)

--- a/Libraries/PeriphDrivers/Source/AES/aes_revb.c
+++ b/Libraries/PeriphDrivers/Source/AES/aes_revb.c
@@ -33,6 +33,7 @@
 /* **** Variable Declaration **** */
 typedef struct {
     uint8_t enc;
+    mxc_dma_regs_t *dma;
     uint8_t channelRX;
     uint8_t channelTX;
     uint32_t remain;
@@ -62,13 +63,15 @@ memcpy32r(uint32_t *dst, const uint32_t *src, unsigned int len)
     }
 }
 
-int MXC_AES_RevB_Init(mxc_aes_revb_regs_t *aes)
+int MXC_AES_RevB_Init(mxc_aes_revb_regs_t *aes, mxc_dma_regs_t *dma)
 {
     aes->ctrl = 0x00;
 
     while (MXC_AES_RevB_IsBusy(aes) != E_NO_ERROR) {}
 
     aes->ctrl |= MXC_F_AES_REVB_CTRL_EN;
+
+    dma_state.dma = dma;
 
     return E_NO_ERROR;
 }
@@ -226,7 +229,7 @@ int MXC_AES_RevB_Decrypt(mxc_aes_revb_regs_t *aes, mxc_aes_revb_req_t *req)
     return MXC_AES_RevB_Generic(aes, req);
 }
 
-int MXC_AES_RevB_TXDMAConfig(void *src_addr, int len)
+int MXC_AES_RevB_TXDMAConfig(void *src_addr, int len, mxc_dma_regs_t *dma)
 {
     uint8_t channel;
     mxc_dma_config_t config;
@@ -240,9 +243,16 @@ int MXC_AES_RevB_TXDMAConfig(void *src_addr, int len)
         return E_BAD_PARAM;
     }
 
+#if (TARGET_NUM == 32657)
+    MXC_DMA_Init(dma);
+
+    channel = MXC_DMA_AcquireChannel(dma);
+#else
     MXC_DMA_Init();
 
     channel = MXC_DMA_AcquireChannel();
+#endif
+
     dma_state.channelTX = channel;
 
     config.reqsel = MXC_DMA_REQUEST_AESTX;
@@ -269,7 +279,12 @@ int MXC_AES_RevB_TXDMAConfig(void *src_addr, int len)
     MXC_DMA_ConfigChannel(config, srcdst);
     MXC_DMA_SetCallback(channel, MXC_AES_RevB_DMACallback);
 
+#if (TARGET_NUM == 32657)
+    MXC_DMA_EnableInt(dma, channel);
+#else
     MXC_DMA_EnableInt(channel);
+#endif
+
     MXC_DMA_Start(channel);
     //MXC_DMA->ch[channel].ctrl |= MXC_F_DMA_CTRL_CTZ_IE;
     MXC_DMA_SetChannelInterruptEn(channel, 0, 1);
@@ -277,7 +292,7 @@ int MXC_AES_RevB_TXDMAConfig(void *src_addr, int len)
     return E_NO_ERROR;
 }
 
-int MXC_AES_RevB_RXDMAConfig(void *dest_addr, int len)
+int MXC_AES_RevB_RXDMAConfig(void *dest_addr, int len, mxc_dma_regs_t *dma)
 {
     if (dest_addr == NULL) {
         return E_NULL_PTR;
@@ -291,9 +306,16 @@ int MXC_AES_RevB_RXDMAConfig(void *dest_addr, int len)
     mxc_dma_config_t config;
     mxc_dma_srcdst_t srcdst;
 
+#if (TARGET_NUM == 32657)
+    MXC_DMA_Init(dma);
+
+    channel = MXC_DMA_AcquireChannel(dma);
+#else
     MXC_DMA_Init();
 
     channel = MXC_DMA_AcquireChannel();
+#endif
+
     dma_state.channelRX = channel;
 
     config.reqsel = MXC_DMA_REQUEST_AESRX;
@@ -320,7 +342,12 @@ int MXC_AES_RevB_RXDMAConfig(void *dest_addr, int len)
     MXC_DMA_ConfigChannel(config, srcdst);
     MXC_DMA_SetCallback(channel, MXC_AES_RevB_DMACallback);
 
+#if (TARGET_NUM == 32657)
+    MXC_DMA_EnableInt(dma, channel);
+#else
     MXC_DMA_EnableInt(channel);
+#endif
+
     MXC_DMA_Start(channel);
     //MXC_DMA->ch[channel].ctrl |= MXC_F_DMA_CTRL_CTZ_IE;
     MXC_DMA_SetChannelInterruptEn(channel, 0, 1);
@@ -359,7 +386,7 @@ int MXC_AES_RevB_GenericAsync(mxc_aes_revb_regs_t *aes, mxc_aes_revb_req_t *req,
     aes->ctrl |= MXC_F_AES_REVB_CTRL_DMA_RX_EN; //Enable AES DMA
     aes->ctrl |= MXC_F_AES_REVB_CTRL_DMA_TX_EN; //Enable AES DMA
 
-    if (MXC_AES_RevB_TXDMAConfig(dma_state.inputText, dma_state.remain) != E_NO_ERROR) {
+    if (MXC_AES_RevB_TXDMAConfig(dma_state.inputText, dma_state.remain, dma_state.dma) != E_NO_ERROR) {
         return E_BAD_PARAM;
     }
 
@@ -385,7 +412,7 @@ void MXC_AES_RevB_DMACallback(int ch, int error)
             if (dma_state.remain < 4) {
                 MXC_AES_Start();
             }
-            MXC_AES_RevB_RXDMAConfig(dma_state.outputText, dma_state.remain);
+            MXC_AES_RevB_RXDMAConfig(dma_state.outputText, dma_state.remain, dma_state.dma);
         } else if (dma_state.channelRX == ch) {
             if (dma_state.remain > 4) {
                 dma_state.remain -= 4;
@@ -394,7 +421,7 @@ void MXC_AES_RevB_DMACallback(int ch, int error)
             }
             MXC_DMA_ReleaseChannel(dma_state.channelRX);
             if (dma_state.remain > 0) {
-                MXC_AES_RevB_TXDMAConfig(dma_state.inputText, dma_state.remain);
+                MXC_AES_RevB_TXDMAConfig(dma_state.inputText, dma_state.remain, dma_state.dma);
             }
         }
     }

--- a/Libraries/PeriphDrivers/Source/AES/aes_revb.h
+++ b/Libraries/PeriphDrivers/Source/AES/aes_revb.h
@@ -26,6 +26,7 @@
 #include "aes_revb_regs.h"
 #include "aeskeys_revb_regs.h"
 #include "trng_revb_regs.h"
+#include "dma.h"
 
 /**
   * @brief  Enumeration type to select AES key
@@ -60,7 +61,7 @@ typedef struct _mxc_aes_revb_cipher_req_t {
     mxc_aes_complete_t callback; ///< Callback function
 } mxc_aes_revb_req_t;
 
-int MXC_AES_RevB_Init(mxc_aes_revb_regs_t *aes);
+int MXC_AES_RevB_Init(mxc_aes_revb_regs_t *aes, mxc_dma_regs_t *dma);
 void MXC_AES_RevB_EnableInt(mxc_aes_revb_regs_t *aes, uint32_t interrupt);
 void MXC_AES_RevB_DisableInt(mxc_aes_revb_regs_t *aes, uint32_t interrupt);
 int MXC_AES_RevB_IsBusy(mxc_aes_revb_regs_t *aes);
@@ -76,8 +77,8 @@ void MXC_AES_RevB_ClearFlags(mxc_aes_revb_regs_t *aes, uint32_t flags);
 int MXC_AES_RevB_Generic(mxc_aes_revb_regs_t *aes, mxc_aes_revb_req_t *req);
 int MXC_AES_RevB_Encrypt(mxc_aes_revb_regs_t *aes, mxc_aes_revb_req_t *req);
 int MXC_AES_RevB_Decrypt(mxc_aes_revb_regs_t *aes, mxc_aes_revb_req_t *req);
-int MXC_AES_RevB_TXDMAConfig(void *src_addr, int len);
-int MXC_AES_RevB_RXDMAConfig(void *dest_addr, int len);
+int MXC_AES_RevB_TXDMAConfig(void *src_addr, int len, mxc_dma_regs_t *dma);
+int MXC_AES_RevB_RXDMAConfig(void *dest_addr, int len, mxc_dma_regs_t *dma);
 int MXC_AES_RevB_GenericAsync(mxc_aes_revb_regs_t *aes, mxc_aes_revb_req_t *req, uint8_t enc);
 int MXC_AES_RevB_EncryptAsync(mxc_aes_revb_regs_t *aes, mxc_aes_revb_req_t *req);
 int MXC_AES_RevB_DecryptAsync(mxc_aes_revb_regs_t *aes, mxc_aes_revb_req_t *req);

--- a/Libraries/PeriphDrivers/Source/CRC/crc_ai87.c
+++ b/Libraries/PeriphDrivers/Source/CRC/crc_ai87.c
@@ -36,7 +36,7 @@ int MXC_CRC_Init(void)
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_CRC);
 #endif
 
-    MXC_CRC_RevA_Init((mxc_crc_reva_regs_t *)MXC_CRC);
+    MXC_CRC_RevA_Init((mxc_crc_reva_regs_t *)MXC_CRC, MXC_DMA);
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/CRC/crc_me15.c
+++ b/Libraries/PeriphDrivers/Source/CRC/crc_me15.c
@@ -36,7 +36,7 @@ int MXC_CRC_Init(void)
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_CRC);
 #endif
 
-    MXC_CRC_RevA_Init((mxc_crc_reva_regs_t *)MXC_CRC);
+    MXC_CRC_RevA_Init((mxc_crc_reva_regs_t *)MXC_CRC, MXC_DMA);
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/CRC/crc_me17.c
+++ b/Libraries/PeriphDrivers/Source/CRC/crc_me17.c
@@ -36,7 +36,7 @@ int MXC_CRC_Init(void)
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_CRC);
 #endif
 
-    MXC_CRC_RevA_Init((mxc_crc_reva_regs_t *)MXC_CRC);
+    MXC_CRC_RevA_Init((mxc_crc_reva_regs_t *)MXC_CRC, MXC_DMA);
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/CRC/crc_me30.c
+++ b/Libraries/PeriphDrivers/Source/CRC/crc_me30.c
@@ -23,18 +23,19 @@
 
 #include "crc.h"
 #include "crc_reva.h"
+#include "dma.h"
 
 /* ************************************************************************* */
 /* Global Control/Configuration functions                                    */
 /* ************************************************************************* */
 
-int MXC_CRC_Init(void)
+int MXC_CRC_Init(mxc_dma_regs_t *dma)
 {
 #ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_CRC);
 #endif
 
-    MXC_CRC_RevA_Init((mxc_crc_reva_regs_t *)MXC_CRC);
+    MXC_CRC_RevA_Init((mxc_crc_reva_regs_t *)MXC_CRC, dma);
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/CRC/crc_reva.h
+++ b/Libraries/PeriphDrivers/Source/CRC/crc_reva.h
@@ -23,6 +23,7 @@
 
 #include "crc.h"
 #include "crc_reva_regs.h"
+#include "dma.h"
 
 /***** CRC Definitions *****/
 /**
@@ -41,7 +42,7 @@ typedef struct _mxc_crc_reva_req_t {
  */
 typedef enum { CRC_REVA_LSB_FIRST, CRC_REVA_MSB_FIRST } mxc_crc_reva_bitorder_t;
 
-int MXC_CRC_RevA_Init(mxc_crc_reva_regs_t *crc);
+int MXC_CRC_RevA_Init(mxc_crc_reva_regs_t *crc, mxc_dma_regs_t *dma);
 int MXC_CRC_RevA_Shutdown(mxc_crc_reva_regs_t *crc);
 int MXC_CRC_RevA_Handler(int ch, int error);
 void MXC_CRC_RevA_SetDirection(mxc_crc_reva_regs_t *crc, mxc_crc_reva_bitorder_t bitOrder);

--- a/Libraries/PeriphDrivers/Source/DMA/dma_me30.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_me30.c
@@ -32,31 +32,33 @@
 
 /****** Functions ******/
 
-int MXC_DMA_Init(void)
+int MXC_DMA_Init(mxc_dma_regs_t *dma)
 {
 #ifndef MSDK_NO_GPIO_CLK_INIT
-    if (MXC_DMA == MXC_DMA0 && !MXC_SYS_IsClockEnabled(MXC_SYS_PERIPH_CLOCK_DMA0)) {
+    if (dma == MXC_DMA0 && !MXC_SYS_IsClockEnabled(MXC_SYS_PERIPH_CLOCK_DMA0)) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_DMA0);
         MXC_SYS_Reset_Periph(MXC_SYS_RESET0_DMA0);
     }
     // TODO(ME30): There is no periph clock enable register for DMA1 atm
-    // else if (MXC_DMA == MXC_DMA1 && !MXC_SYS_IsClockEnabled(MXC_SYS_PERIPH_CLOCK_DMA1))
+    //              -Added but it's in feat/ME30 branch.
+    //               Uncomment when merged.
+    // else if (dma == MXC_DMA1 && !MXC_SYS_IsClockEnabled(MXC_SYS_PERIPH_CLOCK_DMA1))
     //     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_DMA1);
     //     MXC_SYS_Reset_Periph(MXC_SYS_RESET0_DMA1);
     // }
 #endif
 
-    return MXC_DMA_RevA_Init((mxc_dma_reva_regs_t *)MXC_DMA);
+    return MXC_DMA_RevA_Init((mxc_dma_reva_regs_t *)dma);
 }
 
-void MXC_DMA_DeInit(void)
+void MXC_DMA_DeInit(mxc_dma_regs_t *dma)
 {
-    return MXC_DMA_RevA_DeInit((mxc_dma_reva_regs_t *)MXC_DMA);
+    return MXC_DMA_RevA_DeInit((mxc_dma_reva_regs_t *)dma);
 }
 
-int MXC_DMA_AcquireChannel(void)
+int MXC_DMA_AcquireChannel(mxc_dma_regs_t *dma)
 {
-    return MXC_DMA_RevA_AcquireChannel((mxc_dma_reva_regs_t *)MXC_DMA);
+    return MXC_DMA_RevA_AcquireChannel((mxc_dma_reva_regs_t *)dma);
 }
 
 int MXC_DMA_ReleaseChannel(int ch)
@@ -124,14 +126,15 @@ int MXC_DMA_ChannelClearFlags(int ch, int flags)
     return MXC_DMA_RevA_ChannelClearFlags(ch, flags);
 }
 
-int MXC_DMA_EnableInt(int ch)
+// TODO(DMA): Check ME14 becasue you can only get ME14 intrs from MXC_DMA0.
+int MXC_DMA_EnableInt(mxc_dma_regs_t *dma, int ch)
 {
-    return MXC_DMA_RevA_EnableInt((mxc_dma_reva_regs_t *)MXC_DMA, ch);
+    return MXC_DMA_RevA_EnableInt((mxc_dma_reva_regs_t *)dma, ch);
 }
 
-int MXC_DMA_DisableInt(int ch)
+int MXC_DMA_DisableInt(mxc_dma_regs_t *dma, int ch)
 {
-    return MXC_DMA_RevA_DisableInt((mxc_dma_reva_regs_t *)MXC_DMA, ch);
+    return MXC_DMA_RevA_DisableInt((mxc_dma_reva_regs_t *)dma, ch);
 }
 
 int MXC_DMA_Start(int ch)
@@ -149,18 +152,18 @@ mxc_dma_ch_regs_t *MXC_DMA_GetCHRegs(int ch)
     return MXC_DMA_RevA_GetCHRegs(ch);
 }
 
-void MXC_DMA_Handler(void)
+void MXC_DMA_Handler(mxc_dma_regs_t *dma)
 {
-    MXC_DMA_RevA_Handler((mxc_dma_reva_regs_t *)MXC_DMA);
+    MXC_DMA_RevA_Handler((mxc_dma_reva_regs_t *)dma);
 }
 
-int MXC_DMA_MemCpy(void *dest, void *src, int len, mxc_dma_complete_cb_t callback)
+int MXC_DMA_MemCpy(mxc_dma_regs_t *dma, void *dest, void *src, int len, mxc_dma_complete_cb_t callback)
 {
-    return MXC_DMA_RevA_MemCpy((mxc_dma_reva_regs_t *)MXC_DMA, dest, src, len, callback);
+    return MXC_DMA_RevA_MemCpy((mxc_dma_reva_regs_t *)dma, dest, src, len, callback);
 }
 
-int MXC_DMA_DoTransfer(mxc_dma_config_t config, mxc_dma_srcdst_t firstSrcDst,
+int MXC_DMA_DoTransfer(mxc_dma_regs_t *dma, mxc_dma_config_t config, mxc_dma_srcdst_t firstSrcDst,
                        mxc_dma_trans_chain_t callback)
 {
-    return MXC_DMA_RevA_DoTransfer((mxc_dma_reva_regs_t *)MXC_DMA, config, firstSrcDst, callback);
+    return MXC_DMA_RevA_DoTransfer((mxc_dma_reva_regs_t *)dma, config, firstSrcDst, callback);
 }

--- a/Libraries/PeriphDrivers/Source/DMA/dma_reva.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_reva.c
@@ -470,7 +470,7 @@ int MXC_DMA_RevA_MemCpy(mxc_dma_reva_regs_t *dma, void *dest, void *src, int len
     mxc_dma_srcdst_t transfer;
     int channel;
 
-#if TARGET_NUM == 32665
+#if (TARGET_NUM == 32665 || TARGET_NUM == 32657)
     channel = MXC_DMA_AcquireChannel((mxc_dma_regs_t *)dma);
 #else
     channel = MXC_DMA_AcquireChannel();
@@ -500,7 +500,11 @@ int MXC_DMA_RevA_MemCpy(mxc_dma_reva_regs_t *dma, void *dest, void *src, int len
         return retval;
     }
 
+#if (TARGET_NUM == 32657)
+    retval = MXC_DMA_EnableInt((mxc_dma_regs_t *)dma, channel);
+#else
     retval = MXC_DMA_EnableInt(channel);
+#endif
 
     if (retval != E_NO_ERROR) {
         return retval;
@@ -535,7 +539,7 @@ int MXC_DMA_RevA_DoTransfer(mxc_dma_reva_regs_t *dma, mxc_dma_config_t config,
 {
     int retval, channel;
 
-#if TARGET_NUM == 32665
+#if (TARGET_NUM == 32665 || TARGET_NUM == 32657)
     channel = MXC_DMA_AcquireChannel((mxc_dma_regs_t *)dma);
 #else
     channel = MXC_DMA_AcquireChannel();
@@ -553,7 +557,11 @@ int MXC_DMA_RevA_DoTransfer(mxc_dma_reva_regs_t *dma, mxc_dma_config_t config,
         return retval;
     }
 
+#if (TARGET_NUM == 32657)
+    retval = MXC_DMA_EnableInt((mxc_dma_regs_t *)dma, channel);
+#else
     retval = MXC_DMA_EnableInt(channel);
+#endif
 
     if (retval != E_NO_ERROR) {
         return retval;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me30.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me30.c
@@ -337,7 +337,7 @@ int MXC_SPI_MasterTransactionAsync(mxc_spi_req_t *req)
     return MXC_SPI_RevA1_MasterTransactionAsync((mxc_spi_reva_req_t *)req);
 }
 
-int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
+int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req, mxc_dma_regs_t *dma)
 {
     int reqselTx = -1;
     int reqselRx = -1;
@@ -377,8 +377,7 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
         }
     }
 
-    return MXC_SPI_RevA1_MasterTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,
-                                              MXC_DMA);
+    return MXC_SPI_RevA1_MasterTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx, dma);
 }
 
 int MXC_SPI_SlaveTransaction(mxc_spi_req_t *req)
@@ -391,7 +390,7 @@ int MXC_SPI_SlaveTransactionAsync(mxc_spi_req_t *req)
     return MXC_SPI_RevA1_SlaveTransactionAsync((mxc_spi_reva_req_t *)req);
 }
 
-int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
+int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req, mxc_dma_regs_t *dma)
 {
     int reqselTx = -1;
     int reqselRx = -1;
@@ -433,8 +432,7 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
         }
     }
 
-    return MXC_SPI_RevA1_SlaveTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,
-                                             MXC_DMA);
+    return MXC_SPI_RevA1_SlaveTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx, dma);
 }
 
 int MXC_SPI_SetDefaultTXData(mxc_spi_regs_t *spi, unsigned int defaultTXData)

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
@@ -952,7 +952,7 @@ int MXC_SPI_RevA1_MasterTransactionDMA(mxc_spi_reva_req_t *req, int reqselTx, in
     // for non-MT mode do this setup every time, for MT mode only first time
     if ((states[spi_num].mtMode == 0) ||
         ((states[spi_num].mtMode == 1) && (states[spi_num].mtFirstTrans == 1))) {
-#if TARGET_NUM == 32665
+#if (TARGET_NUM == 32665 || TARGET_NUM == 32657)
         MXC_DMA_Init(dma);
         states[spi_num].channelTx = MXC_DMA_AcquireChannel(dma);
         states[spi_num].channelRx = MXC_DMA_AcquireChannel(dma);
@@ -1009,7 +1009,13 @@ int MXC_SPI_RevA1_MasterTransactionDMA(mxc_spi_reva_req_t *req, int reqselTx, in
     //tx
     if (req->txData != NULL && !tx_is_complete) {
         MXC_DMA_SetCallback(states[spi_num].channelTx, MXC_SPI_RevA1_DMACallback);
+
+#if (TARGET_NUM == 32657)
+        MXC_DMA_EnableInt(dma, states[spi_num].channelTx);
+#else
         MXC_DMA_EnableInt(states[spi_num].channelTx);
+#endif
+
         config.reqsel = (mxc_dma_reqsel_t)reqselTx;
         config.ch = states[spi_num].channelTx;
         advConfig.ch = states[spi_num].channelTx;
@@ -1049,7 +1055,13 @@ int MXC_SPI_RevA1_MasterTransactionDMA(mxc_spi_reva_req_t *req, int reqselTx, in
     // rx
     if (req->rxData != NULL && !rx_is_complete) {
         MXC_DMA_SetCallback(states[spi_num].channelRx, MXC_SPI_RevA1_DMACallback);
+
+#if (TARGET_NUM == 32657)
+        MXC_DMA_EnableInt(dma, states[spi_num].channelRx);
+#else
         MXC_DMA_EnableInt(states[spi_num].channelRx);
+#endif
+
         config.reqsel = (mxc_dma_reqsel_t)reqselRx;
         config.ch = states[spi_num].channelRx;
         config.srcinc_en = 0;
@@ -1160,7 +1172,7 @@ int MXC_SPI_RevA1_SlaveTransactionDMA(mxc_spi_reva_req_t *req, int reqselTx, int
     // for non-MT mode do this setup every time, for MT mode only first time
     if ((states[spi_num].mtMode == 0) ||
         ((states[spi_num].mtMode == 1) && (states[spi_num].mtFirstTrans == 1))) {
-#if TARGET_NUM == 32665
+#if (TARGET_NUM == 32665 || TARGET_NUM == 32657)
         MXC_DMA_Init(dma);
         states[spi_num].channelTx = MXC_DMA_AcquireChannel(dma);
         states[spi_num].channelRx = MXC_DMA_AcquireChannel(dma);
@@ -1180,8 +1192,14 @@ int MXC_SPI_RevA1_SlaveTransactionDMA(mxc_spi_reva_req_t *req, int reqselTx, int
 
         MXC_DMA_SetCallback(states[spi_num].channelTx, MXC_SPI_RevA1_DMACallback);
         MXC_DMA_SetCallback(states[spi_num].channelRx, MXC_SPI_RevA1_DMACallback);
+
+#if (TARGET_NUM == 32657)
+        MXC_DMA_EnableInt(dma, states[spi_num].channelTx);
+        MXC_DMA_EnableInt(dma, states[spi_num].channelRx);
+#else
         MXC_DMA_EnableInt(states[spi_num].channelTx);
         MXC_DMA_EnableInt(states[spi_num].channelRx);
+#endif
     }
 
     bits = MXC_SPI_GetDataSize((mxc_spi_regs_t *)req->spi);

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me30.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me30.c
@@ -93,7 +93,10 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
         checksum[1] = ((infoblock[4] & 0x007F8000) >> 15);
 
-        err = MXC_AES_Init();
+        // Info block only accessible for secure code.
+        //  Use Secure DMA1.
+        // TODO(DMA): Figure out access to "secure" functions when in non-secure code.
+        err = MXC_AES_Init(MXC_DMA1);
         if (err) {
             MXC_FLC_LockInfoBlock(MXC_INFO_MEM_BASE);
             return err;

--- a/Libraries/PeriphDrivers/Source/UART/uart_me30.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me30.c
@@ -182,13 +182,13 @@ unsigned int MXC_UART_ReadRXFIFO(mxc_uart_regs_t *uart, unsigned char *bytes, un
     return MXC_UART_RevA_ReadRXFIFO((mxc_uart_reva_regs_t *)uart, bytes, len);
 }
 
-int MXC_UART_ReadRXFIFODMA(mxc_uart_regs_t *uart, unsigned char *bytes, unsigned int len,
+int MXC_UART_ReadRXFIFODMA(mxc_uart_regs_t *uart, mxc_dma_regs_t *dma, unsigned char *bytes, unsigned int len,
                            mxc_uart_dma_complete_cb_t callback)
 {
     mxc_dma_config_t config;
     config.reqsel = MXC_DMA_REQUEST_UART0RX; // TODO(ME30): Updated DMA reqsel
 
-    return MXC_UART_RevA_ReadRXFIFODMA((mxc_uart_reva_regs_t *)uart, MXC_DMA, bytes, len, callback,
+    return MXC_UART_RevA_ReadRXFIFODMA((mxc_uart_reva_regs_t *)uart, dma, bytes, len, callback,
                                        config);
 }
 
@@ -202,13 +202,13 @@ unsigned int MXC_UART_WriteTXFIFO(mxc_uart_regs_t *uart, unsigned char *bytes, u
     return MXC_UART_RevA_WriteTXFIFO((mxc_uart_reva_regs_t *)uart, bytes, len);
 }
 
-int MXC_UART_WriteTXFIFODMA(mxc_uart_regs_t *uart, unsigned char *bytes, unsigned int len,
+int MXC_UART_WriteTXFIFODMA(mxc_uart_regs_t *uart, mxc_dma_regs_t *dma, unsigned char *bytes, unsigned int len,
                             mxc_uart_dma_complete_cb_t callback)
 {
     mxc_dma_config_t config;
     config.reqsel = MXC_DMA_REQUEST_UART0TX; // TODO(ME30): Updated DMA reqsel
 
-    return MXC_UART_RevA_WriteTXFIFODMA((mxc_uart_reva_regs_t *)uart, MXC_DMA, bytes, len, callback,
+    return MXC_UART_RevA_WriteTXFIFODMA((mxc_uart_reva_regs_t *)uart, dma, bytes, len, callback,
                                         config);
 }
 
@@ -282,9 +282,9 @@ int MXC_UART_TransactionAsync(mxc_uart_req_t *req)
     return MXC_UART_RevA_TransactionAsync((mxc_uart_reva_req_t *)req);
 }
 
-int MXC_UART_TransactionDMA(mxc_uart_req_t *req)
+int MXC_UART_TransactionDMA(mxc_uart_req_t *req, mxc_dma_regs_t *dma)
 {
-    return MXC_UART_RevA_TransactionDMA((mxc_uart_reva_req_t *)req, MXC_DMA);
+    return MXC_UART_RevA_TransactionDMA((mxc_uart_reva_req_t *)req, dma);
 }
 
 int MXC_UART_AbortAsync(mxc_uart_regs_t *uart)


### PR DESCRIPTION
### Description

Some updates to the CMSIS for Verification.
- Added undecorated MXC_BASE_* definitions
- Removed `GET_S_` and `GET_NS` definitions from max32657.h
- Define both DMA instances
- Added partition_max32657.h (from CMSIS) to handle SAU memory region partitioning for secure and non-secure code.
- Updated linker, startup, and system files (SystemInit, SAU, Stack Sealing, Interrupt Tables)

Both DMA0 and DMA1 need to be defined, so we can't use the single `MXC_DMA` instance anymore.
1. DMA0 has a secure and non-secure mapping - accessible for secure and non-secure builds. However, DMA0 can not access secure memory or secure peripherals.
2. DMA1 only has a secure mapping - accessible for secure builds. But DMA1 can access both secure or non-secure memory and peripherals.

I'll have a separate PR for the remaining SYS register updates that I need to make.

Edit: Removing multiple linkers comment, just saw your changes @Jake-Carter. But I don't think we need multiple vector table definitions and startup_max32657.S startup code.

We can have one vector table defined that includes all secure and non-secure handlers, and we can dynamically switch between secure and non-secure vector tables during startup process using the `SCB->VTOR` vector table offset register. The `SCB->VTOR` register is banked into two parts, and the appropriate offset for secure and non-secure is used depending on the security context. We can also explicitly label the secure-only interrupts with the `_S` names, and include a build warning/error if the non-secure application references a secure handler.

The secure vector table is set up in `SystemInit()` called from Reset_Handler on startup. We'd have to figure out a mechanism for non-secure builds (non-secure reset handler) to set up the non-secure vector table (using `SCB->VTOR` again). This is at least my current understanding of how we might go about this for our bare metal MSDK.

There's a lot to think about - but given our schedule and priorities, we can focus on handling the secure mode for now so verification can begin. These changes are geared towards finishing the Secure build system changes that you've made, and to prep the non-secure builds for down the road.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.