### PR TITLE
fix(PeriphDrivers): MXC_SYS_GetUSN Checksum error

### DIFF
--- a/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_cfg.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_cfg.c
@@ -185,8 +185,8 @@ void palCfgLoadLlParams(uint8_t *pConfig)
 /*************************************************************************************************/
 void palCfgLoadBdAddress(uint8_t *pDevAddr)
 {
-  uint8_t id[MXC_SYS_USN_CHECKSUM_LEN];
-  uint8_t checksum[MXC_SYS_USN_CHECKSUM_LEN];
+  uint8_t id[MXC_SYS_USN_LEN] = {0};
+  uint8_t checksum[MXC_SYS_USN_CHECKSUM_LEN] = {0};
 
   if(MXC_SYS_GetUSN((uint8_t*)id, (uint8_t*)checksum) != E_NO_ERROR) {
     PalSysAssertTrap();

--- a/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_cfg.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_cfg.c
@@ -185,8 +185,8 @@ void palCfgLoadLlParams(uint8_t *pConfig)
 /*************************************************************************************************/
 void palCfgLoadBdAddress(uint8_t *pDevAddr)
 {
-  uint8_t id[MXC_SYS_USN_CHECKSUM_LEN];
-  uint8_t checksum[MXC_SYS_USN_CHECKSUM_LEN];
+  uint8_t id[MXC_SYS_USN_LEN] = {0};
+  uint8_t checksum[MXC_SYS_USN_CHECKSUM_LEN] = {0};
 
   if(MXC_SYS_GetUSN(id, checksum) != E_NO_ERROR) {
     PalSysAssertTrap();	

--- a/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_cfg.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_cfg.c
@@ -185,8 +185,8 @@ void palCfgLoadLlParams(uint8_t *pConfig)
 /*************************************************************************************************/
 void palCfgLoadBdAddress(uint8_t *pDevAddr)
 {
-  uint8_t id[MXC_SYS_USN_CHECKSUM_LEN];
-  uint8_t checksum[MXC_SYS_USN_CHECKSUM_LEN];
+  uint8_t id[MXC_SYS_USN_LEN] = {0};
+  uint8_t checksum[MXC_SYS_USN_CHECKSUM_LEN] = {0};
 
   if(MXC_SYS_GetUSN((uint8_t*)id, (uint8_t*)checksum) != E_NO_ERROR) {
     PalSysAssertTrap();

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
@@ -103,10 +103,12 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         // Set NULL Key
         MXC_AES_SetExtKey((const void *)aes_key, MXC_AES_128BITS);
 
+        uint8_t usn_copy[MXC_SYS_USN_LEN] = {0}; 
+        memcpy(usn_copy, usn, MXC_SYS_USN_LEN);
         // Compute Checksum
         mxc_aes_req_t aes_req;
         aes_req.length = MXC_SYS_USN_CHECKSUM_LEN / 4;
-        aes_req.inputData = (uint32_t *)usn;
+        aes_req.inputData = (uint32_t *)usn_copy;
         aes_req.resultData = (uint32_t *)check_csum;
         aes_req.keySize = MXC_AES_128BITS;
         aes_req.encryption = MXC_AES_ENCRYPT_EXT_KEY;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
@@ -103,7 +103,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         // Set NULL Key
         MXC_AES_SetExtKey((const void *)aes_key, MXC_AES_128BITS);
 
-        uint8_t usn_copy[MXC_SYS_USN_LEN] = {0}; 
+        uint8_t usn_copy[MXC_SYS_USN_LEN] = { 0 };
         memcpy(usn_copy, usn, MXC_SYS_USN_LEN);
         // Compute Checksum
         mxc_aes_req_t aes_req;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
@@ -110,10 +110,13 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         // Set NULL Key
         MXC_AES_SetExtKey((const void *)aes_key, MXC_AES_128BITS);
 
+        uint8_t usn_copy[MXC_SYS_USN_LEN] = {0}; 
+        memcpy(usn_copy, usn, MXC_SYS_USN_LEN);
+        
         // Compute Checksum
         mxc_aes_req_t aes_req;
         aes_req.length = MXC_SYS_USN_CHECKSUM_LEN / 4;
-        aes_req.inputData = (uint32_t *)usn;
+        aes_req.inputData = (uint32_t *)usn_copy;
         aes_req.resultData = (uint32_t *)check_csum;
         aes_req.keySize = MXC_AES_128BITS;
         aes_req.encryption = MXC_AES_ENCRYPT_EXT_KEY;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
@@ -110,9 +110,9 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         // Set NULL Key
         MXC_AES_SetExtKey((const void *)aes_key, MXC_AES_128BITS);
 
-        uint8_t usn_copy[MXC_SYS_USN_LEN] = {0}; 
+        uint8_t usn_copy[MXC_SYS_USN_LEN] = { 0 };
         memcpy(usn_copy, usn, MXC_SYS_USN_LEN);
-        
+
         // Compute Checksum
         mxc_aes_req_t aes_req;
         aes_req.length = MXC_SYS_USN_CHECKSUM_LEN / 4;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
@@ -105,9 +105,9 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         // Set NULL Key
         MXC_AES_SetExtKey((const void *)aes_key, MXC_AES_128BITS);
 
-        uint8_t usn_copy[MXC_SYS_USN_LEN] = {0}; 
+        uint8_t usn_copy[MXC_SYS_USN_LEN] = { 0 };
         memcpy(usn_copy, usn, MXC_SYS_USN_LEN);
-        
+
         // Compute Checksum
         mxc_aes_req_t aes_req;
         aes_req.length = MXC_SYS_USN_CHECKSUM_LEN / 4;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
@@ -105,10 +105,13 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         // Set NULL Key
         MXC_AES_SetExtKey((const void *)aes_key, MXC_AES_128BITS);
 
+        uint8_t usn_copy[MXC_SYS_USN_LEN] = {0}; 
+        memcpy(usn_copy, usn, MXC_SYS_USN_LEN);
+        
         // Compute Checksum
         mxc_aes_req_t aes_req;
         aes_req.length = MXC_SYS_USN_CHECKSUM_LEN / 4;
-        aes_req.inputData = (uint32_t *)usn;
+        aes_req.inputData = (uint32_t *)usn_copy;
         aes_req.resultData = (uint32_t *)check_csum;
         aes_req.keySize = MXC_AES_128BITS;
         aes_req.encryption = MXC_AES_ENCRYPT_EXT_KEY;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
@@ -97,9 +97,9 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         /* Initialize key and plaintext */
         memset(key, 0, MXC_SYS_USN_CHECKSUM_LEN);
         memset(pt32, 0, MXC_SYS_USN_CHECKSUM_LEN);
-        memcpy(pt32, usn, MXC_SYS_USN_CHECKSUM_LEN);
+        memcpy(pt32, usn, MXC_SYS_USN_LEN);
 
-        /* Read the checksum from the info block */
+        /* Read the checksum from the inspfo block */
         checksum[1] = ((infoblock[3] & 0x7F800000) >> 23);
         checksum[0] = ((infoblock[4] & 0x007F8000) >> 15);
 

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
@@ -102,10 +102,13 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         // Set NULL Key
         MXC_AES_SetExtKey((const void *)aes_key, MXC_AES_128BITS);
 
+        uint8_t usn_copy[MXC_SYS_USN_LEN] = {0}; 
+        memcpy(usn_copy, usn, MXC_SYS_USN_LEN);
+
         // Compute Checksum
         mxc_aes_req_t aes_req;
         aes_req.length = MXC_SYS_USN_CHECKSUM_LEN / 4;
-        aes_req.inputData = (uint32_t *)usn;
+        aes_req.inputData = (uint32_t *)usn_copy;
         aes_req.resultData = (uint32_t *)check_csum;
         aes_req.keySize = MXC_AES_128BITS;
         aes_req.encryption = MXC_AES_ENCRYPT_EXT_KEY;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
@@ -102,7 +102,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         // Set NULL Key
         MXC_AES_SetExtKey((const void *)aes_key, MXC_AES_128BITS);
 
-        uint8_t usn_copy[MXC_SYS_USN_LEN] = {0}; 
+        uint8_t usn_copy[MXC_SYS_USN_LEN] = { 0 };
         memcpy(usn_copy, usn, MXC_SYS_USN_LEN);
 
         // Compute Checksum


### PR DESCRIPTION
## Pull Request Template

### Description
For some MCUs, the ``MXC_SYS_GetUSN`` function used the AES peripheral to calculate the checksum. 
#1016 Addresses an issue with the possibility of an unbounded memory access. The ``MXC_SYS_GetUSN`` function now only copies and clears the 13 bytes of the USN. However, the checksum is calculated using the USN checksum length not the USN length, so the CRC was calculated using the correct 13 bytes of the USN plus 3 uninitialized bytes causing checksum errors. This patch fixes this issue.