### PR TITLE
perf(Other): Use FreeRTOS Heap Allocation Scheme 4, Allow Changing FreeRTOS Heap Allocation Scheme 

### DIFF
--- a/Examples/MAX78000/FreeRTOSDemo/project.mk
+++ b/Examples/MAX78000/FreeRTOSDemo/project.mk
@@ -16,6 +16,11 @@ DEBUG=1
 
 LIB_FREERTOS = 1
 
+# Can provide a value for the FREERTOS heap allocation scheme
+# Default value is 4
+# FREERTOS_HEAP_TYPE := 2
+# export FREERTOS_HEAP_TYPE
+
 ifeq ($(BOARD),Aud01_RevA)
 $(error ERR_NOTSUPPORTED: This project is not supported for the Audio board)
 endif

--- a/Libraries/FreeRTOS/Makefile
+++ b/Libraries/FreeRTOS/Makefile
@@ -67,6 +67,8 @@ else ifeq ($(FREERTOS_HEAP_TYPE), 4)
 SRCS += heap_4.c
 else ifeq ($(FREERTOS_HEAP_TYPE), 5)  
 SRCS += heap_5.c
+else 
+$(error FREERTOS_HEAP_TYPE must be between 1-5. Default: 4)
 endif
 
 # Where to find source files for this project

--- a/Libraries/FreeRTOS/Makefile
+++ b/Libraries/FreeRTOS/Makefile
@@ -48,11 +48,26 @@ SRCS  = list.c
 SRCS += queue.c
 SRCS += tasks.c
 SRCS += port.c
-SRCS += heap_2.c
 SRCS += timers.c
 SRCS += croutine.c
 SRCS += event_groups.c
 SRCS += stream_buffer.c
+
+# Setup a default heap allocation mechanism
+# Default val is 4, which is recommended to best avoid heap fragmentation 
+FREERTOS_HEAP_TYPE ?= 4
+
+ifeq ($(FREERTOS_HEAP_TYPE), 1) 
+SRCS += heap_1.c
+else ifeq ($(FREERTOS_HEAP_TYPE), 2) 
+SRCS += heap_2.c
+else ifeq ($(FREERTOS_HEAP_TYPE), 3)  
+SRCS += heap_3.c
+else ifeq ($(FREERTOS_HEAP_TYPE), 4)  
+SRCS += heap_4.c
+else ifeq ($(FREERTOS_HEAP_TYPE), 5)  
+SRCS += heap_5.c
+endif
 
 # Where to find source files for this project
 VPATH  = Source/portable/GCC/ARM_CM4F

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -2212,6 +2212,12 @@ Once enabled, the following [build configuration variables](#build-configuration
 
 FreeRTOS is supported by all parts in the MSDK.  See the `FreeRTOSDemo` example application.
 
+#### FreeRTOS Build Variables
+
+| Configuration Variable | Description                                                | Details                                                      |
+| ---------------------- | ---------------------------------------------------------- | ------------------------------------------------------------ |
+| `FREERTOS_HEAP_TYPE`            | Specify the method of heap allocation to use for the FreeRTOS API | FreeRTOS provides options for the heap management alogirthms to optimize for memory size, speed, and risk of heap fragmentation. For more details, visit the [FreeRTOS MemMang Docs](https://www.freertos.org/a00111.html).  Acceptable values are `1`, `2`, `3`, `4`, or `5`. The default value is `4` for heap_4. |
+
 #### FreeRTOS-Plus
 
 [FreeRTOS-Plus](https://www.freertos.org/FreeRTOS-Plus/index.html) is an additional library that implements addon functionality for the FreeRTOS kernel.  The MSDK maintains support for some, but not all, available addons.


### PR DESCRIPTION
### Description

FreeRTOS gives some flexibility in the memory allocation scheme used to allow optimizing size/speed/heap fragmentation risk. The FreeRTOS documentation indicates that _heap_2.c is considered outdated_, and that _applications should at a minimum use heap_4 as an alternative_. Heap 4 uses a smarter allocation algorithm for avoiding heap fragmentation (first-fit algorithm + aggregates free RAM segments). 

Sources for info: 
https://www.freertos.org/a00111.html
https://github.com/FreeRTOS/FreeRTOS-Kernel-Book/blob/main/ch03.md

#### Summary of Changes
- Changed default FreeRTOS heap allocation to heap_4.c -heap_4 is recommended by FreeRTOS as an updated alternate to heap_2 for avoiding heap fragmentation 
- Added **FREERTOS_HEAP_TYPE** compile time macro to select the heap allocation method 
  - Default value is 4, but can be 1-5. Error message is included if invalid input is given. 
- Added an entry for FREERTOS_HEAP_TYPE in MAX78000's FreeRTOSDemo project.mk

This would (positively) affect the way FreeRTOS builds for all supported MCUs. 

#### Tests
Tested library builds with all 5 different heap types using FreeRTOSDemo for MAX78000 as the test source code. Example builds with the appropriate heap files based on the new FREERTOS_HEAP_TYPE macro. If the macro is not defined in project.mk, the library builds with heap_4.c by default. 

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

