### PR TITLE
feat(Other): Enable building zephyr for risc-v targets

### DIFF
--- a/Libraries/zephyr/MAX/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/CMakeLists.txt
@@ -40,6 +40,7 @@ set(MSDK_PERIPH_INC_DIR  ${MSDK_PERIPH_DIR}/Include/${TARGET_UC})
 
 zephyr_include_directories(
     ./Include
+    ${MSDK_LIBRARY_DIR}/CMSIS/Include
     ${MSDK_CMSIS_DIR}/Include
     ${MSDK_PERIPH_INC_DIR}
 )

--- a/Libraries/zephyr/MAX/Source/MAX32655/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32655/CMakeLists.txt
@@ -48,14 +48,18 @@ zephyr_include_directories(
     ${MSDK_PERIPH_SRC_DIR}/WUT
 )
 
+if(CONFIG_ARM)
+  zephyr_library_sources(${MSDK_CMSIS_DIR}/Source/system_max32655.c)
+  zephyr_library_sources(${MSDK_PERIPH_SRC_DIR}/SYS/mxc_lock.c)
+elseif(CONFIG_RISCV)
+  zephyr_library_sources(${MSDK_CMSIS_DIR}/Source/system_riscv_max32655.c)
+endif()
+
 zephyr_library_sources(
     ./max32xxx_system.c
 
-    ${MSDK_CMSIS_DIR}/Source/system_max32655.c
-
     ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_assert.c
     ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_delay.c
-    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_lock.c
     ${MSDK_PERIPH_SRC_DIR}/SYS/pins_me17.c
     ${MSDK_PERIPH_SRC_DIR}/SYS/sys_me17.c
      

--- a/Libraries/zephyr/MAX/Source/MAX32680/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32680/CMakeLists.txt
@@ -48,14 +48,18 @@ zephyr_include_directories(
     ${MSDK_PERIPH_SRC_DIR}/WUT
 )
 
+if(CONFIG_ARM)
+  zephyr_library_sources(${MSDK_CMSIS_DIR}/Source/system_max32680.c)
+  zephyr_library_sources(${MSDK_PERIPH_SRC_DIR}/SYS/mxc_lock.c)
+elseif(CONFIG_RISCV)
+  zephyr_library_sources(${MSDK_CMSIS_DIR}/Source/system_riscv_max32680.c)
+endif()
+
 zephyr_library_sources(
     ./max32xxx_system.c
 
-    ${MSDK_CMSIS_DIR}/Source/system_max32680.c
-
     ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_assert.c
     ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_delay.c
-    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_lock.c
     ${MSDK_PERIPH_SRC_DIR}/SYS/pins_me20.c
     ${MSDK_PERIPH_SRC_DIR}/SYS/sys_me17.c
 

--- a/Libraries/zephyr/MAX/Source/MAX32690/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32690/CMakeLists.txt
@@ -51,14 +51,18 @@ zephyr_include_directories(
     ${MSDK_PERIPH_SRC_DIR}/WUT
 )
 
+if(CONFIG_ARM)
+  zephyr_library_sources(${MSDK_CMSIS_DIR}/Source/system_max32690.c)
+  zephyr_library_sources(${MSDK_PERIPH_SRC_DIR}/SYS/mxc_lock.c)
+elseif(CONFIG_RISCV)
+  zephyr_library_sources(${MSDK_CMSIS_DIR}/Source/system_riscv_max32690.c)
+endif()
+
 zephyr_library_sources(
     ./max32xxx_system.c
 
-    ${MSDK_CMSIS_DIR}/Source/system_max32690.c
-
     ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_assert.c
     ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_delay.c
-    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_lock.c
     ${MSDK_PERIPH_SRC_DIR}/SYS/pins_me18.c
     ${MSDK_PERIPH_SRC_DIR}/SYS/sys_me18.c
     


### PR DESCRIPTION
Configures the zephyr build system to use the appropriate cmsis system startup and peripheral driver sources based on the target core architecture. The mxc lock driver is not implemented for risc-v and emits a build warning (which twister promotes to an error), therefore the zephyr build system is configured to build it only for arm.

Before this patch, we could only build zephyr for arm targets, but now we can build zephyr for arm or risc-v targets.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
