### PR TITLE
build(CMSIS): pointless RISC-V build system interruption

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
@@ -387,7 +387,6 @@ ifeq "$(RISCV_RWX_SEGMENTS_SUPPORTED)" "" # ------------------------------------
 # be on the path, and that's how we invoke the linker for our implicit rules
 LINKER_OPTIONS := $(shell $(CC) -Xlinker --help)
 ifneq "$(findstring --no-warn-rwx-segments,$(LINKER_OPTIONS))" ""
-$(error test)
 RISCV_RWX_SEGMENTS_SUPPORTED := 1
 else
 RISCV_RWX_SEGMENTS_SUPPORTED := 0


### PR DESCRIPTION
If you try to build `https://github.com/analogdevicesinc/msdk/tree/main/Examples/MAX78002/RV_ARM_Loader`, this will fail because of a hardcoded interruption. I would propose to remove this line as it does not seem to serve anything and when removed the system builds without issues.