### PR TITLE
fix(workflow): Grant PRs against forks access to write permissions

### DIFF
--- a/.github/workflows/zephyr-hal.yml
+++ b/.github/workflows/zephyr-hal.yml
@@ -29,6 +29,7 @@ jobs:
     permissions:
       # This will depend on permissions set by repo and org (separate levels of permissions)
       contents: write
+      pull-requests: write
 
     steps:
       # Checkout msdk repository

--- a/.github/workflows/zephyr-hal.yml
+++ b/.github/workflows/zephyr-hal.yml
@@ -9,7 +9,8 @@ on:
   # Run only when a pull-request is closed.
   # The 'if_merged' condition in the 'jobs' section below will make sure the PR was
   #  approved before running the steps.
-  pull_request:
+  # Caution: pull_request_target grants workflows triggered by forks access to secrets and write permissions.
+  pull_request_target:
     types:
       - closed
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
### Description

The zepher-hal workflow is failing for PRs against forks because permission to write to remote repo is not granted. Changing the event type to `pull_request_target` grants these triggered workflows with write permissions.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.