### PR TITLE
fix(workflow): Fix BLE Project Build Test Failures

### DIFF
--- a/.github/workflows/scripts/build.py
+++ b/.github/workflows/scripts/build.py
@@ -44,7 +44,9 @@ hardfp_test_list = [
 
 def build_project(project:Path, target, board, maxim_path:Path, distclean=False, extra_args=None) -> Tuple[int, tuple]:
     clean_cmd = "make clean" if not distclean else "make distclean"
-    if target in ["MAX32655", "MAX32665", "MAX32690"]: clean_cmd += "&& make clean.cordio"
+    if "Bluetooth" in project.as_posix() or "BLE" in project.as_posix():
+        # Clean cordio lib for BLE projects
+        clean_cmd += "&& make clean.cordio"
     res = run(clean_cmd, cwd=project, shell=True, capture_output=True, encoding="utf-8")
 
     # Test build

--- a/.github/workflows/scripts/build.py
+++ b/.github/workflows/scripts/build.py
@@ -44,6 +44,7 @@ hardfp_test_list = [
 
 def build_project(project:Path, target, board, maxim_path:Path, distclean=False, extra_args=None) -> Tuple[int, tuple]:
     clean_cmd = "make clean" if not distclean else "make distclean"
+    if target in ["MAX32655", "MAX32665", "MAX32690"]: clean_cmd += "&& make clean.cordio"
     res = run(clean_cmd, cwd=project, shell=True, capture_output=True, encoding="utf-8")
 
     # Test build


### PR DESCRIPTION
### Description

#1013 introduced a build error that was only present on the Github Actions runners for some BLE projects [(Ex)](https://github.com/analogdevicesinc/msdk/actions/runs/9065017515/job/24904593363).  Some outdated cached copies of the Cordio library builds seemed to be causing it.

This PR updates the build test workflow to clean the Cordio library file for BLE projects.  BLE projects are detected if:
- The file path has `Bluetooth` in it
- The project name has `BLE` in it

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.