### PR TITLE
fix(PeriphDrivers): Fix Pulldown/Pullup Configuration for ME30

### DIFF
--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me30.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me30.c
@@ -100,35 +100,19 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     }
 
     // Configure the pad
-    // TODO(ME30): "ps" (weak vs strong pull-up/down select) register field missing
     switch (cfg->pad) {
     case MXC_GPIO_PAD_NONE:
         gpio->padctrl0 &= ~cfg->mask;
-        gpio->padctrl1 &= ~cfg->mask;
-        break;
-
-    case MXC_GPIO_PAD_WEAK_PULL_UP:
-        gpio->padctrl0 |= cfg->mask;
-        gpio->padctrl1 &= ~cfg->mask;
-        // gpio->ps &= ~cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_UP:
         gpio->padctrl0 |= cfg->mask;
-        gpio->padctrl1 &= ~cfg->mask;
-        // gpio->ps |= cfg->mask;
-        break;
-
-    case MXC_GPIO_PAD_WEAK_PULL_DOWN:
-        gpio->padctrl0 &= ~cfg->mask;
-        gpio->padctrl1 |= cfg->mask;
-        // gpio->ps &= ~cfg->mask;
+        gpio->pssel |= cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_DOWN:
-        gpio->padctrl0 &= ~cfg->mask;
-        gpio->padctrl1 |= cfg->mask;
-        // gpio->ps |= cfg->mask;
+        gpio->padctrl0 |= cfg->mask;
+        gpio->pssel &= ~cfg->mask;
         break;
 
     default:


### PR DESCRIPTION
This commit updates MXC_GPIO_Config according to GPIO hardware design. The register definitions shows similar padding functionality to MAX32675.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.