### PR TITLE
revert(PeriphDrivers): Revert incorrect spi_num - reqselTx/Rx matching in DMA-based SPI transactions for MAX32655, MAX32662, MAX32680, MAX78000, and MAX78002

### DIFF
--- a/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
@@ -405,13 +405,13 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
 
     switch (spi_num) {
     case 0:
-        reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     default:
@@ -444,13 +444,13 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
 
     switch (spi_num) {
     case 0:
-        reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     default:

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
@@ -400,13 +400,13 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
 
     switch (spi_num) {
     case 0:
-        reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     default:

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
@@ -419,13 +419,13 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
 
     switch (spi_num) {
     case 0:
-        reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     default:
@@ -458,13 +458,13 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
 
     switch (spi_num) {
     case 0:
-        reqselTx = MXC_DMA_REQUEST_SPI0TX;
-        reqselRx = MXC_DMA_REQUEST_SPI0RX;
+        reqselTx = MXC_DMA_REQUEST_SPI1TX;
+        reqselRx = MXC_DMA_REQUEST_SPI1RX;
         break;
 
     case 1:
-        reqselTx = MXC_DMA_REQUEST_SPI1TX;
-        reqselRx = MXC_DMA_REQUEST_SPI1RX;
+        reqselTx = MXC_DMA_REQUEST_SPI0TX;
+        reqselRx = MXC_DMA_REQUEST_SPI0RX;
         break;
 
     default:


### PR DESCRIPTION
### Description
This pull request reverts the commit that attempted to fix the `spi_num` and `reqselTx/Rx` matching in DMA-based SPI transactions. The previous fix was incorrect due to a misunderstanding of the RISC-V architecture implementation.


### Reason for Reversion
Upon reviewing the `max78000.h` file, it was noted that the `spi_num` and `mxc_dma_reqsel_t` numbers were intentionally ordered to support both ARM and RISC-V architectures. The mismatched numbers were due to this architectural difference, not an error in the original implementation. By reverting this commit, we restore the original, correct behavior for both architectures. (See [max78000.h comment](https://github.com/analogdevicesinc/msdk/blob/796e710782b3b0728f5ae32b1bb65af59638808d/Libraries/CMSIS/Device/Maxim/MAX78000/Include/max78000.h#L632-L633))


### Additional Information
* This reversion addresses issues introduced in #1059.
* The changes were made while handling comments and were not tested specifically for this scenario. I apologize for any inconvenience this may have caused.


### Tests
* Tested the changes on a MAX78000 device to ensure correct behavior of the DMA-based SPI transactions.


### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.