### PR TITLE
fix(PeriphDrivers): Fix SDHC Peripheral Failure for Alternative System Clocks

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32650/Include/system_max32650.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32650/Include/system_max32650.h
@@ -46,8 +46,8 @@ extern "C" {
 #define NANORING_FREQ 8000
 #endif
 
-#ifndef HIRC120_FREQ
-#define HIRC120_FREQ 120000000
+#ifndef HIRC96_FREQ
+#define HIRC96_FREQ 120000000
 #endif
 
 #ifndef HIRC8_FREQ

--- a/Libraries/CMSIS/Device/Maxim/MAX32650/Include/system_max32650.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32650/Include/system_max32650.h
@@ -46,8 +46,8 @@ extern "C" {
 #define NANORING_FREQ 8000
 #endif
 
-#ifndef HIRC96_FREQ
-#define HIRC96_FREQ 120000000
+#ifndef HIRC120_FREQ
+#define HIRC120_FREQ 120000000
 #endif
 
 #ifndef HIRC8_FREQ

--- a/Libraries/PeriphDrivers/Source/SDHC/sdhc_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SDHC/sdhc_ai87.c
@@ -68,17 +68,17 @@ int MXC_SDHC_Init(const mxc_sdhc_cfg_t *cfg)
 unsigned int MXC_SDHC_Get_Input_Clock_Freq(void)
 {
     // Figure 4-1 of the preliminary AI85 UG (04/01/2022) shows the SDHC hardware block
-    // connected directly to the SYS_CLK node.  This is most likely inaccurate, but the
+    // connected directly to the IPO Clock node.  This is most likely inaccurate, but the
     // register description for MXC_GCR->pclkdiv marks the usual SDHC divider as reserved.
     // We will follow figure 4-1 for now.
 
     if (MXC_GCR->pclkdiv & MXC_F_GCR_PCLKDIS1_SDHC) {
-        return SystemCoreClock >> 2; // Div by 4
+        return IPO_FREQ >> 2; // Div by 4
     } else {
-        return SystemCoreClock >> 1; // Div by 2
+        return IPO_FREQ >> 1; // Div by 2
     }
 
-    return SystemCoreClock;
+    return IPO_FREQ;
 }
 
 /* ************************************************************************** */

--- a/Libraries/PeriphDrivers/Source/SDHC/sdhc_me10.c
+++ b/Libraries/PeriphDrivers/Source/SDHC/sdhc_me10.c
@@ -85,9 +85,9 @@ unsigned int MXC_SDHC_Get_Clock_Config(void)
 unsigned int MXC_SDHC_Get_Input_Clock_Freq(void)
 {
     if (MXC_GCR->pclk_div & MXC_F_GCR_PCLK_DIV_SDHCFRQ) {
-        return SystemCoreClock >> 1; // Div by 2
+        return HIRC120_FREQ >> 1; // Div by 2
     } else {
-        return 50000000; // UG specifies a hard-coded 50Mhz value in this case
+        return CRYPTO_FREQ_A3; // UG specifies a hard-coded 50Mhz low-power oscillator
     }
 }
 

--- a/Libraries/PeriphDrivers/Source/SDHC/sdhc_me10.c
+++ b/Libraries/PeriphDrivers/Source/SDHC/sdhc_me10.c
@@ -85,9 +85,9 @@ unsigned int MXC_SDHC_Get_Clock_Config(void)
 unsigned int MXC_SDHC_Get_Input_Clock_Freq(void)
 {
     if (MXC_GCR->pclk_div & MXC_F_GCR_PCLK_DIV_SDHCFRQ) {
-        return HIRC120_FREQ >> 1; // Div by 2
+        return HIRC96_FREQ >> 1; // Div by 2
     } else {
-        return CRYPTO_FREQ_A3; // UG specifies a hard-coded 50Mhz low-power oscillator
+        return 50000000; // UG specifies a hard-coded 50Mhz low-power oscillator
     }
 }
 

--- a/Libraries/PeriphDrivers/Source/SDHC/sdhc_me13.c
+++ b/Libraries/PeriphDrivers/Source/SDHC/sdhc_me13.c
@@ -68,9 +68,9 @@ unsigned int MXC_SDHC_Get_Input_Clock_Freq(void)
 {
     // TODO(JC): Confirm this is the scheme used by ME13
     if (MXC_GCR->pclkdiv & MXC_F_GCR_PCLKDIV_SDHCFRQ) {
-        return SystemCoreClock >> 2; // Div by 4
+        return IPO_FREQ >> 2; // Div by 4
     } else {
-        return SystemCoreClock >> 1; // Div by 2
+        return IPO_FREQ >> 1; // Div by 2
     }
 }
 

--- a/Libraries/PeriphDrivers/Source/SDHC/sdhc_me14.c
+++ b/Libraries/PeriphDrivers/Source/SDHC/sdhc_me14.c
@@ -68,9 +68,9 @@ int MXC_SDHC_Init(const mxc_sdhc_cfg_t *cfg)
 unsigned int MXC_SDHC_Get_Input_Clock_Freq(void)
 {
     if (MXC_GCR->pckdiv & MXC_F_GCR_PCKDIV_SDHCFRQ) {
-        return SystemCoreClock >> 2; // Div by 4
+        return HIRC96_FREQ >> 2; // Div by 4
     } else {
-        return SystemCoreClock >> 1; // Div by 2
+        return HIRC96_FREQ >> 1; // Div by 2
     }
 }
 


### PR DESCRIPTION
### Description

According to the UG, SDHC peripheral is driven by always 96 MHz. Therefore, using System clock in the function MXC_SDHC_Get_Input_Clock_Freq results failure in SDHC peripheral when SytemClock is configured other than 96 MHz. Moreover, according to the UG the SDHC is driven by the 96 MHz Internal High-Speed Oscillator. Similar situations occur for ME10, ME13 and AI87 and commits relating to these MCUs will be pushed after this commit, discussions and related tests.
