### PR TITLE
fix(PeriphDrivers): Fix MAX32690 I2C Recovery Failures for TQFN Package

### DIFF
--- a/Libraries/Boards/MAX32690/EvKit_V1/board.mk
+++ b/Libraries/Boards/MAX32690/EvKit_V1/board.mk
@@ -31,6 +31,9 @@ SRCS += pb.c
 SRCS += tft_st7735.c
 
 PROJ_CFLAGS+=-DEXT_FLASH_MX25
+# Define "MAX32690GTK_PACKAGE_TQFN", which some drivers use to work around MAX32690 Rev A2 Errata #16:
+# https://www.analog.com/media/en/technical-documentation/data-sheets/max32690_a2_errata_rev2.pdf
+PROJ_CFLAGS += -DMAX32690GTK_PACKAGE_TQFN
 
 MISC_DRIVERS_DIR ?= $(MAXIM_PATH)/Libraries/MiscDrivers
 

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_me18.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_me18.c
@@ -54,18 +54,29 @@ int MXC_I2C_Init(mxc_i2c_regs_t *i2c, int masterMode, unsigned int slaveAddr)
      *
      * See MAX32690 Rev A2 Errata #16:
      * https://www.analog.com/media/en/technical-documentation/data-sheets/max32690_a2_errata_rev2.pdf
+     * 
+     * Additionally, note that the TQFN package does not expose some of the duplicate pins.  For this package,
+     * enabling the un-routed GPIOs has been shown to cause initialization issues with the I2C block.
+     * To work around this, "MAX32690GTK_PACKAGE_TQFN" can be defined by the build system.  The recommend place
+     * to do it is in the "board.mk" file of the BSP.  This will prevent the inaccessible pins from being configured.
      */
     if (i2c == MXC_I2C0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_I2C0);
         MXC_GPIO_Config(&gpio_cfg_i2c0);
+#ifndef MAX32690GTK_PACKAGE_TQFN
         MXC_GPIO_Config(&gpio_cfg_i2c0a);
+#endif
     } else if (i2c == MXC_I2C1) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_I2C1);
         MXC_GPIO_Config(&gpio_cfg_i2c1);
+#ifndef MAX32690GTK_PACKAGE_TQFN
         MXC_GPIO_Config(&gpio_cfg_i2c1a);
+#endif
     } else if (i2c == MXC_I2C2) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_I2C2);
+#ifndef MAX32690GTK_PACKAGE_TQFN
         MXC_GPIO_Config(&gpio_cfg_i2c2);
+#endif
         MXC_GPIO_Config(&gpio_cfg_i2c2c);
     } else {
         return E_NO_DEVICE;


### PR DESCRIPTION
### Description

This PR adds a check for the `MAX32690GTK_PACKAGE_TQFN` compiler definition to work around MAX32690 Rev A2 Errata #16 (See https://www.analog.com/media/en/technical-documentation/data-sheets/max32690_a2_errata_rev2.pdf)

Testing found that the `MXC_I2C_Recover` function would fail for this package, but only if the unrouted set of pins were enabled.

The new definition is added to the board.mk file in the BSP for the EVKIT.  In this way, BSPs that use the TQFN package can match the hardware.

As implemented in #958, the WLP package enables both sets as recommended by the errata.  However, for the TQFN this seems to be problematic.  The I2C "scl" status bit in the control register always indicates the pin is at logic level 0 if the unrouted GPIOs are configured.   