### PR TITLE
fix(PeriphDrivers): Fix PWM to work with ME30

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32657/lp.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/lp.h
@@ -50,15 +50,6 @@ extern "C" {
 typedef enum { MXC_LP_V0_9 = 0, MXC_LP_V1_0, MXC_LP_V1_1 } mxc_lp_ovr_t;
 
 /**
- * @brief   Enumeration type for PM Mode
- *
- */
-typedef enum {
-    MXC_LP_IPO = MXC_F_GCR_PM_IPO_PD,
-    MXC_LP_IBRO = MXC_F_GCR_PM_IBRO_PD,
-} mxc_lp_cfg_ds_pd_t;
-
-/**
  * @brief      Places the device into SLEEP mode.  This function returns once an RTC or external interrupt occur.
  */
 void MXC_LP_EnterSleepMode(void);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me30.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me30.c
@@ -119,8 +119,6 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         if (init_pins) {
             if (cfg->bitMode != MXC_TMR_BIT_MODE_16B) {
                 MXC_GPIO_Config(&gpio_cfg_tmr2);
-            } else {
-                MXC_GPIO_Config(&gpio_cfg_tmr2b);
             }
         }
 

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
@@ -192,7 +192,7 @@ void MXC_TMR_RevB_ConfigGeneric(mxc_tmr_revb_regs_t *tmr, mxc_tmr_cfg_t *cfg)
     while (!(tmr->intfl & (MXC_F_TMR_REVB_INTFL_WRDONE_A << timerOffset))) {}
 
     tmr->cmp = (cfg->cmp_cnt << timerOffset);
-#if TARGET_NUM == 32655 || TARGET_NUM == 78000 || TARGET_NUM == 32690 || TARGET_NUM == 78002
+#if TARGET_NUM == 32655 || TARGET_NUM == 32657 || TARGET_NUM == 78000 || TARGET_NUM == 32690 || TARGET_NUM == 78002
     tmr->ctrl1 &= ~(MXC_F_TMR_REVB_CTRL1_OUTEN_A << timerOffset);
 #else
     tmr->ctrl1 |= (MXC_F_TMR_REVB_CTRL1_OUTEN_A << timerOffset);


### PR DESCRIPTION
To build and test PWM on ME30 below modifications are applied.

- Necessary ifndef statement added to tmr_revb.c to get output from timer module.
- Unnecessary pin option is removed from tmr_me30.c
- Unnecessary enumeration is removed from lp.h

## Pull Request Template

### Description

Please include a summary of the changes and related issues. Please also include relevant motivation and context.

### Checklist Before Requesting Review

- [x ] PR Title follows correct guidelines.
- [x ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
