### PR TITLE
fix(PeriphDrivers): Resolve incorrect DMA request in DMA-based SPI transactions for all parts

### DIFF
--- a/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
@@ -405,13 +405,13 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
 
     switch (spi_num) {
     case 0:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     default:
@@ -444,13 +444,13 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
 
     switch (spi_num) {
     case 0:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     default:

--- a/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
@@ -453,36 +453,32 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-            break;
-        }
+    default:
+        return E_BAD_PARAM;
+        break;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-            break;
-        }
+    default:
+        return E_BAD_PARAM;
+        break;
     }
 
     return MXC_SPI_RevA1_SlaveTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
@@ -403,34 +403,30 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_SPI_RevA1_MasterTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
@@ -445,23 +445,11 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-        break;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
@@ -406,22 +406,11 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_es17.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_es17.c
@@ -303,34 +303,30 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_SPI_RevA1_SlaveTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_es17.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_es17.c
@@ -252,35 +252,31 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
     //tx
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_SPI_RevA1_MasterTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_es17.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_es17.c
@@ -294,22 +294,11 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_es17.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_es17.c
@@ -255,23 +255,11 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    //tx
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
@@ -250,34 +250,30 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPIMSSTX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPIMSSTX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPIMSSRX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPIMSSRX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_SPI_RevA1_MasterTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
@@ -253,22 +253,11 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPIMSSTX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPIMSSTX;
         reqselTx = MXC_DMA_REQUEST_SPIMSSRX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
@@ -300,34 +300,30 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPIMSSTX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPIMSSTX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPIMSSRX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPIMSSRX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_SPI_RevA1_SlaveTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
@@ -258,7 +258,7 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
 
     case 1:
         reqselTx = MXC_DMA_REQUEST_SPIMSSTX;
-        reqselTx = MXC_DMA_REQUEST_SPIMSSRX;
+        reqselRx = MXC_DMA_REQUEST_SPIMSSRX;
         break;
 
     default:

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
@@ -292,22 +292,11 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPIMSSTX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPIMSSTX;
         reqselRx = MXC_DMA_REQUEST_SPIMSSRX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
@@ -400,13 +400,13 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
 
     switch (spi_num) {
     case 0:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     default:

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
@@ -362,22 +362,11 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
@@ -409,36 +409,32 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-            break;
-        }
+    default:
+        return E_BAD_PARAM;
+        break;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-            break;
-        }
+    default:
+        return E_BAD_PARAM;
+        break;
     }
 
     return MXC_SPI_RevA1_SlaveTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
@@ -401,23 +401,11 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-        break;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
@@ -359,34 +359,30 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_SPI_RevA1_MasterTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me13.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me13.c
@@ -283,42 +283,38 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 2:
-            reqselTx = MXC_DMA_REQUEST_SPI2TX;
-            break;
+    case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        case 2:
-            reqselRx = MXC_DMA_REQUEST_SPI2RX;
-            break;
+    case 2:
+        reqselRx = MXC_DMA_REQUEST_SPI2RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_SPI_RevA1_MasterTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me13.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me13.c
@@ -286,30 +286,16 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    case 2:
-        reqselTx = MXC_DMA_REQUEST_SPI2TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
         reqselRx = MXC_DMA_REQUEST_SPI2RX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me13.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me13.c
@@ -329,30 +329,16 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    case 2:
-        reqselTx = MXC_DMA_REQUEST_SPI2TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
         reqselRx = MXC_DMA_REQUEST_SPI2RX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me13.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me13.c
@@ -340,42 +340,38 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 2:
-            reqselTx = MXC_DMA_REQUEST_SPI2TX;
-            break;
+    case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        case 2:
-            reqselRx = MXC_DMA_REQUEST_SPI2RX;
-            break;
+    case 2:
+        reqselRx = MXC_DMA_REQUEST_SPI2RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_SPI_RevA1_SlaveTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
@@ -409,42 +409,38 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req, mxc_dma_regs_t *dma)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 2:
-            reqselTx = MXC_DMA_REQUEST_SPI2TX;
-            break;
+    case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        case 2:
-            reqselRx = MXC_DMA_REQUEST_SPI2RX;
-            break;
+    case 2:
+        reqselRx = MXC_DMA_REQUEST_SPI2RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_SPI_RevA1_SlaveTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx, dma);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
@@ -348,42 +348,38 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req, mxc_dma_regs_t *dma)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 2:
-            reqselTx = MXC_DMA_REQUEST_SPI2TX;
-            break;
+    case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        case 2:
-            reqselRx = MXC_DMA_REQUEST_SPI2RX;
-            break;
+    case 2:
+        reqselRx = MXC_DMA_REQUEST_SPI2RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_SPI_RevA1_MasterTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx, dma);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
@@ -398,30 +398,16 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req, mxc_dma_regs_t *dma)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    case 2:
-        reqselTx = MXC_DMA_REQUEST_SPI2TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
         reqselRx = MXC_DMA_REQUEST_SPI2RX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
@@ -351,30 +351,16 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req, mxc_dma_regs_t *dma)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    case 2:
-        reqselTx = MXC_DMA_REQUEST_SPI2TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
         reqselRx = MXC_DMA_REQUEST_SPI2RX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me15.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me15.c
@@ -267,30 +267,16 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    case 2:
-        reqselTx = MXC_DMA_REQUEST_SPI2TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
         reqselRx = MXC_DMA_REQUEST_SPI2RX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me15.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me15.c
@@ -311,30 +311,16 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    case 2:
-        reqselTx = MXC_DMA_REQUEST_SPI2TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
         reqselRx = MXC_DMA_REQUEST_SPI2RX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me15.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me15.c
@@ -322,42 +322,38 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 2:
-            reqselTx = MXC_DMA_REQUEST_SPI2TX;
-            break;
+    case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        case 2:
-            reqselRx = MXC_DMA_REQUEST_SPI2RX;
-            break;
+    case 2:
+        reqselRx = MXC_DMA_REQUEST_SPI2RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
     return MXC_SPI_RevA1_SlaveTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,
                                              MXC_DMA);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me15.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me15.c
@@ -264,42 +264,38 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 2:
-            reqselTx = MXC_DMA_REQUEST_SPI2TX;
-            break;
+    case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        case 2:
-            reqselRx = MXC_DMA_REQUEST_SPI2RX;
-            break;
+    case 2:
+        reqselRx = MXC_DMA_REQUEST_SPI2RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_SPI_RevA1_MasterTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me16.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me16.c
@@ -260,44 +260,40 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 2:
-            reqselTx = MXC_DMA_REQUEST_SPI2TX;
-            break;
+    case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
+        break;
 
-        case 3:
-            reqselTx = MXC_DMA_REQUEST_SPI3TX;
-            break;
-        }
+    case 3:
+        reqselTx = MXC_DMA_REQUEST_SPI3TX;
+        break;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 2:
-            reqselRx = MXC_DMA_REQUEST_SPI2TX;
-            break;
+    case 2:
+        reqselRx = MXC_DMA_REQUEST_SPI2TX;
+        break;
 
-        case 3:
-            reqselRx = MXC_DMA_REQUEST_SPI3TX;
-            break;
-        }
+    case 3:
+        reqselRx = MXC_DMA_REQUEST_SPI3TX;
+        break;
     }
 
     return MXC_SPI_RevA1_MasterTransactionDMA(req, reqselTx, reqselRx);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me16.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me16.c
@@ -308,35 +308,21 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    case 2:
-        reqselTx = MXC_DMA_REQUEST_SPI2TX;
-        break;
-
-    case 3:
-        reqselTx = MXC_DMA_REQUEST_SPI3TX;
-        break;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0TX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1TX;
         break;
 
     case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
         reqselRx = MXC_DMA_REQUEST_SPI2TX;
         break;
 
     case 3:
+        reqselTx = MXC_DMA_REQUEST_SPI3TX;
         reqselRx = MXC_DMA_REQUEST_SPI3TX;
         break;
     }

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me16.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me16.c
@@ -263,35 +263,21 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    case 2:
-        reqselTx = MXC_DMA_REQUEST_SPI2TX;
-        break;
-
-    case 3:
-        reqselTx = MXC_DMA_REQUEST_SPI3TX;
-        break;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0TX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1TX;
         break;
 
     case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
         reqselRx = MXC_DMA_REQUEST_SPI2TX;
         break;
 
     case 3:
+        reqselTx = MXC_DMA_REQUEST_SPI3TX;
         reqselRx = MXC_DMA_REQUEST_SPI3TX;
         break;
     }

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me16.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me16.c
@@ -319,44 +319,40 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 2:
-            reqselTx = MXC_DMA_REQUEST_SPI2TX;
-            break;
+    case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
+        break;
 
-        case 3:
-            reqselTx = MXC_DMA_REQUEST_SPI3TX;
-            break;
-        }
+    case 3:
+        reqselTx = MXC_DMA_REQUEST_SPI3TX;
+        break;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 2:
-            reqselRx = MXC_DMA_REQUEST_SPI2TX;
-            break;
+    case 2:
+        reqselRx = MXC_DMA_REQUEST_SPI2TX;
+        break;
 
-        case 3:
-            reqselRx = MXC_DMA_REQUEST_SPI3TX;
-            break;
-        }
+    case 3:
+        reqselRx = MXC_DMA_REQUEST_SPI3TX;
+        break;
     }
 
     return MXC_SPI_RevA1_SlaveTransactionDMA(req, reqselTx, reqselRx);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
@@ -419,13 +419,13 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
 
     switch (spi_num) {
     case 0:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     default:
@@ -458,13 +458,13 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
 
     switch (spi_num) {
     case 0:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     default:

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
@@ -417,34 +417,30 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_SPI_RevA1_MasterTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
@@ -459,23 +459,11 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-        break;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
@@ -420,22 +420,11 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
@@ -467,36 +467,32 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-            break;
-        }
+    default:
+        return E_BAD_PARAM;
+        break;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-            break;
-        }
+    default:
+        return E_BAD_PARAM;
+        break;
     }
 
     return MXC_SPI_RevA1_SlaveTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
@@ -393,37 +393,22 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-    case 2:
-        reqselTx = MXC_DMA_REQUEST_SPI2TX;
-        break;
-    case 3:
-        reqselTx = MXC_DMA_REQUEST_SPI3TX;
-        break;
-    case 4:
-        reqselTx = MXC_DMA_REQUEST_SPI4TX;
-        break;
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
     case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
         reqselRx = MXC_DMA_REQUEST_SPI2RX;
         break;
     case 3:
+        reqselTx = MXC_DMA_REQUEST_SPI3TX;
         reqselRx = MXC_DMA_REQUEST_SPI3RX;
         break;
     case 4:
+        reqselTx = MXC_DMA_REQUEST_SPI4TX;
         reqselRx = MXC_DMA_REQUEST_SPI4RX;
         break;
     default:

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
@@ -442,38 +442,22 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-    case 1:
-        reqselRx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-    case 2:
-        reqselTx = MXC_DMA_REQUEST_SPI2TX;
-        break;
-    case 3:
-        reqselTx = MXC_DMA_REQUEST_SPI3TX;
-        break;
-    case 4:
-        reqselTx = MXC_DMA_REQUEST_SPI4TX;
-        break;
-    default:
-        return E_BAD_PARAM;
-        break;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
     case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
     case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
         reqselTx = MXC_DMA_REQUEST_SPI2RX;
         break;
     case 3:
+        reqselTx = MXC_DMA_REQUEST_SPI3TX;
         reqselTx = MXC_DMA_REQUEST_SPI3RX;
         break;
     case 4:
+        reqselTx = MXC_DMA_REQUEST_SPI4TX;
         reqselTx = MXC_DMA_REQUEST_SPI4RX;
         break;
     default:

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
@@ -454,50 +454,46 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0TX;
-            break;
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1TX;
-            break;
-        case 2:
-            reqselTx = MXC_DMA_REQUEST_SPI2TX;
-            break;
-        case 3:
-            reqselTx = MXC_DMA_REQUEST_SPI3TX;
-            break;
-        case 4:
-            reqselTx = MXC_DMA_REQUEST_SPI4TX;
-            break;
-        default:
-            return E_BAD_PARAM;
-            break;
-        }
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0TX;
+        break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1TX;
+        break;
+    case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
+        break;
+    case 3:
+        reqselTx = MXC_DMA_REQUEST_SPI3TX;
+        break;
+    case 4:
+        reqselTx = MXC_DMA_REQUEST_SPI4TX;
+        break;
+    default:
+        return E_BAD_PARAM;
+        break;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
-        case 2:
-            reqselTx = MXC_DMA_REQUEST_SPI2RX;
-            break;
-        case 3:
-            reqselTx = MXC_DMA_REQUEST_SPI3RX;
-            break;
-        case 4:
-            reqselTx = MXC_DMA_REQUEST_SPI4RX;
-            break;
-        default:
-            return E_BAD_PARAM;
-            break;
-        }
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
+    case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2RX;
+        break;
+    case 3:
+        reqselTx = MXC_DMA_REQUEST_SPI3RX;
+        break;
+    case 4:
+        reqselTx = MXC_DMA_REQUEST_SPI4RX;
+        break;
+    default:
+        return E_BAD_PARAM;
+        break;
     }
 
     return MXC_SPI_RevA1_SlaveTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
@@ -441,24 +441,24 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
 
     switch (spi_num) {
     case 0:
-        reqselRx = MXC_DMA_REQUEST_SPI0TX;
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
     case 1:
-        reqselRx = MXC_DMA_REQUEST_SPI1TX;
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
     case 2:
         reqselTx = MXC_DMA_REQUEST_SPI2TX;
-        reqselTx = MXC_DMA_REQUEST_SPI2RX;
+        reqselRx = MXC_DMA_REQUEST_SPI2RX;
         break;
     case 3:
         reqselTx = MXC_DMA_REQUEST_SPI3TX;
-        reqselTx = MXC_DMA_REQUEST_SPI3RX;
+        reqselRx = MXC_DMA_REQUEST_SPI3RX;
         break;
     case 4:
         reqselTx = MXC_DMA_REQUEST_SPI4TX;
-        reqselTx = MXC_DMA_REQUEST_SPI4RX;
+        reqselRx = MXC_DMA_REQUEST_SPI4RX;
         break;
     default:
         return E_BAD_PARAM;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
@@ -390,48 +390,44 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
-        case 2:
-            reqselTx = MXC_DMA_REQUEST_SPI2TX;
-            break;
-        case 3:
-            reqselTx = MXC_DMA_REQUEST_SPI3TX;
-            break;
-        case 4:
-            reqselTx = MXC_DMA_REQUEST_SPI4TX;
-            break;
-        default:
-            return E_BAD_PARAM;
-        }
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
+    case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
+        break;
+    case 3:
+        reqselTx = MXC_DMA_REQUEST_SPI3TX;
+        break;
+    case 4:
+        reqselTx = MXC_DMA_REQUEST_SPI4TX;
+        break;
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
-        case 2:
-            reqselRx = MXC_DMA_REQUEST_SPI2RX;
-            break;
-        case 3:
-            reqselRx = MXC_DMA_REQUEST_SPI3RX;
-            break;
-        case 4:
-            reqselRx = MXC_DMA_REQUEST_SPI4RX;
-            break;
-        default:
-            return E_BAD_PARAM;
-        }
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
+    case 2:
+        reqselRx = MXC_DMA_REQUEST_SPI2RX;
+        break;
+    case 3:
+        reqselRx = MXC_DMA_REQUEST_SPI3RX;
+        break;
+    case 4:
+        reqselRx = MXC_DMA_REQUEST_SPI4RX;
+        break;
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_SPI_RevA1_MasterTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me21.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me21.c
@@ -284,30 +284,16 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    case 2:
-        reqselTx = MXC_DMA_REQUEST_SPI2TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
         reqselRx = MXC_DMA_REQUEST_SPI2RX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me21.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me21.c
@@ -328,36 +328,23 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    case 2:
-        reqselTx = MXC_DMA_REQUEST_SPI2TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
         reqselRx = MXC_DMA_REQUEST_SPI2RX;
         break;
 
     default:
         return E_BAD_PARAM;
     }
+
     return MXC_SPI_RevA1_SlaveTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,
                                              MXC_DMA);
 }

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me21.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me21.c
@@ -339,42 +339,38 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 2:
-            reqselTx = MXC_DMA_REQUEST_SPI2TX;
-            break;
+    case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        case 2:
-            reqselRx = MXC_DMA_REQUEST_SPI2RX;
-            break;
+    case 2:
+        reqselRx = MXC_DMA_REQUEST_SPI2RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
     return MXC_SPI_RevA1_SlaveTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,
                                              MXC_DMA);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me21.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me21.c
@@ -281,42 +281,38 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 2:
-            reqselTx = MXC_DMA_REQUEST_SPI2TX;
-            break;
+    case 2:
+        reqselTx = MXC_DMA_REQUEST_SPI2TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        case 2:
-            reqselRx = MXC_DMA_REQUEST_SPI2RX;
-            break;
+    case 2:
+        reqselRx = MXC_DMA_REQUEST_SPI2RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_SPI_RevA1_MasterTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me30.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me30.c
@@ -384,17 +384,6 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req, mxc_dma_regs_t *dma)
         switch (spi_num) {
         case 0:
             reqselTx = MXC_DMA_REQUEST_SPITX;
-            break;
-
-        default:
-            return E_BAD_PARAM;
-            break;
-        }
-    }
-
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
             reqselRx = MXC_DMA_REQUEST_SPIRX;
             break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me30.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me30.c
@@ -347,26 +347,22 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req, mxc_dma_regs_t *dma)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPITX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPITX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPIRX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPIRX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_SPI_RevA1_MasterTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx, dma);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me30.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me30.c
@@ -350,14 +350,6 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req, mxc_dma_regs_t *dma)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPITX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPIRX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me55.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me55.c
@@ -282,30 +282,16 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    case 3:
-        reqselTx = MXC_DMA_REQUEST_SPI3TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 3:
+        reqselTx = MXC_DMA_REQUEST_SPI3TX;
         reqselRx = MXC_DMA_REQUEST_SPI3RX;
         break;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me55.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me55.c
@@ -279,42 +279,38 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 3:
-            reqselTx = MXC_DMA_REQUEST_SPI3TX;
-            break;
+    case 3:
+        reqselTx = MXC_DMA_REQUEST_SPI3TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        case 3:
-            reqselRx = MXC_DMA_REQUEST_SPI3RX;
-            break;
+    case 3:
+        reqselRx = MXC_DMA_REQUEST_SPI3RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_SPI_RevA1_MasterTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me55.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me55.c
@@ -336,42 +336,38 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     spi_num = MXC_SPI_GET_IDX(req->spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->txData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselTx = MXC_DMA_REQUEST_SPI0TX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        break;
 
-        case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
-            break;
+    case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        break;
 
-        case 3:
-            reqselTx = MXC_DMA_REQUEST_SPI3TX;
-            break;
+    case 3:
+        reqselTx = MXC_DMA_REQUEST_SPI3TX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
-    if (req->rxData != NULL) {
-        switch (spi_num) {
-        case 0:
-            reqselRx = MXC_DMA_REQUEST_SPI0RX;
-            break;
+    switch (spi_num) {
+    case 0:
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        break;
 
-        case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
-            break;
+    case 1:
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        break;
 
-        case 3:
-            reqselRx = MXC_DMA_REQUEST_SPI3RX;
-            break;
+    case 3:
+        reqselRx = MXC_DMA_REQUEST_SPI3RX;
+        break;
 
-        default:
-            return E_BAD_PARAM;
-        }
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_SPI_RevA1_SlaveTransactionDMA((mxc_spi_reva_req_t *)req, reqselTx, reqselRx,

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me55.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me55.c
@@ -325,30 +325,16 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
     switch (spi_num) {
     case 0:
         reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        break;
-
-    case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        break;
-
-    case 3:
-        reqselTx = MXC_DMA_REQUEST_SPI3TX;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    switch (spi_num) {
-    case 0:
         reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     case 1:
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
         reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 3:
+        reqselTx = MXC_DMA_REQUEST_SPI3TX;
         reqselRx = MXC_DMA_REQUEST_SPI3RX;
         break;
 


### PR DESCRIPTION
### Description
This pull request addresses an issue in the DMA-based SPI transaction implementation where the DMA request would not be executed under specific conditions.

### Problem Details
- **Issue**: When `MXC_SPI_MasterTransactionDMA` is called with `txData == NULL` and `rxData != NULL` in `SPI_WIDTH_STANDARD` (full duplex) mode, the function sets `reqselTx` to `-1`. However, in `MXC_SPI_RevA1_MasterTransactionDMA`, `MXC_SPI_RevA1_TransSetup` may additionally set `txData` based on the request. This leads to the [use of an invalid request selector](https://github.com/analogdevicesinc/msdk/blob/e1cae5bbb0bed43a754e487a99995dd85ca37b6a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c#L1019), causing the DMA to not be executed and resulting in an infinite wait state.

- **Call Stack**:
  - [MXC_SPI_MasterTransactionDMA](https://github.com/analogdevicesinc/msdk/blob/e1cae5bbb0bed43a754e487a99995dd85ca37b6a/Libraries/PeriphDrivers/Source/SPI/spi_me17.c#L420-L448)
    - Determines `reqselTx` and `reqselRx` based on the device and data presence.
  - [MXC_SPI_RevA1_MasterTransactionDMA](https://github.com/analogdevicesinc/msdk/blob/e1cae5bbb0bed43a754e487a99995dd85ca37b6a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c#L931)
    - Uses `MXC_SPI_RevA1_TransSetup` to configure the request, potentially modifying `req` to include both Tx and Rx data.
  - [MXC_SPI_RevA1_TransSetup](https://github.com/analogdevicesinc/msdk/blob/e1cae5bbb0bed43a754e487a99995dd85ca37b6a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c#L732-L745)
    - Adjusts the request to comply with SPI protocol, potentially setting both Tx and Rx data.

### Solution
- Always pass valid `reqselRx` and `reqselTx` values from `MXC_SPI_MasterTransactionDMA`.
- Configure DMA in `MXC_SPI_RevA1_MasterTransactionDMA` after executing `MXC_SPI_RevA1_TransSetup`.
> Solution Rationale: By ensuring valid `reqselRx` and `reqselTx` values are always passed from `MXC_SPI_MasterTransactionDMA`, the `MXC_SPI_RevA1_MasterTransactionDMA` function can correctly configure the DMA settings based on the request. This prevents the DMA from not being executed due to invalid request selectors. Additionally, the `MXC_SPI_RevA1_MasterTransactionDMA` function always checks the null status of `rxData` and `txData` before using the request selectors, ensuring that no other issues arise from this change.

### Additional Fixes
- Applied the same fix to `MXC_SPI_SlaveTransactionDMA`.
- Corrected potentially swapped `reqselRx` and `reqselTx` values in [spi_me11.c](https://github.com/analogdevicesinc/msdk/blob/e1cae5bbb0bed43a754e487a99995dd85ca37b6a/Libraries/PeriphDrivers/Source/SPI/spi_me11.c#L275) and [spi_me18.c](https://github.com/analogdevicesinc/msdk/blob/e1cae5bbb0bed43a754e487a99995dd85ca37b6a/Libraries/PeriphDrivers/Source/SPI/spi_me18.c#L464-L499) files. Please confirm if this change was intended. ([fix in this PR](https://github.com/analogdevicesinc/msdk/pull/1059/commits/049b11eeef3864ecb332ad281f60fe180c3c142c))

### Tests
- Tested the changes on a MAX78000 device using `spi_me17.c` as a basis.

### Checklist Before Requesting Review
- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] Provide info on any relevant functional testing/validation.