### PR TITLE
fix(PeriphDrivers): IBRO_CLK is connected to timers 4-5

### DIFF
--- a/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
@@ -48,10 +48,6 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         break;
 
     case MXC_TMR_IBRO_CLK:
-        if (tmr_id > 3) { // Timers 4-5 do not support this clock source
-            return E_NOT_SUPPORTED;
-        }
-
         clockSource = MXC_TMR_CLK2;
         MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
         MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, IBRO_FREQ);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
@@ -48,7 +48,12 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         break;
 
     case MXC_TMR_IBRO_CLK:
-        clockSource = MXC_TMR_CLK2;
+        if (tmr_id <= 3) {
+            clockSource = MXC_TMR_CLK2;
+        } else {
+            clockSource = MXC_TMR_CLK0;
+        }
+        
         MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
         MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, IBRO_FREQ);
         break;

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
@@ -53,7 +53,7 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         } else {
             clockSource = MXC_TMR_CLK0;
         }
-        
+
         MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
         MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, IBRO_FREQ);
         break;


### PR DESCRIPTION
According to `data-sheets/MAX78002.pdf` page 43, IBRO is connected to LPTMR0 and LPTMR1.  
I actually tested this as I needed LPTMR0 to output IBRO.  
Therefore, `if (tmr_id > 3)` is wrong.
