### PR TITLE
fix(CMSIS): Set CTB clock to max frequency for MAX32572 startup

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_max32572.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_max32572.c
@@ -147,6 +147,10 @@ __weak void SystemInit(void)
     MXC_SYS_Clock_Select(MXC_SYS_CLOCK_IPO);
     SystemCoreClockUpdate();
 
+    /* Set CTB clock frequency to match ISO (full speed). */
+    /* On reset, GCR_CLKCTRL.crpytoclk_duv is set to 1 (ISO/2). */
+    MXC_GCR->clkctrl &= ~(MXC_F_GCR_CLKCTRL_CRYPTOCLK_DIV);
+
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO1);
 


### PR DESCRIPTION
### Description

In the MAX32572, the `GCR_CLKCTRL.cryptoclk_div` value is set to 1 (not 0 as documented) on reset. This makes the CTB block run at half speed (ISO/2). This PR sets the CTB clock to its max speed (ISO) on startup.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.