### PR TITLE
fix(CMSIS): Fix zephyr build issues

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32520/Source/system_max32520.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32520/Source/system_max32520.c
@@ -39,12 +39,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32570/Source/system_max32570.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32570/Source/system_max32570.c
@@ -36,12 +36,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_max32572.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_max32572.c
@@ -36,12 +36,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_riscv_max32572.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_riscv_max32572.c
@@ -33,12 +33,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32650/Source/system_max32650.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32650/Source/system_max32650.c
@@ -38,12 +38,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_max32655.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_max32655.c
@@ -37,12 +37,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_riscv_max32655.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_riscv_max32655.c
@@ -38,12 +38,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32660/Source/system_max32660.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32660/Source/system_max32660.c
@@ -41,12 +41,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32662/Source/system_max32662.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32662/Source/system_max32662.c
@@ -32,8 +32,7 @@
 
 extern void (*const __isr_vector[])(void);
 
-uint32_t SystemCoreClock __attribute__((section(".shared")));
-volatile uint32_t mailbox __attribute__((section(".mailbox")));
+uint32_t SystemCoreClock = HIRC_FREQ;
 
 /*
 The libc implementation from GCC 11+ depends on _getpid and _kill in some places.

--- a/Libraries/CMSIS/Device/Maxim/MAX32662/Source/system_max32662.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32662/Source/system_max32662.c
@@ -39,12 +39,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Source/system_max32665.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Source/system_max32665.c
@@ -43,12 +43,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Source/system_max32670.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Source/system_max32670.c
@@ -37,12 +37,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Source/system_max32672.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Source/system_max32672.c
@@ -35,12 +35,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Source/system_max32675.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Source/system_max32675.c
@@ -37,12 +37,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_max32680.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_max32680.c
@@ -36,12 +36,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_riscv_max32680.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_riscv_max32680.c
@@ -38,12 +38,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_max32690.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_max32690.c
@@ -36,12 +36,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_riscv_max32690.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_riscv_max32690.c
@@ -33,12 +33,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_max78000.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_max78000.c
@@ -36,12 +36,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_riscv_max78000.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_riscv_max78000.c
@@ -33,12 +33,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_max78002.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_max78002.c
@@ -35,12 +35,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_riscv_max78002.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_riscv_max78002.c
@@ -33,12 +33,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }


### PR DESCRIPTION
This PR updates requires to peripheral drivers being used on zephyr side.
There are two commits one for MAX32662 being build, second for building zephyr with newlib.

MAX32662 build issue
![image](https://github.com/analogdevicesinc/msdk/assets/46590392/ee94255c-25b6-41b1-a579-811d1521ddc3)

Newlib buld issue: https://github.com/zephyrproject-rtos/zephyr/issues/73606
```
[168/173] Linking CXX executable zephyr/zephyr_pre0.elf
FAILED: zephyr/zephyr_pre0.elf zephyr/zephyr_pre0.map /Users/luisubieda/zephyrproject/zephyr/twister-out/max32690evkit_max32690_m4/tests/lib/cpp/cxx/cpp.main.newlib/zephyr/zephyr_pre0.map 
: && ccache /Users/luisubieda/zephyr-sdk-0.16.5-1/arm-zephyr-eabi/bin/arm-zephyr-eabi-g++  -gdwarf-4 zephyr/CMakeFiles/zephyr_pre0.dir/misc/empty_file.c.obj -o zephyr/zephyr_pre0.elf  zephyr/CMakeFiles/offsets.dir/./arch/arm/core/offsets/offsets.c.obj  -fuse-ld=bfd  -T  zephyr/linker_zephyr_pre0.cmd  -Wl,-Map=/Users/luisubieda/zephyrproject/zephyr/twister-out/max32690evkit_max32690_m4/tests/lib/cpp/cxx/cpp.main.newlib/zephyr/zephyr_pre0.map  -Wl,--whole-archive  app/libapp.a  zephyr/libzephyr.a  zephyr/arch/common/libarch__common.a  zephyr/arch/arch/arm/core/libarch__arm__core.a  zephyr/arch/arch/arm/core/cortex_m/libarch__arm__core__cortex_m.a  zephyr/lib/libc/newlib/liblib__libc__newlib.a  zephyr/lib/libc/common/liblib__libc__common.a  zephyr/subsys/rtio/libsubsys__rtio.a  zephyr/subsys/testsuite/ztest/libsubsys__testsuite__ztest.a  zephyr/subsys/net/libsubsys__net.a  zephyr/drivers/clock_control/libdrivers__clock_control.a  zephyr/drivers/console/libdrivers__console.a  zephyr/drivers/gpio/libdrivers__gpio.a  zephyr/drivers/pinctrl/libdrivers__pinctrl.a  zephyr/drivers/serial/libdrivers__serial.a  zephyr/drivers/timer/libdrivers__timer.a  -Wl,--no-whole-archive  zephyr/kernel/libkernel.a  -L"/Users/luisubieda/zephyr-sdk-0.16.5-1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/thumb/v7e-m/nofp"  -L/Users/luisubieda/zephyrproject/zephyr/twister-out/max32690evkit_max32690_m4/tests/lib/cpp/cxx/cpp.main.newlib/zephyr  -lgcc  zephyr/arch/common/libisr_tables.a  -Wl,--fatal-warnings  -mcpu=cortex-m4  -mthumb  -mabi=aapcs  -mfp16-format=ieee  -Wl,--gc-sections  -Wl,--build-id=none  -Wl,--sort-common=descending  -Wl,--sort-section=alignment  -Wl,-u,_OffsetAbsSyms  -Wl,-u,_ConfigAbsSyms  -nostdlib  -static  -Wl,-X  -Wl,-N  -Wl,--orphan-handling=warn  -Wl,-no-pie  -lm  -Wl,-lc  -L"/Users/luisubieda/zephyr-sdk-0.16.5-1/arm-zephyr-eabi/arm-zephyr-eabi"/lib/thumb/v7e-m/nofp  -Wl,-lgcc  -lc && cd /Users/luisubieda/zephyrproject/zephyr/twister-out/max32690evkit_max32690_m4/tests/lib/cpp/cxx/cpp.main.newlib/zephyr && /opt/homebrew/Cellar/cmake/3.25.1/bin/cmake -E true
/Users/luisubieda/zephyr-sdk-0.16.5-1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/lib/libc/newlib/liblib__libc__newlib.a(libc-hooks.c.obj): in function `_kill':
/Users/luisubieda/zephyrproject/zephyr/lib/libc/newlib/libc-hooks.c:261: multiple definition of `_kill'; zephyr/libzephyr.a(system_max32690.c.obj):/Users/luisubieda/zephyrproject/modules/hal/adi/MAX/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_max32690.c:44: first defined here
/Users/luisubieda/zephyr-sdk-0.16.5-1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/lib/libc/newlib/liblib__libc__newlib.a(libc-hooks.c.obj): in function `_getpid':
/Users/luisubieda/zephyrproject/zephyr/lib/libc/newlib/libc-hooks.c:267: multiple definition of `_getpid'; zephyr/libzephyr.a(system_max32690.c.obj):/Users/luisubieda/zephyrproject/modules/hal/adi/MAX/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_max32690.c:42: first defined here
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
