### PR TITLE
fix(PeriphDrivers): MAX32672 timer issue

### DIFF
--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me21.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me21.c
@@ -25,14 +25,14 @@
 
 int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
 {
-    uint8_t tmr_id;
+    uint8_t tmr_id = MXC_TMR_GET_IDX(tmr);
     uint8_t clockSource = MXC_TMR_CLK0;
 
     if (cfg == NULL) {
         return E_NULL_PTR;
     }
 
-    MXC_ASSERT((tmr_id = MXC_TMR_GET_IDX(tmr)) >= 0);
+    MXC_ASSERT(tmr_id >= 0);
 
     switch (cfg->clock) {
     case MXC_TMR_EXT_CLK:
@@ -178,8 +178,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
 
 void MXC_TMR_Shutdown(mxc_tmr_regs_t *tmr)
 {
-    uint8_t tmr_id;
-    MXC_ASSERT((tmr_id = MXC_TMR_GET_IDX(tmr)) >= 0);
+    uint8_t tmr_id = MXC_TMR_GET_IDX(tmr);
+
+    MXC_ASSERT(tmr_id >= 0);
 
     MXC_TMR_RevB_Shutdown((mxc_tmr_revb_regs_t *)tmr);
 


### PR DESCRIPTION
When MXC_ASSERT not enabled timer_id uses without being set for MAX32672 timer driver, this causes run timer issue and compiler gives warnings, see below.
This PR includes fix for this.

![image](https://github.com/user-attachments/assets/1313e638-3816-4734-9154-38e9dc1633b5)


### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [X] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.