### PR TITLE
fix(PeriphDrivers): Fix `MXC_SYS_GetUSN` Buffer Overflow

### DIFF
--- a/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
@@ -75,7 +75,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     uint32_t _usn_32[MXC_SYS_USN_CHECKSUM_LEN / 4];
     // ^ Declare as uint32_t to preserve mem alignment
     uint8_t *_usn_8 = (uint8_t *)_usn_32;
-    memset(_usn_8, 0, MXC_SYS_USN_CHECKSUM_LEN);
+    memset(_usn_8, 0, MXC_SYS_USN_LEN);
 
     _usn_8[0] = (infoblock[0] & 0x007F8000) >> 15;
     _usn_8[1] = (infoblock[0] & 0x7F800000) >> 23;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_ai87.c
@@ -75,7 +75,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     uint32_t _usn_32[MXC_SYS_USN_CHECKSUM_LEN / 4];
     // ^ Declare as uint32_t to preserve mem alignment
     uint8_t *_usn_8 = (uint8_t *)_usn_32;
-    memset(_usn_8, 0, MXC_SYS_USN_CHECKSUM_LEN);
+    memset(_usn_8, 0, MXC_SYS_USN_LEN);
 
     _usn_8[0] = (infoblock[0] & 0x007F8000) >> 15;
     _usn_8[1] = (infoblock[0] & 0x7F800000) >> 23;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
@@ -70,7 +70,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
+    memset(usn, 0, MXC_SYS_USN_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me14.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me14.c
@@ -64,7 +64,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
+    memset(usn, 0, MXC_SYS_USN_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
@@ -76,7 +76,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
+    memset(usn, 0, MXC_SYS_USN_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me16.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me16.c
@@ -62,7 +62,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
+    memset(usn, 0, MXC_SYS_USN_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
@@ -72,7 +72,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
+    memset(usn, 0, MXC_SYS_USN_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
@@ -71,7 +71,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
+    memset(usn, 0, MXC_SYS_USN_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
@@ -68,7 +68,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
+    memset(usn, 0, MXC_SYS_USN_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;


### PR DESCRIPTION
### Description

Fixes #1006 

This PR updates `MXC_SYS_GetUSN` to prevent buffer overflow.  The application-side buffer should be `MXC_SYS_USN_LEN`, but we were using `MXC_SYS_USN_CHECKSUM_LEN` which is a larger buffer size with some additional padding used for the internal CRC calculation.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
