### PR TITLE
fix(PeriphDrivers): MAX32657 does not support VSEL

### DIFF
--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me30.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me30.c
@@ -87,12 +87,6 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
         return E_NO_ERROR;
     }
 
-    // Configure the vssel
-    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
-    if (error != E_NO_ERROR) {
-        return error;
-    }
-
     // Configure alternate function
     error = MXC_GPIO_RevA_SetAF((mxc_gpio_reva_regs_t *)gpio, cfg->func, cfg->mask);
     if (error != E_NO_ERROR) {
@@ -224,7 +218,7 @@ uint32_t MXC_GPIO_GetFlags(mxc_gpio_regs_t *port)
 /* ************************************************************************** */
 int MXC_GPIO_SetVSSEL(mxc_gpio_regs_t *port, mxc_gpio_vssel_t vssel, uint32_t mask)
 {
-    return MXC_GPIO_RevA_SetVSSEL((mxc_gpio_reva_regs_t *)port, vssel, mask);
+    return E_NOT_SUPPORTED;
 }
 
 /* ************************************************************************** */


### PR DESCRIPTION
MAX32657: Does not support VSEL selection

![image](https://github.com/analogdevicesinc/msdk/assets/46590392/cbd84bdc-39d1-4376-8dda-f8f65e3256bd)


### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
