### PR TITLE
fix(PeriphDrivers): Fix build warnings for MAX32672 and MAX32662 ADC

### DIFF
--- a/Libraries/PeriphDrivers/Source/ADC/adc_me12.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me12.c
@@ -34,9 +34,9 @@
 
 #define MXC_F_MCR_ADC_CFG2_CH 0x3
 
-#define TEMP_FACTOR 530.582f / 4096.0
-#define TEMP_FACTOR1V25 1.25 * TEMP_FACTOR
-#define TEMP_FACTOR2V048 2.048 * TEMP_FACTOR
+#define TEMP_FACTOR (double)530.582f / (double)4096.0f
+#define TEMP_FACTOR1V25 (double)1.25f * TEMP_FACTOR
+#define TEMP_FACTOR2V048 (double)2.048f * TEMP_FACTOR
 
 static void initGPIOForChannel(mxc_adc_chsel_t channel)
 {
@@ -284,7 +284,7 @@ int MXC_ConvertTemperature_ToK(uint16_t tempSensor_Readout, mxc_adc_refsel_t ref
 {
     switch (ref) {
     case MXC_ADC_REF_EXT:
-        *temp_k = tempSensor_Readout * TEMP_FACTOR * ext_ref;
+        *temp_k = (double)tempSensor_Readout * (double)TEMP_FACTOR * (double)ext_ref;
         break;
 
     case MXC_ADC_REF_INT_1V25:
@@ -316,7 +316,7 @@ int MXC_ConvertTemperature_ToF(uint16_t tempSensor_Readout, mxc_adc_refsel_t ref
                                float *temp)
 {
     if (MXC_ConvertTemperature_ToK(tempSensor_Readout, ref, ext_ref, temp) == E_NO_ERROR) {
-        *temp = ((*temp * 1.8) - 459.67f);
+        *temp = (*temp * 1.8f) - 459.67f;
         return E_NO_ERROR;
     } else {
         return E_BAD_PARAM;

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me21.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me21.c
@@ -33,9 +33,9 @@
 
 #define MXC_F_MCR_ADC_CFG2_CH 0x3
 
-#define TEMP_FACTOR 530.582f / 4096.0
-#define TEMP_FACTOR1V25 1.25 * TEMP_FACTOR
-#define TEMP_FACTOR2V048 2.048 * TEMP_FACTOR
+#define TEMP_FACTOR (double)530.582f / (double)4096.0f
+#define TEMP_FACTOR1V25 (double)1.25f * TEMP_FACTOR
+#define TEMP_FACTOR2V048 (double)2.048f * TEMP_FACTOR
 
 static void initGPIOForChannel(mxc_adc_chsel_t channel)
 {
@@ -405,7 +405,7 @@ int MXC_ConvertTemperature_ToK(uint16_t tempSensor_Readout, mxc_adc_refsel_t ref
 {
     switch (ref) {
     case MXC_ADC_REF_EXT:
-        *temp_k = tempSensor_Readout * TEMP_FACTOR * ext_ref;
+        *temp_k = (double)tempSensor_Readout * (double)TEMP_FACTOR * (double)ext_ref;
         break;
 
     case MXC_ADC_REF_INT_1V25:
@@ -437,7 +437,7 @@ int MXC_ConvertTemperature_ToF(uint16_t tempSensor_Readout, mxc_adc_refsel_t ref
                                float *temp)
 {
     if (MXC_ConvertTemperature_ToK(tempSensor_Readout, ref, ext_ref, temp) == E_NO_ERROR) {
-        *temp = ((*temp * 1.8) - 459.67f);
+        *temp = (*temp * 1.8f) - 459.67f;
         return E_NO_ERROR;
     } else {
         return E_BAD_PARAM;


### PR DESCRIPTION
## Pull Request Template

### Description

Fixed build warning of ADC for MAX32672 and MAX32662 SoCs.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.