### PR TITLE
chore(Other): Add a function in wrap_uart

### DIFF
--- a/Libraries/zephyr/MAX/Include/wrap_max32_uart.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_uart.h
@@ -213,6 +213,15 @@ static inline void Wrap_MXC_UART_DisableRxDMA(mxc_uart_regs_t *uart)
 
 #endif // defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655)
 
+static inline unsigned int Wrap_MXC_UART_GetRegINTEN(mxc_uart_regs_t *uart)
+{
+#if defined(CONFIG_SOC_MAX32662)
+    return uart->inten;
+#else
+    return uart->int_en;
+#endif
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Interrupt status need to be checked on zephyr side, to provide common interface we need a wrapper function due to MAX32662 int_en register named as inten.

Wrap_MXC_UART_GetRegINTEN function added.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
