### PR TITLE
feat(PeriphDrivers): Enable sysclk-div for MAX32690

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
@@ -203,6 +203,17 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Use the external system clock input */
 } mxc_sys_system_clock_t;
 
+typedef enum {
+    MXC_SYS_CLOCK_DIV_1 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV1,
+    MXC_SYS_CLOCK_DIV_2 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV2,
+    MXC_SYS_CLOCK_DIV_4 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV4,
+    MXC_SYS_CLOCK_DIV_8 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV8,
+    MXC_SYS_CLOCK_DIV_16 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV16,
+    MXC_SYS_CLOCK_DIV_32 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV32,
+    MXC_SYS_CLOCK_DIV_64 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV64,
+    MXC_SYS_CLOCK_DIV_128 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV128
+} mxc_sys_system_clock_div_t;
+
 #define MXC_SYS_USN_CHECKSUM_LEN 16 // Length of the USN + padding for checksum compute
 #define MXC_SYS_USN_CSUM_FIELD_LEN 2 // Size of the checksum field in the USN
 #define MXC_SYS_USN_LEN 13 // Size of the USN including the checksum
@@ -370,6 +381,18 @@ int MXC_SYS_ClockSourceDisable(mxc_sys_system_clock_t clock);
  * @returns         E_NO_ERROR if everything is successful.
  */
 int MXC_SYS_Clock_Select(mxc_sys_system_clock_t clock);
+
+/**
+ * @brief Set the system clock divider.
+ * @param div       Enumeration for desired clock divider.
+ */
+void MXC_SYS_SetClockDiv(mxc_sys_system_clock_div_t div);
+
+/**
+ * @brief Get the system clock divider.
+ * @returns         System clock divider.
+ */
+mxc_sys_system_clock_div_t MXC_SYS_GetClockDiv(void);
 
 /**
  * @brief Wait for a clock to enable with timeout

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
@@ -444,6 +444,25 @@ int MXC_SYS_Clock_Select(mxc_sys_system_clock_t clock)
 }
 
 /* ************************************************************************** */
+void MXC_SYS_SetClockDiv(mxc_sys_system_clock_div_t div)
+{
+    /* Return if this setting is already current */
+    if (div == MXC_SYS_GetClockDiv()) {
+        return;
+    }
+
+    MXC_SETFIELD(MXC_GCR->clkctrl, MXC_F_GCR_CLKCTRL_SYSCLK_DIV, div);
+
+    SystemCoreClockUpdate();
+}
+
+/* ************************************************************************** */
+mxc_sys_system_clock_div_t MXC_SYS_GetClockDiv(void)
+{
+    return (MXC_GCR->clkctrl & MXC_F_GCR_CLKCTRL_SYSCLK_DIV);
+}
+
+/* ************************************************************************** */
 void MXC_SYS_Reset_Periph(mxc_sys_reset_t reset)
 {
     /* The mxc_sys_reset_t enum uses enum values that are the offset by 32 and 64 for the rst register. */

--- a/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
@@ -69,8 +69,6 @@ static inline void Wrap_MXC_SYS_SetClockDiv(int div)
 #define ADI_MAX32_CLK_ISO MXC_SYS_CLOCK_ISO
 #endif
 
-#if !defined(CONFIG_SOC_MAX32690)
-
 #define z_sysclk_prescaler(v) MXC_SYS_CLOCK_DIV_##v
 #define sysclk_prescaler(v) z_sysclk_prescaler(v)
 
@@ -78,8 +76,6 @@ static inline void Wrap_MXC_SYS_SetClockDiv(int div)
 {
     MXC_SYS_SetClockDiv((mxc_sys_system_clock_div_t)div);
 }
-
-#endif // !defined(CONFIG_SOC_MAX32690)
 
 #endif // part number
 


### PR DESCRIPTION
MAX32690 Support sysclk-div as per of [MAX32690-UG](https://www.analog.com/media/en/technical-documentation/user-guides/ug7618.pdf) and related register definition already added in CMSIS files.
This PR enable set and get sysclk-div feature.

![image](https://github.com/analogdevicesinc/msdk/assets/46590392/4ee6ba84-c1c2-461d-87ae-d8e659a3a2dc)

Tested on MAX32690 with zephyr, it works.

### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
