### PR TITLE
fix(PeriphDrivers): Ensure single execution of DMA-based SPI transaction callback for all parts

### DIFF
--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
@@ -1007,7 +1007,7 @@ int MXC_SPI_RevA1_MasterTransactionDMA(mxc_spi_reva_req_t *req, int reqselTx, in
     }
 
     //tx
-    if (req->txData != NULL && !tx_is_complete) {
+    if (req->txData != NULL && req->txLen && !tx_is_complete) {
         MXC_DMA_SetCallback(states[spi_num].channelTx, MXC_SPI_RevA1_DMACallback);
 
 #if (TARGET_NUM == 32657)
@@ -1053,7 +1053,7 @@ int MXC_SPI_RevA1_MasterTransactionDMA(mxc_spi_reva_req_t *req, int reqselTx, in
     }
 
     // rx
-    if (req->rxData != NULL && !rx_is_complete) {
+    if (req->rxData != NULL && req->rxLen && !rx_is_complete) {
         MXC_DMA_SetCallback(states[spi_num].channelRx, MXC_SPI_RevA1_DMACallback);
 
 #if (TARGET_NUM == 32657)
@@ -1107,11 +1107,11 @@ int MXC_SPI_RevA1_MasterTransactionDMA(mxc_spi_reva_req_t *req, int reqselTx, in
     }
 
     // Manually run TX/RX callbacks if the FIFO pre-load already completed that portion of the transaction
-    if (tx_is_complete) {
+    if (req->txData != NULL && req->txLen && tx_is_complete) {
         MXC_SPI_RevA1_DMACallback(states[spi_num].channelTx, E_NO_ERROR);
     }
 
-    if (rx_is_complete) {
+    if (req->rxData != NULL && req->rxLen && rx_is_complete) {
         MXC_SPI_RevA1_DMACallback(states[spi_num].channelRx, E_NO_ERROR);
     }
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
@@ -1296,22 +1296,25 @@ int MXC_SPI_RevA1_SlaveTransactionDMA(mxc_spi_reva_req_t *req, int reqselTx, int
 void MXC_SPI_RevA1_DMACallback(int ch, int error)
 {
     mxc_spi_reva_req_t *temp_req;
+    uint8_t req_done;
 
     for (int i = 0; i < MXC_SPI_INSTANCES; i++) {
         if (states[i].req != NULL) {
             if (states[i].channelTx == ch) {
-                states[i].req_done++;
+                req_done = states[i].req_done++;
             } else if (states[i].channelRx == ch) {
-                states[i].req_done++;
+                req_done = states[i].req_done++;
                 //save the request
                 temp_req = states[i].req;
 
                 if (MXC_SPI_GetDataSize((mxc_spi_regs_t *)temp_req->spi) > 8) {
                     MXC_SPI_RevA1_SwapByte(temp_req->rxData, temp_req->rxLen);
                 }
+            } else {
+                continue;
             }
 
-            if (!states[i].txrx_req || (states[i].txrx_req && states[i].req_done == 2)) {
+            if (!states[i].txrx_req || (states[i].txrx_req && req_done == 1)) {
                 //save the request
                 temp_req = states[i].req;
                 MXC_FreeLock((uint32_t *)&states[i].req);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
@@ -18,7 +18,6 @@
  *
  ******************************************************************************/
 
-#include <stdatomic.h>
 #include <stdio.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -44,7 +43,7 @@ typedef struct {
     int mtMode;
     int mtFirstTrans;
     bool txrx_req;
-    atomic_uint_fast8_t req_done;
+    uint8_t req_done;
     uint8_t async;
     bool hw_ss_control;
 } spi_req_reva_state_t;
@@ -1302,9 +1301,9 @@ void MXC_SPI_RevA1_DMACallback(int ch, int error)
     for (int i = 0; i < MXC_SPI_INSTANCES; i++) {
         if (states[i].req != NULL) {
             if (states[i].channelTx == ch) {
-                req_done = atomic_fetch_add(&states[i].req_done, 1);
+                req_done = states[i].req_done++;
             } else if (states[i].channelRx == ch) {
-                req_done = atomic_fetch_add(&states[i].req_done, 1);
+                req_done = states[i].req_done++;
                 //save the request
                 temp_req = states[i].req;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
@@ -1296,25 +1296,22 @@ int MXC_SPI_RevA1_SlaveTransactionDMA(mxc_spi_reva_req_t *req, int reqselTx, int
 void MXC_SPI_RevA1_DMACallback(int ch, int error)
 {
     mxc_spi_reva_req_t *temp_req;
-    uint8_t req_done;
 
     for (int i = 0; i < MXC_SPI_INSTANCES; i++) {
         if (states[i].req != NULL) {
             if (states[i].channelTx == ch) {
-                req_done = states[i].req_done++;
+                states[i].req_done++;
             } else if (states[i].channelRx == ch) {
-                req_done = states[i].req_done++;
+                states[i].req_done++;
                 //save the request
                 temp_req = states[i].req;
 
                 if (MXC_SPI_GetDataSize((mxc_spi_regs_t *)temp_req->spi) > 8) {
                     MXC_SPI_RevA1_SwapByte(temp_req->rxData, temp_req->rxLen);
                 }
-            } else {
-                continue;
             }
 
-            if (!states[i].txrx_req || (states[i].txrx_req && req_done == 1)) {
+            if (!states[i].txrx_req || (states[i].txrx_req && states[i].req_done == 2)) {
                 //save the request
                 temp_req = states[i].req;
                 MXC_FreeLock((uint32_t *)&states[i].req);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
@@ -18,6 +18,7 @@
  *
  ******************************************************************************/
 
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -43,7 +44,7 @@ typedef struct {
     int mtMode;
     int mtFirstTrans;
     bool txrx_req;
-    uint8_t req_done;
+    atomic_uint_fast8_t req_done;
     uint8_t async;
     bool hw_ss_control;
 } spi_req_reva_state_t;
@@ -1301,9 +1302,9 @@ void MXC_SPI_RevA1_DMACallback(int ch, int error)
     for (int i = 0; i < MXC_SPI_INSTANCES; i++) {
         if (states[i].req != NULL) {
             if (states[i].channelTx == ch) {
-                req_done = states[i].req_done++;
+                req_done = atomic_fetch_add(&states[i].req_done, 1);
             } else if (states[i].channelRx == ch) {
-                req_done = states[i].req_done++;
+                req_done = atomic_fetch_add(&states[i].req_done, 1);
                 //save the request
                 temp_req = states[i].req;
 


### PR DESCRIPTION
### Description
This pull request contains three commits to ensure that the `req->completeCB` callback of `MXC_SPI_MasterTransactionDMA` is only executed once. Previously, the `MXC_SPI_MasterTransactionDMA` function could trigger the `req->completeCB` callback multiple times, which is different from users' expectations (see Background & Problem).


### Background
The `MXC_SPI_MasterTransactionDMA` function initiates DMA requests up to two times. To execute `req->completeCB` only for the last DMA callback, there is an internal DMA callback counting mechanism.

#### Callbacks
1. [req->completeCB](https://github.com/analogdevicesinc/msdk/blob/b7b5ff1f5705434e025fd2755b9b0ed760f97972/Libraries/PeriphDrivers/Source/SPI/spi_reva1.h#L67): A user-provided callback that should be executed once after `MXC_SPI_MasterTransactionDMA` completes.

2. [MXC_SPI_RevA1_DMACallback](https://github.com/analogdevicesinc/msdk/blob/b7b5ff1f5705434e025fd2755b9b0ed760f97972/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c#L1296): A DMA request callback used internally. The `MXC_SPI_MasterTransactionDMA` function initiates up to two DMA requests, and each call triggers the `MXC_SPI_RevA1_DMACallback` function.


#### How `MXC_SPI_MasterTransactionDMA` executes the `completeCB` callback once?
1. Save a flag `states[i].txrx_req` which indicates whether both of Tx/Rx DMA requests are needed. ([ref](https://github.com/analogdevicesinc/msdk/blob/b7b5ff1f5705434e025fd2755b9b0ed760f97972/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c#L756-L760))
2. Save two flags `tx_is_complete` and `rx_is_complete` which indicate whether Tx/Rx DMA requests are needed. ([ref](https://github.com/analogdevicesinc/msdk/blob/b7b5ff1f5705434e025fd2755b9b0ed760f97972/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c#L994-L999))
5. Initiate Tx/Rx DMA when `tx/rxData != NULL && !tx/rx_is_complete`. ([tx](https://github.com/analogdevicesinc/msdk/blob/b7b5ff1f5705434e025fd2755b9b0ed760f97972/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c#L1010), [rx](https://github.com/analogdevicesinc/msdk/blob/b7b5ff1f5705434e025fd2755b9b0ed760f97972/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c#L1056))
6. If `tx/rx_is_complete == true`, run `MXC_SPI_RevA1_DMACallback` manually. ([ref](https://github.com/analogdevicesinc/msdk/blob/b7b5ff1f5705434e025fd2755b9b0ed760f97972/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c#L1109-L1116))
7. Inside `MXC_SPI_RevA1_DMACallback`, when `states[i].txrx_req == true`, execute `req->completeCB` for second `MXC_SPI_RevA1_DMACallback` call. If `states[i].txrx_req == false`, always call `req->completeCB`. ([ref](https://github.com/analogdevicesinc/msdk/blob/b7b5ff1f5705434e025fd2755b9b0ed760f97972/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c#L1302-L1321))


### Problem
1. The condition of the `states[i].txrx_req` flag and the actual DMA request condition differ.
  * Example
    * Input `req`: `txData == NULL && txLen == 0 && txCnt == 0 && rxData != NULL && rxLen > 0 && rxCnt = 0`
    * Internal variables: `txrx_req = false`, `tx_is_complete = true`, `rx_is_complete = false`
    * Rx DMA will be initiated
    * Due to `tx_is_complete == true`, [this code](https://github.com/analogdevicesinc/msdk/blob/b7b5ff1f5705434e025fd2755b9b0ed760f97972/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c#L1110-L1112) will execute `MXC_SPI_RevA1_DMACallback`.
    * Rx DMA also triggers `MXC_SPI_RevA1_DMACallback` after the DMA request finishes.

~~2. Inside `MXC_SPI_RevA1_DMACallback`, the shared variable`states[i].req_done` is used multiple times ([usage 1](https://github.com/analogdevicesinc/msdk/blob/b7b5ff1f5705434e025fd2755b9b0ed760f97972/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c#L1302-L1305), [usage 2](https://github.com/analogdevicesinc/msdk/blob/b7b5ff1f5705434e025fd2755b9b0ed760f97972/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c#L1314)). This can trigger `req->completeCB` multiple times when execution of two `MXC_SPI_RevA1_DMACallback` calls overlaps.~~


### Commit Details
* Commit 1: Solving Problem 1
  * Always check `req->rx/txData != NULL && req->rx/txLen` for both setting `txrx_req` and initiating DMA.

~~* Commit 2: Partially solving Problem 2 * Use the shared variable `states[i].req_done` once in `MXC_SPI_RevA1_DMACallback` by utilizing a non-shared local variable `req_done`. * Potential issue: When an inturrept occurs during `req_done = states[i].req_done++` execution, `req->completeCB` may not be executed.~~
~~* Commit 3: Solving potential issue of commit 2 * Use an atomic operation to fetch and increment the shared variable `states[i].req_done`, ensuring that the operation is safe from interrupt and that the `req->completeCB` callback is executed correctly.~~


### Tests
* Tested the changes on a MAX78000 device.


### Checklist Before Requesting Review
- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.