### PR TITLE
perf(Boards, MiscDrivers):  Reduce refresh time and add font color selection on TFT Display drivers for MAX32690

### DIFF
--- a/Libraries/Boards/MAX32690/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX32690/EvKit_V1/Source/board.c
@@ -191,7 +191,6 @@ void TFT_SPI_Write(uint8_t *datain, uint32_t count, bool data)
     }
 
     MXC_GPIO_OutClr(tft_cs.port, tft_cs.mask); // Assert chip select (active low)
-    MXC_Delay(10);
 
     for (int i = 0; i < count; i++) {
         tx_byte = datain[i];
@@ -214,15 +213,12 @@ void TFT_SPI_Write(uint8_t *datain, uint32_t count, bool data)
                 tx_byte = tx_byte << 1;
             }
 
-            for (int k = 0; k < 2; k++) {}
 
             tft_clk.port->out_set = tft_clk.mask; // Clk high
 
-            for (int k = 0; k < 2; k++) {}
         }
     }
 
-    MXC_Delay(10);
     MXC_GPIO_OutSet(tft_cs.port, tft_cs.mask); // De-assert chip select (active low)
 
     return;

--- a/Libraries/Boards/MAX32690/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX32690/EvKit_V1/Source/board.c
@@ -213,9 +213,7 @@ void TFT_SPI_Write(uint8_t *datain, uint32_t count, bool data)
                 tx_byte = tx_byte << 1;
             }
 
-
             tft_clk.port->out_set = tft_clk.mask; // Clk high
-
         }
     }
 

--- a/Libraries/MiscDrivers/Display/tft_st7735.c
+++ b/Libraries/MiscDrivers/Display/tft_st7735.c
@@ -755,30 +755,10 @@ void MXC_TFT_PrintFont(int x0, int y0, int id, text_t *str, area_t *area)
 
 void MXC_TFT_PrintFontColor(int x0, int y0, int id, text_t *str, unsigned int font_color, unsigned int fill_color)
 {
-    int i;
-    char value;
-
     MXC_TFT_SetForeGroundColor(font_color);
     g_background_color = fill_color;
 
-    if (id != 0)
-        MXC_TFT_SetFont(id);
-
-    locate(x0, y0);
-
-    for (i = 0; i < str->len; i++) {
-        value = str->data[i];
-
-        if (value == '\n') { // new line
-            char_x = 0;
-            char_y = char_y + g_font[2];
-            if (char_y >= height() - g_font[2]) {
-                char_y = 0;
-            }
-        } else {
-            tft_character(char_x, char_y, value);
-        }
-    }
+    MXC_TFT_PrintFont(x0, y0, id, str, NULL);
 }
 
 void MXC_TFT_Print(int x0, int y0, text_t *str, area_t *area)

--- a/Libraries/MiscDrivers/Display/tft_st7735.c
+++ b/Libraries/MiscDrivers/Display/tft_st7735.c
@@ -753,7 +753,8 @@ void MXC_TFT_PrintFont(int x0, int y0, int id, text_t *str, area_t *area)
     }
 }
 
-void MXC_TFT_PrintFontColor(int x0, int y0, int id, text_t *str, unsigned int font_color, unsigned int fill_color)
+void MXC_TFT_PrintFontColor(int x0, int y0, int id, text_t *str, unsigned int font_color,
+                            unsigned int fill_color)
 {
     MXC_TFT_SetForeGroundColor(font_color);
     g_background_color = fill_color;

--- a/Libraries/MiscDrivers/Display/tft_st7735.c
+++ b/Libraries/MiscDrivers/Display/tft_st7735.c
@@ -753,6 +753,34 @@ void MXC_TFT_PrintFont(int x0, int y0, int id, text_t *str, area_t *area)
     }
 }
 
+void MXC_TFT_PrintFontColor(int x0, int y0, int id, text_t *str, unsigned int font_color, unsigned int fill_color)
+{
+    int i;
+    char value;
+
+    MXC_TFT_SetForeGroundColor(font_color);
+    g_background_color = fill_color;
+
+    if (id != 0)
+        MXC_TFT_SetFont(id);
+
+    locate(x0, y0);
+
+    for (i = 0; i < str->len; i++) {
+        value = str->data[i];
+
+        if (value == '\n') { // new line
+            char_x = 0;
+            char_y = char_y + g_font[2];
+            if (char_y >= height() - g_font[2]) {
+                char_y = 0;
+            }
+        } else {
+            tft_character(char_x, char_y, value);
+        }
+    }
+}
+
 void MXC_TFT_Print(int x0, int y0, text_t *str, area_t *area)
 {
     MXC_TFT_PrintFont(x0, y0, (int)g_font, str, area);

--- a/Libraries/MiscDrivers/Display/tft_st7735.h
+++ b/Libraries/MiscDrivers/Display/tft_st7735.h
@@ -223,7 +223,7 @@ void MXC_TFT_ResetCursor(void);
 void MXC_TFT_PrintFont(int x0, int y0, int font_id, text_t *str, area_t *area);
 
 /**
- * @brief      Print string with selected font
+ * @brief      Print string with selected font, font color, and surrounding fill color
  *
  * @param       x0              x location on screen
  * @param       y0              y location on screen

--- a/Libraries/MiscDrivers/Display/tft_st7735.h
+++ b/Libraries/MiscDrivers/Display/tft_st7735.h
@@ -232,7 +232,8 @@ void MXC_TFT_PrintFont(int x0, int y0, int font_id, text_t *str, area_t *area);
  * @param       font_color      Color of the font text in RGB565 format
  * @param       fill_color      Color of the area surrounding the text in RGB565 format
  */
-void MXC_TFT_PrintFontColor(int x0, int y0, int id, text_t *str, unsigned int font_color, unsigned int fill_color);
+void MXC_TFT_PrintFontColor(int x0, int y0, int id, text_t *str, unsigned int font_color,
+                            unsigned int fill_color);
 
 /**
  * @brief      Print string with current font

--- a/Libraries/MiscDrivers/Display/tft_st7735.h
+++ b/Libraries/MiscDrivers/Display/tft_st7735.h
@@ -216,11 +216,23 @@ void MXC_TFT_ResetCursor(void);
  *
  * @param       x0              x location on screen
  * @param       y0              y location on screen
- * @param       fon_id          Font number
+ * @param       id              Font number ID
  * @param       str             String which will be display
  * @param       area            Location of printf outputs
  */
 void MXC_TFT_PrintFont(int x0, int y0, int font_id, text_t *str, area_t *area);
+
+/**
+ * @brief      Print string with selected font
+ *
+ * @param       x0              x location on screen
+ * @param       y0              y location on screen
+ * @param       id              Font number ID
+ * @param       str             String which will be display
+ * @param       font_color      Color of the font text in RGB565 format
+ * @param       fill_color      Color of the area surrounding the text in RGB565 format
+ */
+void MXC_TFT_PrintFontColor(int x0, int y0, int id, text_t *str, unsigned int font_color, unsigned int fill_color);
 
 /**
  * @brief      Print string with current font


### PR DESCRIPTION
### Description

Slight modifications to the TFT LCD display drivers on the MAX32690 EV Kit V1 board.
- Removed delays in `TFT_SPI_Write()` to reduce the screen refresh time from 0.87129 seconds to 0.120858 seconds -- an 86% improvement.
- `MXC_TFT_PrintFont()` would use the initially set background color around the printed text. Added a function to offer color selection of both the background and the font text.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
