### PR TITLE
fix(BLE): Compiling PAL with interrupt handlers.

### DIFF
--- a/Libraries/Cordio/platform/targets/maxim/build/cordio.mk
+++ b/Libraries/Cordio/platform/targets/maxim/build/cordio.mk
@@ -123,9 +123,12 @@ APP_BUILD_C_FILES += ${ROOT_DIR}/controller/sources/ble/init/init.c
 endif
 
 # Remove these files from the library build, board level dependencies. Will have to be
-# re-built for each application
+# re-built for each application. Remove files that have interrupt handlers.
+# This will prevent weak handlers from being overwritten by the weak handlers in the startup file.
 APP_BUILD_C_FILES += ${ROOT_DIR}/platform/targets/maxim/${CHIP_LC}/sources/pal_uart.c
 APP_BUILD_C_FILES += ${ROOT_DIR}/platform/targets/maxim/${CHIP_LC}/sources/pal_sys.c
+APP_BUILD_C_FILES += ${ROOT_DIR}/platform/targets/maxim/${CHIP_LC}/sources/pal_rtc.c
+APP_BUILD_C_FILES += ${ROOT_DIR}/platform/targets/maxim/${CHIP_LC}/sources/pal_timer.c
 
 # This will let us enable/disable trace messaging by application
 APP_BUILD_C_FILES += ${ROOT_DIR}/wsf/sources/targets/${RTOS}/wsf_trace.c

--- a/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_rtc.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_rtc.c
@@ -61,14 +61,14 @@ static struct {
  *  \return None.
  */
 /*************************************************************************************************/
-__attribute__ ((weak)) void WUT_IRQHandler(void)
+__attribute__ ((weak)) void WUT0_IRQHandler(void)
 {
   PalLedOn(PAL_LED_ID_CPU_ACTIVE);
 #ifndef __riscv
-  MXC_WUT_IntClear(MXC_WUT);
+  MXC_WUT_IntClear(MXC_WUT0);
 #endif
 
-  NVIC_ClearPendingIRQ(WUT_IRQn);
+  NVIC_ClearPendingIRQ(WUT0_IRQn);
 }
 
 /*************************************************************************************************/
@@ -95,7 +95,7 @@ void PalRtcCompareSet(uint8_t channelId, uint32_t value)
 {
   PAL_SYS_ASSERT(channelId == 0);
 
-  MXC_WUT_SetCompare(MXC_WUT, value);
+  MXC_WUT_SetCompare(MXC_WUT0, value);
 }
 
 /*************************************************************************************************/
@@ -110,15 +110,15 @@ void PalRtcInit(void)
   cfg.mode = MXC_WUT_MODE_COMPARE;
   cfg.cmp_cnt = PAL_MAX_RTC_COUNTER_VAL;
 
-  MXC_WUT_Init(MXC_WUT, MXC_WUT_PRES_1);
-  MXC_WUT_Config(MXC_WUT, &cfg);
+  MXC_WUT_Init(MXC_WUT0, MXC_WUT_PRES_1);
+  MXC_WUT_Config(MXC_WUT0, &cfg);
   MXC_LP_EnableWUTAlarmWakeup();
 
-  NVIC_ClearPendingIRQ(WUT_IRQn);
-  NVIC_EnableIRQ(WUT_IRQn);
+  NVIC_ClearPendingIRQ(WUT0_IRQn);
+  NVIC_EnableIRQ(WUT0_IRQn);
 
   /* Enable WUT */
-  MXC_WUT_Enable(MXC_WUT);
+  MXC_WUT_Enable(MXC_WUT0);
 
   palRtcCb.state = PAL_RTC_STATE_READY;
 }
@@ -135,7 +135,7 @@ void PalRtcInit(void)
 /*************************************************************************************************/
 uint32_t PalRtcCounterGet(void)
 {
-  uint32_t count = MXC_WUT_GetCount(MXC_WUT);
+  uint32_t count = MXC_WUT_GetCount(MXC_WUT0);
 
   return count;
 }
@@ -150,7 +150,7 @@ uint32_t PalRtcCounterGet(void)
 void PalRtcEnableCompareIrq(uint8_t channelId)
 {
   PAL_SYS_ASSERT(channelId == 0);
-  NVIC_EnableIRQ(WUT_IRQn);
+  NVIC_EnableIRQ(WUT0_IRQn);
 }
 
 /*************************************************************************************************/
@@ -163,5 +163,5 @@ void PalRtcEnableCompareIrq(uint8_t channelId)
 void PalRtcDisableCompareIrq(uint8_t channelId)
 {
   PAL_SYS_ASSERT(channelId == 0);
-  NVIC_DisableIRQ(WUT_IRQn);
+  NVIC_DisableIRQ(WUT0_IRQn);
 }


### PR DESCRIPTION
This will cause the files that have interrupt handlers to be compiled for every application instead of into the Cordio library. We need to make sure that these objects are linked before the startup.S files so the weak interrupt handlers in the C code is used instead of in the startup file.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
