### PR TITLE
fix(PeriphDrivers): Fix `-wstrict-prototype` and other Misc. MAX78002 Warnings

### DIFF
--- a/Examples/MAX78002/ADC/main.c
+++ b/Examples/MAX78002/ADC/main.c
@@ -232,10 +232,10 @@ void temperature_average(float temperature)
 
     if (temp_samples == SAMPLE_AVG) {
         average = sum / SAMPLE_AVG;
-        printf("Average = %0.2fC\n", average);
+        printf("Average = %0.2fC\n", (double)average);
 
         for (loop_counter = 0; loop_counter < SAMPLE_AVG; loop_counter++) {
-            printf("%0.2fC ", TEMP_SAMPLES[loop_counter]);
+            printf("%0.2fC ", (double)TEMP_SAMPLES[loop_counter]);
             if (loop_counter == 15) {
                 printf("\n");
             }

--- a/Examples/MAX78002/CNN/facial_recognition/include/record.h
+++ b/Examples/MAX78002/CNN/facial_recognition/include/record.h
@@ -26,8 +26,8 @@
 #define SHOW_START_X (TFT_WIDTH - HEIGHT_ID) / 2
 #define SHOW_START_Y (TFT_HEIGHT - WIDTH_ID) / 2
 
-int record();
-void show_keyboard();
-void init_cnn_from_flash();
+int record(void);
+void show_keyboard(void);
+void init_cnn_from_flash(void);
 
 #endif // _RECORD_H_

--- a/Examples/MAX78002/CNN/facial_recognition/src/record.c
+++ b/Examples/MAX78002/CNN/facial_recognition/src/record.c
@@ -135,17 +135,17 @@ static int font = (int)&Liberation_Sans16x16[0];
 void get_status(Person *p);
 int update_status(Person *p);
 int update_info_field(Person *p);
-void FLC0_IRQHandler();
-int init_db();
-int init_status();
+void FLC0_IRQHandler(void);
+int init_db(void);
+int init_status(void);
 int add_person(Person *p);
 void flash_to_cnn(Person *p, uint32_t cnn_location);
-void setup_irqs();
+void setup_irqs(void);
 void read_db(Person *p);
-bool check_db();
-void show_keyboard();
+bool check_db(void);
+void show_keyboard(void);
 void get_name(Person *p);
-void show_face();
+void show_face(void);
 
 /***** Functions *****/
 

--- a/Examples/MAX78002/CNN/kws20_demo/main.c
+++ b/Examples/MAX78002/CNN/kws20_demo/main.c
@@ -863,7 +863,7 @@ uint8_t check_inference(q15_t *ml_soft, int32_t *ml_data, int16_t *out_class, do
             else
                 TFT_Print(buff, 20, 30, font_2,
                           snprintf(buff, sizeof(buff), "%s (%0.1f%%)", keywords[max_index],
-                                   (double)100.0 * max / 32768.0));
+                                   (double)(100.0 * max / 32768.0)));
             //TFT_Print(buff, 1, 80, font_1, snprintf(buff, sizeof(buff), "Top classes:"));
         } else {
             /* uncomment to show the next 4 top classes */

--- a/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/src/camera/camera.h
+++ b/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/src/camera/camera.h
@@ -43,7 +43,7 @@
 
 /***** Functions *****/
 
-bool camera_init();
+bool camera_init(void);
 void camera_capture(void);
 void camera_capture_and_load_cnn(void);
 void camera_display_last_image(void);

--- a/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/src/cnn/nms.c
+++ b/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/src/cnn/nms.c
@@ -96,16 +96,6 @@ uint32_t utils_get_time_ms(void)
     return ms;
 }
 
-static uint8_t signed_to_unsigned(int8_t val)
-{
-    uint8_t value;
-    if (val < 0) {
-        value = ~val + 1;
-        return (128 - value);
-    }
-    return val + 128;
-}
-
 int get_prior_idx(int os_idx, int ar_idx, int scale_idx, int rel_idx)
 {
     int prior_idx = 0;
@@ -170,7 +160,7 @@ void calc_softmax(int32_t *prior_cls_vals, int prior_idx)
 
     for (ch = 0; ch < (NUM_CLASSES); ++ch) {
         prior_cls_softmax[prior_idx * NUM_CLASSES + ch] =
-            (uint8_t)(256. * exp(prior_cls_vals[ch] / fp_scale) / sum);
+            (uint8_t)((double)256. * exp(prior_cls_vals[ch] / fp_scale) / sum);
     }
 }
 
@@ -318,8 +308,8 @@ void get_cxcy(float *cxcy, int prior_idx)
     cx = rel_idx % dims_x[scale_idx];
     cxcy[0] = (float)((float)(cx + 0.5) / dims_x[scale_idx]);
     cxcy[1] = (float)((float)(cy + 0.5) / dims_y[scale_idx]);
-    cxcy[2] = obj_scales[os_idx] * scales[scale_idx] * sqrt(ars[ar_idx]);
-    cxcy[3] = obj_scales[os_idx] * scales[scale_idx] / sqrt(ars[ar_idx]);
+    cxcy[2] = obj_scales[os_idx] * scales[scale_idx] * (float)sqrt(ars[ar_idx]);
+    cxcy[3] = obj_scales[os_idx] * scales[scale_idx] / (float)sqrt(ars[ar_idx]);
 
     for (i = 0; i < 4; ++i) {
         cxcy[i] = MAX(0.0, cxcy[i]);
@@ -336,8 +326,8 @@ void gcxgcy_to_cxcy(float *cxcy, int prior_idx, float *priors_cxcy)
 
     cxcy[0] = priors_cxcy[0] + gcxgcy[0] * priors_cxcy[2] / 10;
     cxcy[1] = priors_cxcy[1] + gcxgcy[1] * priors_cxcy[3] / 10;
-    cxcy[2] = exp(gcxgcy[2] / 5) * priors_cxcy[2];
-    cxcy[3] = exp(gcxgcy[3] / 5) * priors_cxcy[3];
+    cxcy[2] = (float)exp(gcxgcy[2] / 5) * priors_cxcy[2];
+    cxcy[3] = (float)exp(gcxgcy[3] / 5) * priors_cxcy[3];
 }
 
 void cxcy_to_xy(float *xy, float *cxcy)

--- a/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/src/sram/aps6404.c
+++ b/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/src/sram/aps6404.c
@@ -51,7 +51,7 @@ int _transmit_spi_header(uint8_t cmd, uint32_t address)
     return err;
 }
 
-int ram_init()
+int ram_init(void)
 {
     int err = E_NO_ERROR;
     err = spi_init();
@@ -66,7 +66,7 @@ int ram_init()
     return err;
 }
 
-int ram_reset()
+int ram_reset(void)
 {
     int err = E_NO_ERROR;
     uint8_t data[2] = { 0x66, 0x99 };
@@ -77,7 +77,7 @@ int ram_reset()
     return err;
 }
 
-int ram_enter_quadmode()
+int ram_enter_quadmode(void)
 {
     int err = E_NO_ERROR;
     uint8_t tx_data = 0x35;
@@ -91,7 +91,7 @@ int ram_enter_quadmode()
     return err;
 }
 
-int ram_exit_quadmode()
+int ram_exit_quadmode(void)
 {
     int err = E_NO_ERROR;
     uint8_t tx_data = 0xF5;

--- a/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/src/sram/aps6404.h
+++ b/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/src/sram/aps6404.h
@@ -34,13 +34,13 @@ typedef struct {
     int EID;
 } ram_id_t;
 
-int ram_init();
+int ram_init(void);
 
-int ram_reset();
+int ram_reset(void);
 
-int ram_enter_quadmode();
+int ram_enter_quadmode(void);
 
-int ram_exit_quadmode();
+int ram_exit_quadmode(void);
 
 int ram_read_id(ram_id_t *out);
 

--- a/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/src/sram/fastspi.c
+++ b/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/src/sram/fastspi.c
@@ -107,7 +107,7 @@ void processSPI(void)
     }
 }
 
-void SPI_IRQHandler()
+void SPI_IRQHandler(void)
 {
     uint32_t status = SPI->intfl;
 
@@ -133,7 +133,7 @@ void SPI_IRQHandler()
     }
 }
 
-int dma_init()
+int dma_init(void)
 {
     if (g_dma_initialized)
         return E_NO_ERROR;

--- a/Examples/MAX78002/CSI2/src/sram/aps6404.c
+++ b/Examples/MAX78002/CSI2/src/sram/aps6404.c
@@ -51,7 +51,7 @@ int _transmit_spi_header(uint8_t cmd, uint32_t address)
     return err;
 }
 
-int ram_init()
+int ram_init(void)
 {
     int err = E_NO_ERROR;
     err = spi_init();
@@ -66,7 +66,7 @@ int ram_init()
     return err;
 }
 
-int ram_reset()
+int ram_reset(void)
 {
     int err = E_NO_ERROR;
     uint8_t data[2] = { 0x66, 0x99 };
@@ -77,7 +77,7 @@ int ram_reset()
     return err;
 }
 
-int ram_enter_quadmode()
+int ram_enter_quadmode(void)
 {
     int err = E_NO_ERROR;
     uint8_t tx_data = 0x35;
@@ -91,7 +91,7 @@ int ram_enter_quadmode()
     return err;
 }
 
-int ram_exit_quadmode()
+int ram_exit_quadmode(void)
 {
     int err = E_NO_ERROR;
     uint8_t tx_data = 0xF5;

--- a/Examples/MAX78002/CSI2/src/sram/aps6404.h
+++ b/Examples/MAX78002/CSI2/src/sram/aps6404.h
@@ -33,13 +33,13 @@ typedef struct {
     int EID;
 } ram_id_t;
 
-int ram_init();
+int ram_init(void);
 
-int ram_reset();
+int ram_reset(void);
 
-int ram_enter_quadmode();
+int ram_enter_quadmode(void);
 
-int ram_exit_quadmode();
+int ram_exit_quadmode(void);
 
 int ram_read_id(ram_id_t *out);
 

--- a/Examples/MAX78002/CSI2/src/sram/fastspi.c
+++ b/Examples/MAX78002/CSI2/src/sram/fastspi.c
@@ -107,7 +107,7 @@ void processSPI(void)
     }
 }
 
-void SPI_IRQHandler()
+void SPI_IRQHandler(void)
 {
     uint32_t status = SPI->intfl;
 
@@ -133,7 +133,7 @@ void SPI_IRQHandler()
     }
 }
 
-int dma_init()
+int dma_init(void)
 {
     if (g_dma_initialized)
         return E_NO_ERROR;

--- a/Examples/MAX78002/QSPI/aps6404.h
+++ b/Examples/MAX78002/QSPI/aps6404.h
@@ -33,13 +33,13 @@ typedef struct {
     int EID;
 } ram_id_t;
 
-int ram_init();
+int ram_init(void);
 
-int ram_reset();
+int ram_reset(void);
 
-int ram_enter_quadmode();
+int ram_enter_quadmode(void);
 
-int ram_exit_quadmode();
+int ram_exit_quadmode(void);
 
 int ram_read_id(ram_id_t *out);
 

--- a/Examples/MAX78002/QSPI/fastspi.c
+++ b/Examples/MAX78002/QSPI/fastspi.c
@@ -104,7 +104,7 @@ void processSPI(void)
     }
 }
 
-void SPI_IRQHandler()
+void SPI_IRQHandler(void)
 {
     uint32_t status = SPI->intfl;
 
@@ -130,7 +130,7 @@ void SPI_IRQHandler()
     }
 }
 
-int dma_init()
+int dma_init(void)
 {
     int err = MXC_DMA_Init();
     if (err)

--- a/Examples/MAX78002/QSPI/main.c
+++ b/Examples/MAX78002/QSPI/main.c
@@ -236,7 +236,7 @@ int main(void)
 
     if (fail_count > 0) {
         printf("\nFailed with %i mismatches (%.2f%%)!\n", fail_count,
-               100 * (((float)fail_count) / (TEST_SIZE * TEST_COUNT)));
+               (double)(100 * (((float)fail_count) / (TEST_SIZE * TEST_COUNT))));
         return E_FAIL;
     }
 

--- a/Examples/MAX78002/Watchdog/main.c
+++ b/Examples/MAX78002/Watchdog/main.c
@@ -85,7 +85,7 @@ void MXC_WDT_Setup(void)
     MXC_WDT_Enable(MXC_WDT0);
 }
 
-void SW1_Callback(void)
+void SW1_Callback(void *pb)
 {
     printf("\nEnabling Timeout Interrupt...\n");
     MXC_WDT_Disable(MXC_WDT0);
@@ -105,7 +105,7 @@ void SW1_Callback(void)
     PB_RegisterCallback(0, NULL);
 }
 
-void SW2_Callback(void)
+void SW2_Callback(void *pb)
 {
     printf("What happens if the watchdog is reset too early?\n");
     sw2_pressed = 1;

--- a/Libraries/MiscDrivers/Camera/mipi_camera.c
+++ b/Libraries/MiscDrivers/Camera/mipi_camera.c
@@ -310,7 +310,7 @@ int mipi_camera_sleep(int sleep)
     return camera.sleep(sleep);
 }
 
-int mipi_camera_capture()
+int mipi_camera_capture(void)
 {
     return MXC_CSI2_CaptureFrameDMA();
 }

--- a/Libraries/MiscDrivers/Camera/mipi_camera.h
+++ b/Libraries/MiscDrivers/Camera/mipi_camera.h
@@ -192,7 +192,7 @@ int mipi_camera_sleep(int sleep);
  * the received data in time for each new row.
  * @return 0 (E_NO_ERROR) on a successful capture of a full frame, non-zero @ref MXC_Error_Codes on failure.
  */
-int mipi_camera_capture();
+int mipi_camera_capture(void);
 
 /**
  * @brief Retrieve the current camera settings

--- a/Libraries/PeriphDrivers/Include/MAX78002/csi2.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/csi2.h
@@ -330,17 +330,19 @@ int MXC_CSI2_Stop(void);
 
 /**
  * @brief      Capture an image frame using DMA. Same as MXC_CSI2_CaptureFrameDMA.
- * @param      num_data_lanes    Number of data lanes used.
+ * @note       API changed on 7-8-2024 to remove 'num_data_lanes' as an argument.  Set
+ *             'num_lanes' in @ref mxc_csi2_ctrl_cfg_t instead, which is passed to
+ *             @ref MXC_CSI2_Init
  * @return     #E_NO_ERROR if everything is successful.
  */
-int MXC_CSI2_CaptureFrame(int num_data_lanes);
+int MXC_CSI2_CaptureFrame(void);
 
 /**
  * @brief      Capture an image frame using DMA.
  * @param      num_data_lanes    Number of data lanes used.
  * @return     #E_NO_ERROR if everything is successful.
  */
-int MXC_CSI2_CaptureFrameDMA();
+int MXC_CSI2_CaptureFrameDMA(void);
 
 /**
  * @brief      Select Lane Control Source for D0-D4 and C0.
@@ -588,7 +590,7 @@ int MXC_CSI2_PPI_Stop(void);
 
 bool MXC_CSI2_DMA_Frame_Complete(void);
 
-mxc_csi2_capture_stats_t MXC_CSI2_GetCaptureStats();
+mxc_csi2_capture_stats_t MXC_CSI2_GetCaptureStats(void);
 
 /**
  * @brief      Clears the interrupt flags for PPI.

--- a/Libraries/PeriphDrivers/Source/CSI2/csi2_ai87.c
+++ b/Libraries/PeriphDrivers/Source/CSI2/csi2_ai87.c
@@ -87,12 +87,12 @@ int MXC_CSI2_Stop(void)
     return MXC_CSI2_RevA_Stop((mxc_csi2_reva_regs_t *)MXC_CSI2);
 }
 
-int MXC_CSI2_CaptureFrame(int num_data_lanes)
+int MXC_CSI2_CaptureFrame(void)
 {
-    return MXC_CSI2_RevA_CaptureFrameDMA(num_data_lanes);
+    return MXC_CSI2_RevA_CaptureFrameDMA();
 }
 
-int MXC_CSI2_CaptureFrameDMA()
+int MXC_CSI2_CaptureFrameDMA(void)
 {
     return MXC_CSI2_RevA_CaptureFrameDMA();
 }

--- a/Libraries/PeriphDrivers/Source/CSI2/csi2_reva.c
+++ b/Libraries/PeriphDrivers/Source/CSI2/csi2_reva.c
@@ -106,7 +106,7 @@ void _free_line_buffer(void)
     }
 }
 
-int _init_line_buffer()
+int _init_line_buffer(void)
 {
     _free_line_buffer();
 
@@ -120,7 +120,7 @@ int _init_line_buffer()
     return E_NO_ERROR;
 }
 
-void _swap_line_buffer()
+void _swap_line_buffer(void)
 {
     uint8_t *temp = lb.active;
     lb.active = lb.inactive;
@@ -277,7 +277,7 @@ int MXC_CSI2_RevA_Stop(mxc_csi2_reva_regs_t *csi2)
     return E_NO_ERROR;
 }
 
-int MXC_CSI2_RevA_CaptureFrameDMA()
+int MXC_CSI2_RevA_CaptureFrameDMA(void)
 {
     int i;
     int error;
@@ -417,7 +417,7 @@ void MXC_CSI2_RevA_GetImageDetails(uint32_t *imgLen, uint32_t *w, uint32_t *h)
     *h = csi2_state.req->lines_per_frame;
 }
 
-void MXC_CSI2_RevA_Handler()
+void MXC_CSI2_RevA_Handler(void)
 {
     uint32_t ctrl_flags, vfifo_flags, ppi_flags;
 
@@ -1054,12 +1054,12 @@ bool MXC_CSI2_RevA_DMA_Frame_Complete(void)
     return g_frame_complete;
 }
 
-mxc_csi2_reva_capture_stats_t MXC_CSI2_RevA_DMA_GetCaptureStats()
+mxc_csi2_reva_capture_stats_t MXC_CSI2_RevA_DMA_GetCaptureStats(void)
 {
     return csi2_state.capture_stats;
 }
 
-void MXC_CSI2_RevA_DMA_Handler()
+void MXC_CSI2_RevA_DMA_Handler(void)
 {
     // Clear CTZ Status Flag
     if (MXC_DMA->ch[csi2_state.dma_channel].status & MXC_F_DMA_STATUS_CTZ_IF) {

--- a/Libraries/PeriphDrivers/Source/CSI2/csi2_reva.h
+++ b/Libraries/PeriphDrivers/Source/CSI2/csi2_reva.h
@@ -66,7 +66,7 @@ int MXC_CSI2_RevA_Start(mxc_csi2_reva_regs_t *csi2, int num_data_lanes);
 
 int MXC_CSI2_RevA_Stop(mxc_csi2_reva_regs_t *csi2);
 
-int MXC_CSI2_RevA_CaptureFrameDMA();
+int MXC_CSI2_RevA_CaptureFrameDMA(void);
 
 int MXC_CSI2_RevA_SetLaneCtrlSource(mxc_csi2_reva_regs_t *csi2, mxc_csi2_lane_src_t *src);
 
@@ -76,7 +76,7 @@ void MXC_CSI2_RevA_GetImageDetails(uint32_t *imgLen, uint32_t *w, uint32_t *h);
 
 int MXC_CSI2_RevA_Callback(mxc_csi2_req_t *req, int retVal);
 
-void MXC_CSI2_RevA_Handler();
+void MXC_CSI2_RevA_Handler(void);
 
 /********************************/
 /* CSI2 RX Controller Functions */
@@ -159,7 +159,7 @@ int MXC_CSI2_RevA_PPI_Stop(void);
 /* CSI2 DMA - Used for all features */
 /************************************/
 
-mxc_csi2_reva_capture_stats_t MXC_CSI2_RevA_DMA_GetCaptureStats();
+mxc_csi2_reva_capture_stats_t MXC_CSI2_RevA_DMA_GetCaptureStats(void);
 
 bool MXC_CSI2_RevA_DMA_Frame_Complete(void);
 
@@ -171,6 +171,6 @@ int MXC_CSI2_RevA_DMA_GetCurrentLineCnt(void);
 
 int MXC_CSI2_RevA_DMA_GetCurrentFrameEndCnt(void);
 
-void MXC_CSI2_RevA_DMA_Callback();
+void MXC_CSI2_RevA_DMA_Callback(mxc_dma_reva_regs_t *dma, int a, int b);
 
 #endif // LIBRARIES_PERIPHDRIVERS_SOURCE_CSI2_CSI2_REVA_H_

--- a/Libraries/PeriphDrivers/max78002_files.mk
+++ b/Libraries/PeriphDrivers/max78002_files.mk
@@ -48,7 +48,13 @@ PERIPH_DRIVER_INCLUDE_DIR += $(INCLUDE_DIR)/$(TARGET_UC)/
 # Source files
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SYS/mxc_assert.c
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SYS/mxc_delay.c
+# TODO(JC): Implement mxc_lock for RISC-V.  Skip for now.
+ifneq "$(RISCV_CORE)" "1"
+ifneq "$(RISCV_CORE)" "RV32"
+# ^ NOTE(JC): Some legacy Makefiles use "RV32".  We recommend using "1" in the UG
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SYS/mxc_lock.c
+endif
+endif
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SYS/nvic_table.c
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SYS/pins_ai87.c
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SYS/sys_ai87.c
@@ -69,9 +75,14 @@ PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/CRC
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/CRC/crc_ai87.c
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/CRC/crc_reva.c
 
+ifneq "$(RISCV_CORE)" "1"
+ifneq "$(RISCV_CORE)" "RV32"
+# The RISC-V core does not have access to the CSI2 peripheral.
 PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/CSI2
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/CSI2/csi2_ai87.c
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/CSI2/csi2_reva.c
+endif
+endif
 
 PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/DMA
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/DMA/dma_ai87.c


### PR DESCRIPTION
### Description

Primarily fixes `-wtrict-prototype` warnings for the MAX78002 peripheral driver builds.  While I was at it I also fixed double promotion and some other misc. warnings in the examples.

The build system now skips CSI2 and mxc_lock driver files for RISC-V builds (i.e. when `RISCV_CORE = 1`) to avoid those warnings as well.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.