### PR TITLE
feat(PeriphDrivers): Add Clock Setter APIs for MAX32690 & MAX78002 Peripherals, Add Dual Mode TMR Support, Add MAX32690 Clock Calibration API for IPO, Add MAX32690 RISCV Clock Setter, CFS Support Functions

### DIFF
--- a/Libraries/Boards/MAX78002/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX78002/EvKit_V1/Source/board.c
@@ -370,7 +370,11 @@ int Console_Init(void)
 {
     int err;
 
-    if ((err = MXC_UART_Init(ConsoleUart, CONSOLE_BAUD, MXC_UART_IBRO_CLK)) != E_NO_ERROR) {
+    MXC_UART_Enable(ConsoleUart);
+    MXC_UART_SetClockSource(ConsoleUart, MXC_UART_IBRO_CLK);
+    MXC_UART_LockClockSource(ConsoleUart);
+
+    if ((err = MXC_UART_Init(ConsoleUart, CONSOLE_BAUD, MXC_UART_APB_CLK)) != E_NO_ERROR) {
         return err;
     }
 

--- a/Libraries/Boards/MAX78002/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX78002/EvKit_V1/Source/board.c
@@ -370,11 +370,7 @@ int Console_Init(void)
 {
     int err;
 
-    MXC_UART_Enable(ConsoleUart);
-    MXC_UART_SetClockSource(ConsoleUart, MXC_UART_IBRO_CLK);
-    MXC_UART_LockClockSource(ConsoleUart);
-
-    if ((err = MXC_UART_Init(ConsoleUart, CONSOLE_BAUD, MXC_UART_APB_CLK)) != E_NO_ERROR) {
+    if ((err = MXC_UART_Init(ConsoleUart, CONSOLE_BAUD, MXC_UART_IBRO_CLK)) != E_NO_ERROR) {
         return err;
     }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.h
@@ -834,6 +834,15 @@ typedef enum {
 #define MXC_USBHS_NUM_DMA 8 /* HW must have at least this many DMA channels */
 #define MXC_USBHS_MAX_PACKET 512
 
+/** @brief USB clock source options */
+typedef enum {
+    MXC_USB_CLOCK_SYS_DIV_10 = 0, ///< SYS_CLK divded by 10
+    MXC_USB_CLOCK_EXTCLK = 1, ///< External clock input
+    MXC_USB_CLOCK_ERFO = 2 ///< External RF Oscillator input
+} _mxc_usb_clock_t;
+
+#define mxc_usb_clock_t _mxc_usb_clock_t
+
 /******************************************************************************/
 /*                                                  Low Power General control */
 #define MXC_BASE_LPGCR ((uint32_t)0x40080000UL)

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.h
@@ -339,10 +339,7 @@ typedef enum {
 #define MXC_BASE_WDT1 ((uint32_t)0x40080800UL)
 #define MXC_WDT1 ((mxc_wdt_regs_t *)MXC_BASE_WDT1)
 
-#define MXC_WDT_GET_IDX(p) \
-    ((p) == MXC_WDT0 ? 0 : \
-     (p) == MXC_WDT1 ? 1 : \
-                      -1)
+#define MXC_WDT_GET_IDX(p) ((p) == MXC_WDT0 ? 0 : (p) == MXC_WDT1 ? 1 : -1)
 
 /******************************************************************************/
 /*                                                                   AES Keys */

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.h
@@ -339,6 +339,11 @@ typedef enum {
 #define MXC_BASE_WDT1 ((uint32_t)0x40080800UL)
 #define MXC_WDT1 ((mxc_wdt_regs_t *)MXC_BASE_WDT1)
 
+#define MXC_WDT_GET_IDX(p) \
+    ((p) == MXC_WDT0 ? 0 : \
+     (p) == MXC_WDT1 ? 1 : \
+                      -1)
+
 /******************************************************************************/
 /*                                                                   AES Keys */
 #define MXC_BASE_AESKEYS ((uint32_t)0x40005000UL)

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.h
@@ -843,6 +843,12 @@ typedef enum {
     MXC_USB_CLOCK_ERFO = 2 ///< External RF Oscillator input
 } _mxc_usb_clock_t;
 
+/**
+ * @brief   USB clock source options macro
+ * @note    (Developers): "mxc_usb_clock_t" should be defined as a macro in the top-level 
+            file here so that the pre-processor can check for its existence when the USB
+            library is built.  The macro should pass through to the actual enum
+*/
 #define mxc_usb_clock_t _mxc_usb_clock_t
 
 /******************************************************************************/

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_max32690.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_max32690.c
@@ -111,6 +111,12 @@ __weak void PinInit(void)
     /* Do nothing */
 }
 
+__weak int ClockInit(void)
+{
+    /* Do nothing */
+    return E_NO_ERROR;
+}
+
 /* This function can be implemented by the application to initialize the board */
 __weak int Board_Init(void)
 {
@@ -162,6 +168,7 @@ __weak void SystemInit(void)
     PalSysInit();
 
     PinInit();
+    ClockInit();
     Board_Init();
 
     __enable_irq();

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Include/max78002.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Include/max78002.h
@@ -677,6 +677,15 @@ typedef enum {
 #define MXC_USBHS_NUM_DMA 8 /* HW must have at least this many DMA channels */
 #define MXC_USBHS_MAX_PACKET 512
 
+/** @brief USB clock source options */
+typedef enum {
+    MXC_USB_CLOCK_SYS_DIV_10 = 0, ///< SYS_CLK divded by 10
+    MXC_USB_CLOCK_EXTCLK = 1, ///< External clock input
+    MXC_USB_CLOCK_ERFO = 2 ///< External RF Oscillator input
+} _mxc_usb_clock_t;
+
+#define mxc_usb_clock_t _mxc_usb_clock_t
+
 /******************************************************************************/
 /*                                                                       SDHC */
 #define MXC_BASE_SDHC ((uint32_t)0x400B6000UL)

--- a/Libraries/MAXUSB/include/core/usb.h
+++ b/Libraries/MAXUSB/include/core/usb.h
@@ -21,6 +21,7 @@
 #ifndef LIBRARIES_MAXUSB_INCLUDE_CORE_USB_H_
 #define LIBRARIES_MAXUSB_INCLUDE_CORE_USB_H_
 
+#include <stdbool.h>
 #include "usb_hwopt.h"
 #include "usb_protocol.h"
 
@@ -160,6 +161,16 @@ typedef enum {
  * 
  */
 int MXC_USB_SetClockSource(mxc_usb_clock_t clock_source);
+
+/**
+ * @brief   Lock the input clock source to the USB peripheral.
+ *
+ * @param   lock Whether to lock the clock source.  Set to true to lock, false to unlock.
+ *  
+ * @return This function returns zero (0) for success, non-zero for failure
+ * 
+ */
+int MXC_USB_LockClockSource(bool lock);
 
 /** 
  * @brief Shut down the USB peripheral block

--- a/Libraries/MAXUSB/include/core/usb.h
+++ b/Libraries/MAXUSB/include/core/usb.h
@@ -135,6 +135,32 @@ typedef struct {
  */
 int MXC_USB_Init(maxusb_cfg_options_t *options);
 
+#ifndef mxc_usb_clock_t
+#warning "mxc_usb_clock_t" not implemented.  See note in usb.h on "MXC_USB_SetClockSource"
+typedef enum {
+  MXC_USB_CLOCK_0 = 0,
+  MXC_USB_CLOCK_1 = 1,
+  MXC_USB_CLOCK_2 = 2
+} mxc_usb_clock_t;
+#endif
+
+/**
+ * @brief Set the input clock source to the USB peripheral.
+ *
+ * @param   clock_source Input clock source
+ * @note    (Developers): "mxc_usb_clock_t" should be defined as a macro in the top-level "max32xxx.h" file
+ *          so that the pre-processor can check for its existence.  Ex:
+ * 
+ *          #define mxc_usb_clock_t _mxc_usb_clock_t
+ * 
+ *          where "_mxc_usb_clock_t" is the actual "typedef enum".
+ *          See "max32690.h" for reference.
+ *  
+ * @return This function returns zero (0) for success, non-zero for failure
+ * 
+ */
+int MXC_USB_SetClockSource(mxc_usb_clock_t clock_source);
+
 /** 
  * @brief Shut down the USB peripheral block
  *

--- a/Libraries/MAXUSB/include/core/usb.h
+++ b/Libraries/MAXUSB/include/core/usb.h
@@ -136,6 +136,10 @@ typedef struct {
  */
 int MXC_USB_Init(maxusb_cfg_options_t *options);
 
+#ifdef MAX32690
+// Clock setter mux APIs are currently only supported on the MAX32690.  It does not exist
+// on earlier hardware revisions such as the MAX32650
+
 #ifndef mxc_usb_clock_t
 #warning "mxc_usb_clock_t" not implemented.  See note in usb.h on "MXC_USB_SetClockSource"
 typedef enum {
@@ -171,6 +175,8 @@ int MXC_USB_SetClockSource(mxc_usb_clock_t clock_source);
  * 
  */
 int MXC_USB_LockClockSource(bool lock);
+
+#endif
 
 /** 
  * @brief Shut down the USB peripheral block

--- a/Libraries/MAXUSB/src/core/musbhsfc/usb.c
+++ b/Libraries/MAXUSB/src/core/musbhsfc/usb.c
@@ -26,8 +26,12 @@
 #include "mxc_errors.h"
 #include "mxc_sys.h"
 #include "usbhs_regs.h"
-#include "fcr_regs.h"
 #include "usb.h"
+
+#ifdef MAX32690
+#include "fcr_regs.h"
+static bool g_is_clock_locked = false;
+#endif
 
 #define USBHS_M31_CLOCK_RECOVERY
 
@@ -46,8 +50,6 @@ static unsigned int ep_size[MXC_USBHS_NUM_EP];
 static setup_phase_t setup_phase = SETUP_IDLE;
 /* Driver options passed in during MXC_USB_Init() */
 static maxusb_cfg_options_t driver_opts;
-
-static bool g_is_clock_locked = false;
 
 static volatile uint8_t *get_fifo_ptr(unsigned int ep)
 {
@@ -176,6 +178,8 @@ int MXC_USB_Init(maxusb_cfg_options_t *options)
     return 0;
 }
 
+#ifdef MAX32690
+
 int MXC_USB_LockClockSource(bool lock)
 {
     g_is_clock_locked = lock;
@@ -206,6 +210,8 @@ int MXC_USB_SetClockSource(mxc_usb_clock_t clock_source)
 
     return E_NO_ERROR;
 }
+
+#endif
 
 int MXC_USB_Shutdown(void)
 {

--- a/Libraries/MAXUSB/src/core/musbhsfc/usb.c
+++ b/Libraries/MAXUSB/src/core/musbhsfc/usb.c
@@ -47,6 +47,8 @@ static setup_phase_t setup_phase = SETUP_IDLE;
 /* Driver options passed in during MXC_USB_Init() */
 static maxusb_cfg_options_t driver_opts;
 
+static bool g_is_clock_locked = false;
+
 static volatile uint8_t *get_fifo_ptr(unsigned int ep)
 {
     volatile uint32_t *ptr;
@@ -174,8 +176,18 @@ int MXC_USB_Init(maxusb_cfg_options_t *options)
     return 0;
 }
 
+int MXC_USB_LockClockSource(bool lock)
+{
+    g_is_clock_locked = lock;
+    return E_NO_ERROR;
+}
+
 int MXC_USB_SetClockSource(mxc_usb_clock_t clock_source)
 {
+    if (g_is_clock_locked) {
+        return E_BAD_STATE; // Clock source must be unlocked to set it.
+    }
+
     // The USB peripheral's clock source is set in the FCR register bank.
     // The actual clock source selected by each field value may vary between 
     // microcontrollers, so it is the responsibility of the implementer to define

--- a/Libraries/MAXUSB/src/core/musbhsfc/usb.c
+++ b/Libraries/MAXUSB/src/core/musbhsfc/usb.c
@@ -193,7 +193,7 @@ int MXC_USB_SetClockSource(mxc_usb_clock_t clock_source)
     }
 
     // The USB peripheral's clock source is set in the FCR register bank.
-    // The actual clock source selected by each field value may vary between 
+    // The actual clock source selected by each field value may vary between
     // microcontrollers, so it is the responsibility of the implementer to define
     // mxc_usb_clock_t correctly in the top-level "max32xxx.h" file.  The enum values
     // should match the field values when type-casted to an unsigned int.

--- a/Libraries/PeriphDrivers/Include/MAX32690/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/adc.h
@@ -98,10 +98,16 @@ typedef enum {
  * @brief       Clock settings
  */
 typedef enum {
-    MXC_ADC_HCLK = 0, ///< HCLK CLock
-    MXC_ADC_CLK_ADC0, ///< ADC0 Clock
-    MXC_ADC_CLK_ADC1, ///< ADC1 Clock
-    MXC_ADC_CLK_ADC2, ///< ADC2 Clock
+    MXC_ADC_CLK_SYS_OSC = 0,
+    MXC_ADC_CLK_EXT = 1,
+    MXC_ADC_CLK_IBRO = 2,
+    MXC_ADC_CLK_ERFO = 3,
+
+    // Legacy names
+    MXC_ADC_HCLK = MXC_ADC_CLK_SYS_OSC, ///< HCLK CLock
+    MXC_ADC_CLK_ADC0 = MXC_ADC_CLK_EXT, ///< ADC0 Clock
+    MXC_ADC_CLK_ADC1 = MXC_ADC_CLK_IBRO, ///< ADC1 Clock
+    MXC_ADC_CLK_ADC2 = MXC_ADC_CLK_ERFO, ///< ADC2 Clock
 } mxc_adc_clock_t;
 
 /**
@@ -234,6 +240,22 @@ typedef struct {
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
  */
 int MXC_ADC_Init(mxc_adc_req_t *req);
+
+/**
+ * @brief   Set the input clock source for the ADC peripheral
+ *
+ * @param   clock_source Input clock source 
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_ADC_SetClockSource(mxc_adc_clock_t clock_source);
+
+/**
+ * @brief   Set the clock divider the ADC peripheral's input clock
+ *
+ * @param   div Clock divider
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_ADC_SetClockDiv(mxc_adc_clkdiv_t div);
 
 /**
  * @brief   Shuts down the ADC

--- a/Libraries/PeriphDrivers/Include/MAX32690/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/adc.h
@@ -28,6 +28,7 @@
 #define LIBRARIES_PERIPHDRIVERS_INCLUDE_MAX32690_ADC_H_
 
 /* **** Includes **** */
+#include <stdbool.h>
 #include <stdint.h>
 #include "adc_regs.h"
 #include "mcr_regs.h"
@@ -248,6 +249,15 @@ int MXC_ADC_Init(mxc_adc_req_t *req);
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
  */
 int MXC_ADC_SetClockSource(mxc_adc_clock_t clock_source);
+
+/**
+ * @brief   Lock the input clock source for the ADC peripheral.  The clock source
+ *          must be unlocked for it to be set.
+ *
+ * @param   lock Whether to lock the clock source.  Set to true to lock, false, to unlock. 
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_ADC_LockClockSource(bool lock);
 
 /**
  * @brief   Set the clock divider the ADC peripheral's input clock

--- a/Libraries/PeriphDrivers/Include/MAX32690/mxc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/mxc.h
@@ -1,0 +1,78 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Analog Devices, Inc.),
+ * Copyright (C) 2023-2024 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#ifndef LIBRARIES_PERIPHDRIVERS_INCLUDE_MAX32690_MXC_H_
+#define LIBRARIES_PERIPHDRIVERS_INCLUDE_MAX32690_MXC_H_
+
+#ifdef __riscv
+// TODO(JC): This is a somewhat ugly hack added to avoid
+// implicit function warnings on RISC-V projects
+// when LIB_BOARD was added to libs.mk.  When the
+// RISC-V build system is improved to use libs.mk
+// this should be removed.
+#ifndef LIB_BOARD
+#define LIB_BOARD
+#endif
+#endif
+
+#include "mxc_device.h"
+#include "mxc_delay.h"
+#include "mxc_assert.h"
+#include "mxc_errors.h"
+#include "mxc_lock.h"
+#include "mxc_pins.h"
+#include "mxc_sys.h"
+#include "nvic_table.h"
+#ifdef LIB_BOARD
+#include "board.h"
+#endif
+
+/*
+ *  Peripheral Driver Includes
+ */
+#include "adc.h"
+#include "aes.h"
+#include "can.h"
+#include "crc.h"
+#include "ctb.h"
+#include "dma.h"
+#include "emcc.h"
+#include "flc.h"
+#include "gpio.h"
+#include "hpb.h"
+#include "i2c.h"
+#include "i2s.h"
+#include "icc.h"
+#include "lp.h"
+#include "lpcmp.h"
+#include "owm.h"
+#include "pt.h"
+#include "rtc.h"
+#include "sema.h"
+#include "spi.h"
+#include "spixf.h"
+#include "spixr.h"
+#include "tmr.h"
+#include "trng.h"
+#include "uart.h"
+#include "wdt.h"
+#include "wut.h"
+
+#endif // LIBRARIES_PERIPHDRIVERS_INCLUDE_MAX32690_MXC_H_

--- a/Libraries/PeriphDrivers/Include/MAX32690/mxc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/mxc.h
@@ -48,7 +48,7 @@
  *  Peripheral Driver Includes
  */
 #include "adc.h"
-#include "aes.h"
+// #include "aes.h" // TODO(JC): AES drivers not implemented for ME18 (?)
 #include "can.h"
 #include "crc.h"
 #include "ctb.h"

--- a/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
@@ -202,10 +202,6 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_ERTCO, /**< Select the External RTC Crystal Oscillator */
     MXC_SYS_CLOCK_EXTCLK =
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Use the external system clock input */
-#ifdef __riscv
-    ,
-    MXC_SYS_CLOCK_PCLK /**< Use the PCLK as the RISC-V system clock */
-#endif
 } mxc_sys_system_clock_t;
 
 typedef enum {

--- a/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
@@ -202,6 +202,10 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_ERTCO, /**< Select the External RTC Crystal Oscillator */
     MXC_SYS_CLOCK_EXTCLK =
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Use the external system clock input */
+#ifdef __riscv
+    ,
+    MXC_SYS_CLOCK_PCLK /**< Use the PCLK as the RISC-V system clock */
+#endif
 } mxc_sys_system_clock_t;
 
 typedef enum {

--- a/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
@@ -26,6 +26,7 @@
 #ifndef LIBRARIES_PERIPHDRIVERS_INCLUDE_MAX32690_MXC_SYS_H_
 #define LIBRARIES_PERIPHDRIVERS_INCLUDE_MAX32690_MXC_SYS_H_
 
+#include <stdbool.h>
 #include "mxc_device.h"
 #include "lpgcr_regs.h"
 #include "gcr_regs.h"
@@ -428,6 +429,18 @@ uint32_t MXC_SYS_RiscVClockRate(void);
  *          to reprogram the target micro.
  */
 int MXC_SYS_LockDAP_Permanent(void);
+
+/**
+ * @brief Bypass the crystal oscillator driver circuit for the specified clock.  Some clock sources
+ *        support this option, allowing an external square wave input signal to be fed directly to the
+ *        clock's input pin.  Refer to the microcontroller's User Guide for more details.
+ *
+ * @param   clock The clock source target
+ * @param   bypass Bypass the oscillator circuit or not.  Set to true to bypass, false to disable the bypass
+ * 
+ * @return @ref MXC_Error_Codes
+ */
+int MXC_SYS_SetBypass(mxc_sys_system_clock_t clock, bool bypass);
 
 #ifdef __cplusplus
 }

--- a/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
@@ -396,6 +396,14 @@ void MXC_SYS_SetClockDiv(mxc_sys_system_clock_div_t div);
 mxc_sys_system_clock_div_t MXC_SYS_GetClockDiv(void);
 
 /**
+ * @brief Calibrate the specified system clock.
+ * @param   clock Clock source to calibrate.  Note usually only the IPO supports calibration.  
+ *          Check the microcontroller's UG for more details.
+ * @returns         E_NO_ERROR if everything is successful.
+ */
+int MXC_SYS_ClockCalibrate(mxc_sys_system_clock_t clock);
+
+/**
  * @brief Wait for a clock to enable with timeout
  * @param      ready The clock to wait for
  * @return     E_NO_ERROR if ready, E_TIME_OUT if timeout

--- a/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
@@ -205,6 +205,11 @@ typedef enum {
 } mxc_sys_system_clock_t;
 
 typedef enum {
+    MXC_SYS_RISCV_CLOCK_ISO, /**< Select the Internal Secondary Oscillator (ISO) as the RISCV clock source */
+    MXC_SYS_RISCV_CLOCK_PCLK /**< Select the Advanced Peripheral Bus (APB) clock as the RISCV clock source */
+} mxc_sys_riscv_clock_t;
+
+typedef enum {
     MXC_SYS_CLOCK_DIV_1 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV1,
     MXC_SYS_CLOCK_DIV_2 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV2,
     MXC_SYS_CLOCK_DIV_4 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV4,
@@ -424,6 +429,14 @@ void MXC_SYS_RISCVRun(void);
  * @brief Shutdown the RISCV core 
  */
 void MXC_SYS_RISCVShutdown(void);
+
+/**
+ * @brief Set the clock source for the RISC-V core.
+ * 
+ * @param clock The clock source to set
+ * @returns 0 if successful, @ref MXC_Error_Codes on errors
+ */
+int MXC_SYS_RISCVClockSelect(mxc_sys_riscv_clock_t clock);
 
 /**
  * @brief Returns the clock rate (in Hz) of the Risc-V core.

--- a/Libraries/PeriphDrivers/Include/MAX32690/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/tmr.h
@@ -209,7 +209,8 @@ void MXC_TMR_LockClockSource(mxc_tmr_regs_t *tmr, bool lock);
  * @param   bit_mode Bit mode of the TMR module.
  * @param   clk_src Desired clock source.
  */
-uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_clock_t clk_src);
+uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
+                               mxc_tmr_clock_t clk_src);
 
 /**
  * @brief   Set the input clock prescalar for the specified timer instance.
@@ -217,7 +218,8 @@ uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
  * @param   bit_mode Bit mode of the TMR module.
  * @param   prescalar Desired clock source prescalar.
  */
-void MXC_TMR_SetPrescalar(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_pres_t prescalar);
+void MXC_TMR_SetPrescalar(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
+                          mxc_tmr_pres_t prescalar);
 
 /**
  * @brief   Shutdown timer module clock.

--- a/Libraries/PeriphDrivers/Include/MAX32690/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/tmr.h
@@ -195,6 +195,31 @@ typedef void (*mxc_tmr_complete_t)(int error);
 int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins);
 
 /**
+ * @brief   Lock the clock source for the specified timer instance.  If the clock source is locked,
+ *          @ref MXC_TMR_SetClockSource will have no effect.
+ * @param   tmr  Pointer to timer instance
+ * @param   lock Whether to lock the clock source or not.  Set to true to lock, false to unlock
+ */
+void MXC_TMR_LockClockSource(mxc_tmr_regs_t *tmr, bool lock);
+
+/**
+ * @brief   Set the clock source for the specified timer instance.  Note this API will have no effect
+ *          if the clock source has been locked via @ref MXC_TMR_LockClockSource
+ * @param   tmr  Pointer to timer instance
+ * @param   bit_mode Bit mode of the TMR module.
+ * @param   clk_src Desired clock source.
+ */
+void MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_clock_t clk_src);
+
+/**
+ * @brief   Set the input clock prescalar for the specified timer instance.
+ * @param   tmr  Pointer to timer instance
+ * @param   bit_mode Bit mode of the TMR module.
+ * @param   prescalar Desired clock source prescalar.
+ */
+void MXC_TMR_SetPrescalar(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_pres_t prescalar);
+
+/**
  * @brief   Shutdown timer module clock.
  * @param   tmr  Pointer to timer module to initialize.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32690/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/tmr.h
@@ -209,7 +209,7 @@ void MXC_TMR_LockClockSource(mxc_tmr_regs_t *tmr, bool lock);
  * @param   bit_mode Bit mode of the TMR module.
  * @param   clk_src Desired clock source.
  */
-void MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_clock_t clk_src);
+uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_clock_t clk_src);
 
 /**
  * @brief   Set the input clock prescalar for the specified timer instance.

--- a/Libraries/PeriphDrivers/Include/MAX32690/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/uart.h
@@ -78,14 +78,10 @@ typedef enum {
 /**
  * @brief      Clock settings */
 typedef enum {
-    /*For UART3 APB clock source is the 8MHz clock*/
-    MXC_UART_APB_CLK = 0,
-    MXC_UART_EXT_CLK = 1,
-    /*IBRO and ERFO clock can only be used for UART 0, 1 & 2*/
-    MXC_UART_IBRO_CLK = 2,
-    MXC_UART_ERFO_CLK = 3,
-    /*ERTCO clock can only be used for UART3*/
-    MXC_UART_ERTCO_CLK = 4,
+    MXC_UART_APB_CLK = 0, ///< Use the APB clock.  Can only be used for UART 0, 1 & 2
+    MXC_UART_ERFO_CLK = 1, ///< Use the ERFO.  Can only be used for UART 0, 1 & 2
+    MXC_UART_IBRO_CLK = 2, ///< Use the IBRO.  Can be used for all UART instances
+    MXC_UART_ERTCO_CLK = 3, ///< Use the ERTCO.  Can only be used for UART3 (LPUART0)
 } mxc_uart_clock_t;
 
 /**
@@ -258,6 +254,8 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
  *          for a list of return codes.
  */
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock);
+
+mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart);
 
 /**
  * @brief   Lock the clock source for the baud rate generator.  It must be unlocked before

--- a/Libraries/PeriphDrivers/Include/MAX32690/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/uart.h
@@ -259,6 +259,16 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
  */
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock);
 
+/**
+ * @brief   Lock the clock source for the baud rate generator.  It must be unlocked before
+ *          it can be set again.
+ * 
+ * @param   uart    Pointer to UART registers (selects the UART block used.)
+ * @param   lock    Set to true to lock the clock source, false to unlock the clock source.
+ *
+ */
+void MXC_UART_LockClockSource(mxc_uart_regs_t *uart, bool lock);
+
 /* ************************************************************************* */
 /* Low-level functions                                                       */
 /* ************************************************************************* */

--- a/Libraries/PeriphDrivers/Include/MAX32690/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/wdt.h
@@ -222,6 +222,14 @@ void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt);
  */
 int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source);
 
+/**
+ * @brief       Lock the input clock source for the WDT.  The clock source must be unlocked
+ *              to be set again.
+ * @param       wdt     Pointer to watchdog registers.
+ * @param       lock    Whether to lock the clock source.  Set to true to lock, false to unlock.
+ */
+int MXC_WDT_LockClockSource(mxc_wdt_regs_t *wdt, bool lock);
+
 /**@} end of group wdt */
 
 #ifdef __cplusplus

--- a/Libraries/PeriphDrivers/Include/MAX32690/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/wdt.h
@@ -94,6 +94,7 @@ typedef enum {
  */
 typedef enum {
     MXC_WDT_PCLK = 0,
+    MXC_WDT_APB_CLK = MXC_WDT_PCLK,
     MXC_WDT_IBRO_CLK,
     MXC_WDT_INRO_CLK,
     MXC_WDT_ERTCO_CLK,

--- a/Libraries/PeriphDrivers/Include/MAX78002/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/tmr.h
@@ -192,6 +192,31 @@ typedef void (*mxc_tmr_complete_t)(int error);
 int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins);
 
 /**
+ * @brief   Lock the clock source for the specified timer instance.  If the clock source is locked,
+ *          @ref MXC_TMR_SetClockSource will have no effect.
+ * @param   tmr  Pointer to timer instance
+ * @param   lock Whether to lock the clock source or not.  Set to true to lock, false to unlock
+ */
+void MXC_TMR_LockClockSource(mxc_tmr_regs_t *tmr, bool lock);
+
+/**
+ * @brief   Set the clock source for the specified timer instance.  Note this API will have no effect
+ *          if the clock source has been locked via @ref MXC_TMR_LockClockSource
+ * @param   tmr  Pointer to timer instance
+ * @param   bit_mode Bit mode of the TMR module.
+ * @param   clk_src Desired clock source.
+ */
+void MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_clock_t clk_src);
+
+/**
+ * @brief   Set the input clock prescalar for the specified timer instance.
+ * @param   tmr  Pointer to timer instance
+ * @param   bit_mode Bit mode of the TMR module.
+ * @param   prescalar Desired clock source prescalar.
+ */
+void MXC_TMR_SetPrescalar(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_pres_t prescalar);
+
+/**
  * @brief   Shutdown timer module clock.
  * @param   tmr  Pointer to timer module to initialize.
  */

--- a/Libraries/PeriphDrivers/Include/MAX78002/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/tmr.h
@@ -206,7 +206,7 @@ void MXC_TMR_LockClockSource(mxc_tmr_regs_t *tmr, bool lock);
  * @param   bit_mode Bit mode of the TMR module.
  * @param   clk_src Desired clock source.
  */
-void MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_clock_t clk_src);
+uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_clock_t clk_src);
 
 /**
  * @brief   Set the input clock prescalar for the specified timer instance.

--- a/Libraries/PeriphDrivers/Include/MAX78002/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/tmr.h
@@ -206,7 +206,8 @@ void MXC_TMR_LockClockSource(mxc_tmr_regs_t *tmr, bool lock);
  * @param   bit_mode Bit mode of the TMR module.
  * @param   clk_src Desired clock source.
  */
-uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_clock_t clk_src);
+uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
+                               mxc_tmr_clock_t clk_src);
 
 /**
  * @brief   Set the input clock prescalar for the specified timer instance.
@@ -214,7 +215,8 @@ uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
  * @param   bit_mode Bit mode of the TMR module.
  * @param   prescalar Desired clock source prescalar.
  */
-void MXC_TMR_SetPrescalar(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_pres_t prescalar);
+void MXC_TMR_SetPrescalar(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
+                          mxc_tmr_pres_t prescalar);
 
 /**
  * @brief   Shutdown timer module clock.

--- a/Libraries/PeriphDrivers/Include/MAX78002/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/uart.h
@@ -131,14 +131,6 @@ struct _mxc_uart_req_t {
 /* ************************************************************************* */
 
 /**
- * @brief   Enable (but do not initialize) a UART peripheral.  This enables the peripheral
- *          clock only, "powering on" the peripheral.
-
- * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
- */
-int MXC_UART_Enable(mxc_uart_regs_t *uart);
-
-/**
  * @brief   Initialize and enable UART peripheral.
  * 
  * This function initializes everything necessary to call a UART transaction function.

--- a/Libraries/PeriphDrivers/Include/MAX78002/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/uart.h
@@ -77,11 +77,7 @@ typedef enum {
 
 /**
  * @brief      Clock settings */
-typedef enum {
-    MXC_UART_APB_CLK = 0,
-    MXC_UART_IBRO_CLK,
-    MXC_UART_ERTCO_CLK
-} mxc_uart_clock_t;
+typedef enum { MXC_UART_APB_CLK = 0, MXC_UART_IBRO_CLK, MXC_UART_ERTCO_CLK } mxc_uart_clock_t;
 
 /**
  * @brief   The callback routine used to indicate the transaction has terminated.

--- a/Libraries/PeriphDrivers/Include/MAX78002/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/uart.h
@@ -131,6 +131,14 @@ struct _mxc_uart_req_t {
 /* ************************************************************************* */
 
 /**
+ * @brief   Enable (but do not initialize) a UART peripheral.  This enables the peripheral
+ *          clock only, "powering on" the peripheral.
+
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_UART_Enable(mxc_uart_regs_t *uart);
+
+/**
  * @brief   Initialize and enable UART peripheral.
  * 
  * This function initializes everything necessary to call a UART transaction function.
@@ -244,10 +252,29 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
  * @param   uart         Pointer to UART registers (selects the UART block used.)
  * @param   clock        Clock source
  *
- * @return  Actual baud rate if successful, otherwise see \ref MXC_Error_Codes 
- *          for a list of return codes.
+ * @return  See \ref MXC_Error_Codes for a list of return codes.
  */
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock);
+
+mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart);
+
+/**
+ * @brief   Locks the clock source for the baud rate generator.
+ * 
+ * @param   uart         Pointer to UART registers (selects the UART block used.)
+ *
+ * @return  See \ref MXC_Error_Codes for a list of return codes.
+ */
+void MXC_UART_LockClockSource(mxc_uart_regs_t *uart);
+
+/**
+ * @brief   Unlocks the clock source for the baud rate generator.
+ * 
+ * @param   uart         Pointer to UART registers (selects the UART block used.)
+ *
+ * @return  See \ref MXC_Error_Codes for a list of return codes.
+ */
+void MXC_UART_UnlockClockSource(mxc_uart_regs_t *uart);
 
 /* ************************************************************************* */
 /* Low-level functions                                                       */

--- a/Libraries/PeriphDrivers/Include/MAX78002/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/uart.h
@@ -78,13 +78,9 @@ typedef enum {
 /**
  * @brief      Clock settings */
 typedef enum {
-    /*For UART3 APB clock source is the 8MHz clock*/
     MXC_UART_APB_CLK = 0,
-    MXC_UART_EXT_CLK = 1,
-    /*IBRO clock can only be used for UART 0, 1 & 2*/
-    MXC_UART_IBRO_CLK = 2,
-    /*ERTCO clock can only be used for UART3*/
-    MXC_UART_ERTCO_CLK = 4,
+    MXC_UART_IBRO_CLK,
+    MXC_UART_ERTCO_CLK
 } mxc_uart_clock_t;
 
 /**

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me18.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me18.c
@@ -115,6 +115,16 @@ int MXC_ADC_Init(mxc_adc_req_t *req)
     return MXC_ADC_RevB_Init((mxc_adc_revb_regs_t *)MXC_ADC, req);
 }
 
+int MXC_ADC_SetClockSource(mxc_adc_clock_t clock_source)
+{
+    return MXC_ADC_RevB_SetClockSource((mxc_adc_revb_regs_t *)MXC_ADC, clock_source);
+}
+
+int MXC_ADC_SetClockDiv(mxc_adc_clkdiv_t div)
+{
+    return MXC_ADC_RevB_SetClockDiv((mxc_adc_revb_regs_t *)MXC_ADC, div);
+}
+
 int MXC_ADC_Shutdown(void)
 {
     MXC_ADC_RevB_Shutdown((mxc_adc_revb_regs_t *)MXC_ADC);

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me18.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me18.c
@@ -120,6 +120,11 @@ int MXC_ADC_SetClockSource(mxc_adc_clock_t clock_source)
     return MXC_ADC_RevB_SetClockSource((mxc_adc_revb_regs_t *)MXC_ADC, clock_source);
 }
 
+int MXC_ADC_LockClockSource(bool lock)
+{
+    return MXC_ADC_RevB_LockClockSource((mxc_adc_revb_regs_t *)MXC_ADC, lock);
+}
+
 int MXC_ADC_SetClockDiv(mxc_adc_clkdiv_t div)
 {
     return MXC_ADC_RevB_SetClockDiv((mxc_adc_revb_regs_t *)MXC_ADC, div);

--- a/Libraries/PeriphDrivers/Source/ADC/adc_revb.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_revb.c
@@ -118,9 +118,14 @@ int MXC_ADC_RevB_SetClockDiv(mxc_adc_revb_regs_t *adc, mxc_adc_clkdiv_t div)
     return E_NO_ERROR;
 }
 
-void MXC_ADC_RevB_LockClockSource(mxc_adc_revb_regs_t *adc, bool lock)
+int MXC_ADC_RevB_LockClockSource(mxc_adc_revb_regs_t *adc, bool lock)
 {
     g_is_clock_locked = lock;
+    if (g_is_clock_locked == lock) {
+        return E_FAIL;
+    } else {
+        return E_NO_ERROR;
+    }
 }
 
 int MXC_ADC_RevB_Shutdown(mxc_adc_revb_regs_t *adc)

--- a/Libraries/PeriphDrivers/Source/ADC/adc_revb.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_revb.c
@@ -50,7 +50,7 @@ static mxc_adc_complete_cb_t async_callback;
 static mxc_adc_conversion_req_t *async_req;
 // static volatile uint8_t flag;      //indicates  to irqhandler where to store data
 
-bool g_is_clock_source_locked = false;
+static bool g_is_clock_locked = false;
 
 int MXC_ADC_RevB_Init(mxc_adc_revb_regs_t *adc, mxc_adc_req_t *req)
 {
@@ -104,7 +104,7 @@ int MXC_ADC_RevB_Init(mxc_adc_revb_regs_t *adc, mxc_adc_req_t *req)
 
 int MXC_ADC_RevB_SetClockSource(mxc_adc_revb_regs_t *adc, mxc_adc_clock_t clock_source)
 {
-    if (!g_is_clock_source_locked) {
+    if (!g_is_clock_locked) {
         MXC_SETFIELD(adc->clkctrl, MXC_F_ADC_REVB_CLKCTRL_CLKSEL, clock_source << MXC_F_ADC_REVB_CLKCTRL_CLKSEL_POS);
     }
     return E_NO_ERROR;
@@ -112,7 +112,7 @@ int MXC_ADC_RevB_SetClockSource(mxc_adc_revb_regs_t *adc, mxc_adc_clock_t clock_
 
 int MXC_ADC_RevB_SetClockDiv(mxc_adc_revb_regs_t *adc, mxc_adc_clkdiv_t div)
 {
-    if (!g_is_clock_source_locked) {
+    if (!g_is_clock_locked) {
         MXC_SETFIELD(adc->clkctrl, MXC_F_ADC_REVB_CLKCTRL_CLKDIV, div << MXC_F_ADC_REVB_CLKCTRL_CLKDIV_POS);
     }
     return E_NO_ERROR;
@@ -120,7 +120,7 @@ int MXC_ADC_RevB_SetClockDiv(mxc_adc_revb_regs_t *adc, mxc_adc_clkdiv_t div)
 
 void MXC_ADC_RevB_LockClockSource(mxc_adc_revb_regs_t *adc, bool lock)
 {
-    g_is_clock_source_locked = lock;
+    g_is_clock_locked = lock;
 }
 
 int MXC_ADC_RevB_Shutdown(mxc_adc_revb_regs_t *adc)

--- a/Libraries/PeriphDrivers/Source/ADC/adc_revb.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_revb.c
@@ -50,6 +50,8 @@ static mxc_adc_complete_cb_t async_callback;
 static mxc_adc_conversion_req_t *async_req;
 // static volatile uint8_t flag;      //indicates  to irqhandler where to store data
 
+bool g_is_clock_source_locked = false;
+
 int MXC_ADC_RevB_Init(mxc_adc_revb_regs_t *adc, mxc_adc_req_t *req)
 {
     if (req == NULL) {
@@ -63,11 +65,10 @@ int MXC_ADC_RevB_Init(mxc_adc_revb_regs_t *adc, mxc_adc_req_t *req)
     //Enter reset mode
     adc->ctrl0 &= ~MXC_F_ADC_REVB_CTRL0_RESETB;
 
+    MXC_ADC_RevB_SetClockSource(adc, req->clock);
+    MXC_ADC_RevB_SetClockDiv(adc, req->clkdiv); 
+
     //Power up to Sleep State
-    MXC_SETFIELD(adc->clkctrl, MXC_F_ADC_REVB_CLKCTRL_CLKSEL,
-                 (req->clock << MXC_F_ADC_REVB_CLKCTRL_CLKSEL_POS));
-    MXC_SETFIELD(adc->clkctrl, MXC_F_ADC_REVB_CLKCTRL_CLKDIV,
-                 (req->clkdiv << MXC_F_ADC_REVB_CLKCTRL_CLKDIV_POS));
 
     adc->ctrl0 |= MXC_F_ADC_REVB_CTRL0_RESETB;
 
@@ -99,6 +100,27 @@ int MXC_ADC_RevB_Init(mxc_adc_revb_regs_t *adc, mxc_adc_req_t *req)
     async_req = NULL;
 
     return E_NO_ERROR;
+}
+
+int MXC_ADC_RevB_SetClockSource(mxc_adc_revb_regs_t *adc, mxc_adc_clock_t clock_source)
+{
+    if (!g_is_clock_source_locked) {
+        MXC_SETFIELD(adc->clkctrl, MXC_F_ADC_REVB_CLKCTRL_CLKSEL, clock_source << MXC_F_ADC_REVB_CLKCTRL_CLKSEL_POS);
+    }
+    return E_NO_ERROR;
+}
+
+int MXC_ADC_RevB_SetClockDiv(mxc_adc_revb_regs_t *adc, mxc_adc_clkdiv_t div)
+{
+    if (!g_is_clock_source_locked) {
+        MXC_SETFIELD(adc->clkctrl, MXC_F_ADC_REVB_CLKCTRL_CLKDIV, div << MXC_F_ADC_REVB_CLKCTRL_CLKDIV_POS);
+    }
+    return E_NO_ERROR;
+}
+
+void MXC_ADC_RevB_LockClockSource(mxc_adc_revb_regs_t *adc, bool lock)
+{
+    g_is_clock_source_locked = lock;
 }
 
 int MXC_ADC_RevB_Shutdown(mxc_adc_revb_regs_t *adc)

--- a/Libraries/PeriphDrivers/Source/ADC/adc_revb.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_revb.c
@@ -66,7 +66,7 @@ int MXC_ADC_RevB_Init(mxc_adc_revb_regs_t *adc, mxc_adc_req_t *req)
     adc->ctrl0 &= ~MXC_F_ADC_REVB_CTRL0_RESETB;
 
     MXC_ADC_RevB_SetClockSource(adc, req->clock);
-    MXC_ADC_RevB_SetClockDiv(adc, req->clkdiv); 
+    MXC_ADC_RevB_SetClockDiv(adc, req->clkdiv);
 
     //Power up to Sleep State
 
@@ -105,7 +105,8 @@ int MXC_ADC_RevB_Init(mxc_adc_revb_regs_t *adc, mxc_adc_req_t *req)
 int MXC_ADC_RevB_SetClockSource(mxc_adc_revb_regs_t *adc, mxc_adc_clock_t clock_source)
 {
     if (!g_is_clock_locked) {
-        MXC_SETFIELD(adc->clkctrl, MXC_F_ADC_REVB_CLKCTRL_CLKSEL, clock_source << MXC_F_ADC_REVB_CLKCTRL_CLKSEL_POS);
+        MXC_SETFIELD(adc->clkctrl, MXC_F_ADC_REVB_CLKCTRL_CLKSEL,
+                     clock_source << MXC_F_ADC_REVB_CLKCTRL_CLKSEL_POS);
     }
     return E_NO_ERROR;
 }
@@ -113,7 +114,8 @@ int MXC_ADC_RevB_SetClockSource(mxc_adc_revb_regs_t *adc, mxc_adc_clock_t clock_
 int MXC_ADC_RevB_SetClockDiv(mxc_adc_revb_regs_t *adc, mxc_adc_clkdiv_t div)
 {
     if (!g_is_clock_locked) {
-        MXC_SETFIELD(adc->clkctrl, MXC_F_ADC_REVB_CLKCTRL_CLKDIV, div << MXC_F_ADC_REVB_CLKCTRL_CLKDIV_POS);
+        MXC_SETFIELD(adc->clkctrl, MXC_F_ADC_REVB_CLKCTRL_CLKDIV,
+                     div << MXC_F_ADC_REVB_CLKCTRL_CLKDIV_POS);
     }
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/ADC/adc_revb.h
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_revb.h
@@ -22,6 +22,7 @@
 #define LIBRARIES_PERIPHDRIVERS_SOURCE_ADC_ADC_REVB_H_
 
 #include <stdio.h>
+#include <stdbool.h>
 #include "adc.h"
 #include "adc_revb_regs.h"
 

--- a/Libraries/PeriphDrivers/Source/ADC/adc_revb.h
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_revb.h
@@ -38,7 +38,7 @@ int MXC_ADC_RevB_SetClockSource(mxc_adc_revb_regs_t *adc, mxc_adc_clock_t clock_
 
 int MXC_ADC_RevB_SetClockDiv(mxc_adc_revb_regs_t *adc, mxc_adc_clkdiv_t div);
 
-void MXC_ADC_RevB_LockClockSource(mxc_adc_revb_regs_t *adc, bool lock);
+int MXC_ADC_RevB_LockClockSource(mxc_adc_revb_regs_t *adc, bool lock);
 
 int MXC_ADC_RevB_Shutdown(mxc_adc_revb_regs_t *adc);
 

--- a/Libraries/PeriphDrivers/Source/ADC/adc_revb.h
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_revb.h
@@ -34,6 +34,12 @@
 
 int MXC_ADC_RevB_Init(mxc_adc_revb_regs_t *adc, mxc_adc_req_t *req);
 
+int MXC_ADC_RevB_SetClockSource(mxc_adc_revb_regs_t *adc, mxc_adc_clock_t clock_source);
+
+int MXC_ADC_RevB_SetClockDiv(mxc_adc_revb_regs_t *adc, mxc_adc_clkdiv_t div);
+
+void MXC_ADC_RevB_LockClockSource(mxc_adc_revb_regs_t *adc, bool lock);
+
 int MXC_ADC_RevB_Shutdown(mxc_adc_revb_regs_t *adc);
 
 void MXC_ADC_RevB_EnableInt(mxc_adc_revb_regs_t *adc, uint32_t flags);

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
@@ -36,6 +36,7 @@
 #include "fcr_regs.h"
 #include "mcr_regs.h"
 #include "pwrseq_regs.h"
+#include "rtc_regs.h"
 #include "flc.h"
 #include "ctb.h"
 
@@ -552,6 +553,20 @@ int MXC_SYS_LockDAP_Permanent(void)
 
     return err;
 #endif
+}
+
+int MXC_SYS_SetBypass(mxc_sys_system_clock_t clock, bool bypass)
+{
+    // Only ERFO and ERTCO support this option.
+    if (clock == MXC_SYS_CLOCK_ERFO) {
+        MXC_SETFIELD(MXC_GCR->pm, MXC_F_GCR_PM_ERFO_BP, bypass << MXC_F_GCR_PM_ERFO_BP_POS);
+    } else if (clock == MXC_SYS_CLOCK_ERTCO) {
+        MXC_SETFIELD(MXC_RTC->oscctrl, MXC_F_RTC_OSCCTRL_BYPASS, bypass << MXC_F_RTC_OSCCTRL_BYPASS_POS);
+    } else {
+        return E_BAD_PARAM;
+    }
+
+    return E_NO_ERROR;
 }
 
 /**@} end of mxc_sys */

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
@@ -444,6 +444,26 @@ int MXC_SYS_Clock_Select(mxc_sys_system_clock_t clock)
     return E_NO_ERROR;
 }
 
+int MXC_SYS_ClockCalibrate(mxc_sys_system_clock_t clock)
+{
+    if (clock != MXC_SYS_CLOCK_IPO) {
+        return E_BAD_PARAM; // Only the IPO supports calibration
+    }
+
+    int err = E_NO_ERROR;
+    // The following section implements section 4.1.1.1 of the MAX32690 UG Rev 1
+    if ((err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO))) return err;
+    MXC_SETFIELD(MXC_FCR->autocal2, MXC_F_FCR_AUTOCAL2_ACDIV, 3662 << MXC_F_FCR_AUTOCAL2_ACDIV_POS);
+    MXC_SETFIELD(MXC_FCR->autocal1, MXC_F_FCR_AUTOCAL1_INITTRM, 0x40 << MXC_F_FCR_AUTOCAL1_INITTRM_POS);
+    MXC_FCR->autocal0 |= 0x7;
+    MXC_Delay(MXC_DELAY_MSEC(10)); // Wait 10ms for calibration to complete
+    // Calculated trim is loaded to MXC_FCR->hirc96mactmrout and is used by the hardware as long as
+    // MXC_FCR->autocal0.acen is set to 1
+    MXC_FCR->autocal0 &= ~MXC_F_FCR_AUTOCAL0_ACRUN; // Stop the calibration
+    MXC_FCR->autocal0 |= MXC_F_FCR_AUTOCAL0_ACEN; // Enable use of calibration value
+    return E_NO_ERROR;
+}
+
 /* ************************************************************************** */
 void MXC_SYS_SetClockDiv(mxc_sys_system_clock_div_t div)
 {

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
@@ -339,6 +339,7 @@ int MXC_SYS_Clock_Timeout(uint32_t ready)
 /* ************************************************************************** */
 int MXC_SYS_Clock_Select(mxc_sys_system_clock_t clock)
 {
+#ifdef __arm__
     uint32_t current_clock;
 
     // Save the current system clock
@@ -437,6 +438,21 @@ int MXC_SYS_Clock_Select(mxc_sys_system_clock_t clock)
 
         return E_TIME_OUT;
     }
+#else
+#ifdef __riscv
+    switch(clock) {
+        case MXC_SYS_CLOCK_PCLK:
+            MXC_PWRSEQ &= ~MXC_F_PWRSEQ_LPCN_ISOCLK_SELECT;
+            break;
+        case MXC_SYS_CLOCK_ISO:
+            MXC_SYS_Clock_Enable(MXC_SYS_CLOCK_ISO);
+            MXC_PWRSEQ |= MXC_F_PWRSEQ_LPCN_ISOCLK_SELECT;
+            break;
+        default:
+            return E_BAD_PARAM;
+    }
+#endif
+#endif
 
     // Update the system core clock
     SystemCoreClockUpdate();

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
@@ -339,7 +339,6 @@ int MXC_SYS_Clock_Timeout(uint32_t ready)
 /* ************************************************************************** */
 int MXC_SYS_Clock_Select(mxc_sys_system_clock_t clock)
 {
-#ifdef __arm__
     uint32_t current_clock;
 
     // Save the current system clock
@@ -438,21 +437,6 @@ int MXC_SYS_Clock_Select(mxc_sys_system_clock_t clock)
 
         return E_TIME_OUT;
     }
-#else
-#ifdef __riscv
-    switch(clock) {
-        case MXC_SYS_CLOCK_PCLK:
-            MXC_PWRSEQ->lpcn &= ~MXC_F_PWRSEQ_LPCN_ISOCLK_SELECT;
-            break;
-        case MXC_SYS_CLOCK_ISO:
-            MXC_SYS_ClockEnable(MXC_SYS_CLOCK_ISO);
-            MXC_PWRSEQ->lpcn |= MXC_F_PWRSEQ_LPCN_ISOCLK_SELECT;
-            break;
-        default:
-            return E_BAD_PARAM;
-    }
-#endif
-#endif
 
     // Update the system core clock
     SystemCoreClockUpdate();

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
@@ -442,11 +442,11 @@ int MXC_SYS_Clock_Select(mxc_sys_system_clock_t clock)
 #ifdef __riscv
     switch(clock) {
         case MXC_SYS_CLOCK_PCLK:
-            MXC_PWRSEQ &= ~MXC_F_PWRSEQ_LPCN_ISOCLK_SELECT;
+            MXC_PWRSEQ->lpcn &= ~MXC_F_PWRSEQ_LPCN_ISOCLK_SELECT;
             break;
         case MXC_SYS_CLOCK_ISO:
             MXC_SYS_Clock_Enable(MXC_SYS_CLOCK_ISO);
-            MXC_PWRSEQ |= MXC_F_PWRSEQ_LPCN_ISOCLK_SELECT;
+            MXC_PWRSEQ->lpcn |= MXC_F_PWRSEQ_LPCN_ISOCLK_SELECT;
             break;
         default:
             return E_BAD_PARAM;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
@@ -445,7 +445,7 @@ int MXC_SYS_Clock_Select(mxc_sys_system_clock_t clock)
             MXC_PWRSEQ->lpcn &= ~MXC_F_PWRSEQ_LPCN_ISOCLK_SELECT;
             break;
         case MXC_SYS_CLOCK_ISO:
-            MXC_SYS_Clock_Enable(MXC_SYS_CLOCK_ISO);
+            MXC_SYS_ClockEnable(MXC_SYS_CLOCK_ISO);
             MXC_PWRSEQ->lpcn |= MXC_F_PWRSEQ_LPCN_ISOCLK_SELECT;
             break;
         default:

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
@@ -191,9 +191,10 @@ uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
     }
 
     MXC_TMR_RevB_SetClockSource((mxc_tmr_revb_regs_t *)tmr, bit_mode, clk_src);
-    return clockSource; /*  Note this function returns the actual value of the clockSource field to set because 
-                            our TMR API was written extremely jankily.  The Init function accepts this register value
-                            as an argument, so we need to pass that back up from this API... */
+    return clockSource;
+    /*  Note this function returns the actual value of the clockSource field to set because 
+        our TMR API was written extremely jankily.  The Init function accepts this register value
+        as an argument, so we need to pass that back up from this API... */
 }
 
 void MXC_TMR_SetPrescalar(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
@@ -90,7 +90,14 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
     //enable peripheral clock and configure gpio pins
     switch (tmr_id) {
     case 0:
-        MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR0);
+        if (cfg->bitMode == MXC_TMR_BIT_MODE_32) {
+            /*  If the bit mode is set to 16A or 16B we avoid a full peripheral reset
+                because the user is probably trying to use the dual-mode timer config,
+                which requires two Init calls.  We don't want to reset because that would
+                wipe out any previous initializations.
+             */
+            MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR0);
+        }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR0);
 
         if (init_pins) {
@@ -104,7 +111,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         break;
 
     case 1:
-        MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR1);
+        if (cfg->bitMode == MXC_TMR_BIT_MODE_32) {
+            MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR1);
+        }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR1);
 
         if (init_pins) {
@@ -118,7 +127,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         break;
 
     case 2:
-        MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR2);
+        if (cfg->bitMode == MXC_TMR_BIT_MODE_32) {
+            MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR2);
+        }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR2);
 
         if (init_pins) {
@@ -132,7 +143,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         break;
 
     case 3:
-        MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR3);
+        if (cfg->bitMode == MXC_TMR_BIT_MODE_32) {
+            MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR3);
+        }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR3);
 
         if (init_pins) {

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
@@ -134,7 +134,8 @@ void MXC_TMR_LockClockSource(mxc_tmr_regs_t *tmr, bool lock)
     MXC_TMR_RevB_LockClockSource((mxc_tmr_revb_regs_t *)tmr, lock);
 }
 
-uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_clock_t clk_src)
+uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
+                               mxc_tmr_clock_t clk_src)
 {
     uint8_t tmr_id = MXC_TMR_GET_IDX(tmr);
     uint8_t clockSource = MXC_TMR_CLK0;
@@ -195,7 +196,8 @@ uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
                             as an argument, so we need to pass that back up from this API... */
 }
 
-void MXC_TMR_SetPrescalar(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_pres_t prescalar)
+void MXC_TMR_SetPrescalar(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
+                          mxc_tmr_pres_t prescalar)
 {
     MXC_TMR_RevB_SetPrescalar((mxc_tmr_revb_regs_t *)tmr, bit_mode, prescalar);
 }

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
@@ -177,6 +177,21 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }
 
+void MXC_TMR_LockClockSource(mxc_tmr_regs_t *tmr, bool lock)
+{
+    MXC_TMR_RevB_LockClockSource((mxc_tmr_revb_regs_t *)tmr, lock);
+}
+
+void MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_clock_t clk_src)
+{
+    MXC_TMR_RevB_SetClockSource((mxc_tmr_revb_regs_t *)tmr, bit_mode, clk_src);
+}
+
+void MXC_TMR_SetPrescalar(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_pres_t prescalar)
+{
+    MXC_TMR_RevB_SetPrescalar((mxc_tmr_revb_regs_t *)tmr, bit_mode, prescalar);
+}
+
 void MXC_TMR_Shutdown(mxc_tmr_regs_t *tmr)
 {
     MXC_ASSERT(MXC_TMR_GET_IDX(tmr) >= 0);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
@@ -209,9 +209,10 @@ uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
     }
 
     MXC_TMR_RevB_SetClockSource((mxc_tmr_revb_regs_t *)tmr, bit_mode, clockSource);
-    return clockSource; /*  Note this function returns the actual value of the clockSource field to set because 
-                            our TMR API was written extremely jankily.  The Init function accepts this register value
-                            as an argument, so we need to pass that back up from this API... */
+    return clockSource;
+    /*  Note this function returns the actual value of the clockSource field to set because 
+        our TMR API was written extremely jankily.  The Init function accepts this register value
+        as an argument, so we need to pass that back up from this API... */
 }
 
 void MXC_TMR_SetPrescalar(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
@@ -195,6 +195,21 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }
 
+void MXC_TMR_LockClockSource(mxc_tmr_regs_t *tmr, bool lock)
+{
+    MXC_TMR_RevB_LockClockSource((mxc_tmr_revb_regs_t *)tmr, lock);
+}
+
+void MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_clock_t clk_src)
+{
+    MXC_TMR_RevB_SetClockSource((mxc_tmr_revb_regs_t *)tmr, bit_mode, clk_src);
+}
+
+void MXC_TMR_SetPrescalar(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_pres_t prescalar)
+{
+    MXC_TMR_RevB_SetPrescalar((mxc_tmr_revb_regs_t *)tmr, bit_mode, prescalar);
+}
+
 void MXC_TMR_Shutdown(mxc_tmr_regs_t *tmr)
 {
     MXC_ASSERT(MXC_TMR_GET_IDX(tmr) >= 0);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
@@ -36,74 +36,6 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
     tmr_id = MXC_TMR_GET_IDX(tmr);
     MXC_ASSERT(tmr_id >= 0);
 
-    switch (cfg->clock) {
-    case MXC_TMR_ISO_CLK:
-        if (tmr_id > 3) { // Timers 4-5 do not support this clock source
-            return E_NOT_SUPPORTED;
-        }
-
-        clockSource = MXC_TMR_CLK1;
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ISO);
-        MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, ISO_FREQ);
-        break;
-
-    case MXC_TMR_IBRO_CLK:
-        if (tmr_id > 3) { // Timers 4-5
-            clockSource = MXC_TMR_CLK0;
-        } else if (tmr_id < 4) { // Timers 0-3
-            clockSource = MXC_TMR_CLK2;
-        }
-
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-        MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, IBRO_FREQ);
-        break;
-
-    case MXC_TMR_ERFO_CLK:
-        if (tmr_id > 3) { // Timers 4-5 do not support this clock source
-            return E_NOT_SUPPORTED;
-        }
-
-        clockSource = MXC_TMR_CLK3;
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
-        MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, ERFO_FREQ);
-        break;
-
-    case MXC_TMR_ERTCO_CLK:
-        if (tmr_id == 4) {
-            clockSource = MXC_TMR_CLK1;
-        } else { // Timers 5 do not support this clock source
-            return E_NOT_SUPPORTED;
-        }
-
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
-        MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, ERTCO_FREQ);
-        break;
-
-    case MXC_TMR_INRO_CLK:
-        if (tmr_id < 4) { // Timers 0-3 do not support this clock source
-            return E_NOT_SUPPORTED;
-        }
-
-        clockSource = MXC_TMR_CLK2;
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_INRO);
-        MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, INRO_FREQ);
-        break;
-
-    case MXC_TMR_EXT_CLK:
-        if (tmr_id < 3) { // GPIO3[5]
-            clockSource = MXC_TMR_CLK3;
-        } else {
-            return E_NOT_SUPPORTED;
-        }
-
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_EXTCLK);
-        break;
-
-    default:
-        MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, PeripheralClock);
-        break;
-    }
-
 #ifndef MSDK_NO_GPIO_CLK_INIT
     //enable peripheral clock and configure gpio pins
     switch (tmr_id) {
@@ -192,6 +124,8 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
     (void)init_pins;
 #endif
 
+    uint8_t clockSource = MXC_TMR_SetClockSource(tmr, cfg->bitMode, cfg->clock);
+
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }
 
@@ -200,9 +134,83 @@ void MXC_TMR_LockClockSource(mxc_tmr_regs_t *tmr, bool lock)
     MXC_TMR_RevB_LockClockSource((mxc_tmr_revb_regs_t *)tmr, lock);
 }
 
-void MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_clock_t clk_src)
+uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_clock_t clk_src)
 {
-    MXC_TMR_RevB_SetClockSource((mxc_tmr_revb_regs_t *)tmr, bit_mode, clk_src);
+    uint8_t tmr_id = MXC_TMR_GET_IDX(tmr);
+    uint8_t clockSource = MXC_TMR_CLK0;
+
+    switch (clk_src) {
+    case MXC_TMR_ISO_CLK:
+        if (tmr_id > 3) { // Timers 4-5 do not support this clock source
+            return E_NOT_SUPPORTED;
+        }
+
+        clockSource = MXC_TMR_CLK1;
+        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ISO);
+        MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, ISO_FREQ);
+        break;
+
+    case MXC_TMR_IBRO_CLK:
+        if (tmr_id > 3) { // Timers 4-5
+            clockSource = MXC_TMR_CLK0;
+        } else if (tmr_id < 4) { // Timers 0-3
+            clockSource = MXC_TMR_CLK2;
+        }
+
+        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+        MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, IBRO_FREQ);
+        break;
+
+    case MXC_TMR_ERFO_CLK:
+        if (tmr_id > 3) { // Timers 4-5 do not support this clock source
+            return E_NOT_SUPPORTED;
+        }
+
+        clockSource = MXC_TMR_CLK3;
+        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+        MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, ERFO_FREQ);
+        break;
+
+    case MXC_TMR_ERTCO_CLK:
+        if (tmr_id == 4) {
+            clockSource = MXC_TMR_CLK1;
+        } else { // Timers 5 do not support this clock source
+            return E_NOT_SUPPORTED;
+        }
+
+        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+        MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, ERTCO_FREQ);
+        break;
+
+    case MXC_TMR_INRO_CLK:
+        if (tmr_id < 4) { // Timers 0-3 do not support this clock source
+            return E_NOT_SUPPORTED;
+        }
+
+        clockSource = MXC_TMR_CLK2;
+        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_INRO);
+        MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, INRO_FREQ);
+        break;
+
+    case MXC_TMR_EXT_CLK:
+        if (tmr_id < 3) { // GPIO3[5]
+            clockSource = MXC_TMR_CLK3;
+        } else {
+            return E_NOT_SUPPORTED;
+        }
+
+        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_EXTCLK);
+        break;
+
+    default:
+        MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, PeripheralClock);
+        break;
+    }
+
+    MXC_TMR_RevB_SetClockSource((mxc_tmr_revb_regs_t *)tmr, bit_mode, clockSource);
+    return clockSource; /*  Note this function returns the actual value of the clockSource field to set because 
+                            our TMR API was written extremely jankily.  The Init function accepts this register value
+                            as an argument, so we need to pass that back up from this API... */
 }
 
 void MXC_TMR_SetPrescalar(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_pres_t prescalar)

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
@@ -108,7 +108,14 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
     //enable peripheral clock and configure gpio pins
     switch (tmr_id) {
     case 0:
-        MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR0);
+        if (cfg->bitMode == MXC_TMR_BIT_MODE_32) {
+            /*  If the bit mode is set to 16A or 16B we avoid a full peripheral reset
+                because the user is probably trying to use the dual-mode timer config,
+                which requires two Init calls.  We don't want to reset because that would
+                wipe out any previous initializations.
+             */
+            MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR0);
+        }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR0);
 
         if (init_pins) {
@@ -122,7 +129,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         break;
 
     case 1:
-        MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR1);
+        if (cfg->bitMode == MXC_TMR_BIT_MODE_32) {
+            MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR1);
+        }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR1);
 
         if (init_pins) {
@@ -136,7 +145,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         break;
 
     case 2:
-        MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR2);
+        if (cfg->bitMode == MXC_TMR_BIT_MODE_32) {
+            MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR2);
+        }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR2);
 
         if (init_pins) {
@@ -150,7 +161,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         break;
 
     case 3:
-        MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR3);
+        if (cfg->bitMode == MXC_TMR_BIT_MODE_32) {
+            MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR3);
+        }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR3);
 
         if (init_pins) {

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
@@ -134,7 +134,8 @@ void MXC_TMR_LockClockSource(mxc_tmr_regs_t *tmr, bool lock)
     MXC_TMR_RevB_LockClockSource((mxc_tmr_revb_regs_t *)tmr, lock);
 }
 
-uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_clock_t clk_src)
+uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
+                               mxc_tmr_clock_t clk_src)
 {
     uint8_t tmr_id = MXC_TMR_GET_IDX(tmr);
     uint8_t clockSource = MXC_TMR_CLK0;
@@ -213,7 +214,8 @@ uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
                             as an argument, so we need to pass that back up from this API... */
 }
 
-void MXC_TMR_SetPrescalar(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_pres_t prescalar)
+void MXC_TMR_SetPrescalar(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
+                          mxc_tmr_pres_t prescalar)
 {
     MXC_TMR_RevB_SetPrescalar((mxc_tmr_revb_regs_t *)tmr, bit_mode, prescalar);
 }

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
@@ -124,7 +124,7 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
     (void)init_pins;
 #endif
 
-    uint8_t clockSource = MXC_TMR_SetClockSource(tmr, cfg->bitMode, cfg->clock);
+    clockSource = MXC_TMR_SetClockSource(tmr, cfg->bitMode, cfg->clock);
 
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
@@ -38,9 +38,8 @@ typedef struct {
 } mxc_tmr_revb_clksrc_freq_t;
 
 static mxc_tmr_revb_clksrc_freq_t tmr_clksrc[MXC_CFG_TMR_INSTANCES];
-static bool g_is_clock_locked[MXC_CFG_TMR_INSTANCES] = {
-    [0 ... MXC_CFG_TMR_INSTANCES - 1] = false
-};
+static bool g_is_clock_locked[MXC_CFG_TMR_INSTANCES] = { [0 ... MXC_CFG_TMR_INSTANCES - 1] =
+                                                             false };
 
 /* **** Functions **** */
 int MXC_TMR_RevB_Init(mxc_tmr_revb_regs_t *tmr, mxc_tmr_cfg_t *cfg, uint8_t clk_src)
@@ -137,9 +136,11 @@ void MXC_TMR_RevB_LockClockSource(mxc_tmr_revb_regs_t *tmr, bool lock)
     g_is_clock_locked[MXC_TMR_GET_IDX((mxc_tmr_regs_t *)tmr)] = lock;
 }
 
-void MXC_TMR_RevB_SetClockSource(mxc_tmr_revb_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, uint8_t clk_src)
+void MXC_TMR_RevB_SetClockSource(mxc_tmr_revb_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
+                                 uint8_t clk_src)
 {
-    if (g_is_clock_locked[MXC_TMR_GET_IDX((mxc_tmr_regs_t *)tmr)]) return;
+    if (g_is_clock_locked[MXC_TMR_GET_IDX((mxc_tmr_regs_t *)tmr)])
+        return;
 
     // Select clock Source
     // Note:  For 32-bit cascade mode, TMR A and TMR B clock sources must be
@@ -154,7 +155,8 @@ void MXC_TMR_RevB_SetClockSource(mxc_tmr_revb_regs_t *tmr, mxc_tmr_bit_mode_t bi
     }
 }
 
-void MXC_TMR_RevB_SetPrescalar(mxc_tmr_revb_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_pres_t prescalar)
+void MXC_TMR_RevB_SetPrescalar(mxc_tmr_revb_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
+                               mxc_tmr_pres_t prescalar)
 {
     // Set prescaler
     // Note:  For 32-bit cascade mode, TMR A and TMR B clock sources must be
@@ -259,7 +261,7 @@ void MXC_TMR_RevB_Start(mxc_tmr_revb_regs_t *tmr)
     if (tmr->ctrl0 & MXC_F_TMR_CTRL0_CLKEN_B) {
         tmr->ctrl0 |= MXC_F_TMR_REVB_CTRL0_EN_B;
         while (!(tmr->ctrl1 & MXC_F_TMR_REVB_CTRL1_CLKEN_B)) {}
-    } 
+    }
 }
 
 void MXC_TMR_RevB_Stop(mxc_tmr_revb_regs_t *tmr)

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
@@ -38,6 +38,9 @@ typedef struct {
 } mxc_tmr_revb_clksrc_freq_t;
 
 static mxc_tmr_revb_clksrc_freq_t tmr_clksrc[MXC_CFG_TMR_INSTANCES];
+static bool g_is_clock_locked[MXC_CFG_TMR_INSTANCES] = {
+    [0 ... MXC_CFG_TMR_INSTANCES - 1] = false
+};
 
 /* **** Functions **** */
 int MXC_TMR_RevB_Init(mxc_tmr_revb_regs_t *tmr, mxc_tmr_cfg_t *cfg, uint8_t clk_src)
@@ -60,21 +63,8 @@ int MXC_TMR_RevB_Init(mxc_tmr_revb_regs_t *tmr, mxc_tmr_cfg_t *cfg, uint8_t clk_
     // Clear interrupt flag
     tmr->intfl |= (MXC_F_TMR_REVB_INTFL_IRQ_A | MXC_F_TMR_REVB_INTFL_IRQ_B);
 
-    // Select clock Source and prescaler
-    // Note:  For 32-bit cascade mode, TMR A and TMR B clock sources must be
-    //        the same to ensure proper operation.  (See MAX32670 UG Rev 4 Section 13.4)
-    if (cfg->bitMode == TMR_BIT_MODE_16A || cfg->bitMode == TMR_BIT_MODE_32) {
-        MXC_SETFIELD(tmr->ctrl1, MXC_F_TMR_CTRL1_CLKSEL_A,
-                     (clk_src << MXC_F_TMR_CTRL1_CLKSEL_A_POS));
-        MXC_SETFIELD(tmr->ctrl0, MXC_F_TMR_CTRL0_CLKDIV_A, cfg->pres);
-    }
-    if (cfg->bitMode == TMR_BIT_MODE_16B || cfg->bitMode == TMR_BIT_MODE_32) {
-        MXC_SETFIELD(tmr->ctrl1, MXC_F_TMR_CTRL1_CLKSEL_B,
-                     (clk_src << MXC_F_TMR_CTRL1_CLKSEL_B_POS));
-        // mxc_tmr_pres_t is for for CLKDIV_A register settings [7:4]
-        // Field positions for CLKDIV_B are Located at [23:20]. Shift 16 more bits.
-        MXC_SETFIELD(tmr->ctrl0, MXC_F_TMR_CTRL0_CLKDIV_B, (cfg->pres) << 16);
-    }
+    MXC_TMR_RevB_SetClockSource(tmr, cfg->bitMode, cfg->clock);
+    MXC_TMR_RevB_SetPrescalar(tmr, cfg->bitMode, cfg->pres);
 
     //TIMER_16B only supports compare, oneshot and continuous modes.
     switch (cfg->mode) {
@@ -140,6 +130,43 @@ int MXC_TMR_RevB_Init(mxc_tmr_revb_regs_t *tmr, mxc_tmr_cfg_t *cfg, uint8_t clk_
     }
 
     return E_NO_ERROR;
+}
+
+void MXC_TMR_RevB_LockClockSource(mxc_tmr_revb_regs_t *tmr, bool lock)
+{
+    g_is_clock_locked[MXC_TMR_GET_IDX((mxc_tmr_regs_t *)tmr)] = lock;
+}
+
+void MXC_TMR_RevB_SetClockSource(mxc_tmr_revb_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, uint8_t clk_src)
+{
+    if (g_is_clock_locked[MXC_TMR_GET_IDX((mxc_tmr_regs_t *)tmr)]) return;
+
+    // Select clock Source
+    // Note:  For 32-bit cascade mode, TMR A and TMR B clock sources must be
+    //        the same to ensure proper operation.  (See MAX32670 UG Rev 4 Section 13.4)
+    if (bit_mode == TMR_BIT_MODE_16A || bit_mode == TMR_BIT_MODE_32) {
+        MXC_SETFIELD(tmr->ctrl1, MXC_F_TMR_CTRL1_CLKSEL_A,
+                     (clk_src << MXC_F_TMR_CTRL1_CLKSEL_A_POS));
+    }
+    if (bit_mode == TMR_BIT_MODE_16B || bit_mode == TMR_BIT_MODE_32) {
+        MXC_SETFIELD(tmr->ctrl1, MXC_F_TMR_CTRL1_CLKSEL_B,
+                     (clk_src << MXC_F_TMR_CTRL1_CLKSEL_B_POS));
+    }
+}
+
+void MXC_TMR_RevB_SetPrescalar(mxc_tmr_revb_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_pres_t prescalar)
+{
+    // Set prescaler
+    // Note:  For 32-bit cascade mode, TMR A and TMR B clock sources must be
+    //        the same to ensure proper operation.  (See MAX32670 UG Rev 4 Section 13.4)
+    if (bit_mode == TMR_BIT_MODE_16A || bit_mode == TMR_BIT_MODE_32) {
+        MXC_SETFIELD(tmr->ctrl0, MXC_F_TMR_CTRL0_CLKDIV_A, prescalar);
+    }
+    if (bit_mode == TMR_BIT_MODE_16B || bit_mode == TMR_BIT_MODE_32) {
+        // mxc_tmr_pres_t is for for CLKDIV_A register settings [7:4]
+        // Field positions for CLKDIV_B are Located at [23:20]. Shift 16 more bits.
+        MXC_SETFIELD(tmr->ctrl0, MXC_F_TMR_CTRL0_CLKDIV_B, (prescalar) << 16);
+    }
 }
 
 void MXC_TMR_RevB_SetClockSourceFreq(mxc_tmr_revb_regs_t *tmr, int clksrc_freq)

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb.h
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb.h
@@ -41,8 +41,10 @@ typedef enum {
 /* **** Functions **** */
 int MXC_TMR_RevB_Init(mxc_tmr_revb_regs_t *tmr, mxc_tmr_cfg_t *cfg, uint8_t clk_src);
 void MXC_TMR_RevB_LockClockSource(mxc_tmr_revb_regs_t *tmr, bool lock);
-void MXC_TMR_RevB_SetClockSource(mxc_tmr_revb_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, uint8_t clk_src);
-void MXC_TMR_RevB_SetPrescalar(mxc_tmr_revb_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_pres_t prescalar);
+void MXC_TMR_RevB_SetClockSource(mxc_tmr_revb_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
+                                 uint8_t clk_src);
+void MXC_TMR_RevB_SetPrescalar(mxc_tmr_revb_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
+                               mxc_tmr_pres_t prescalar);
 void MXC_TMR_RevB_SetClockSourceFreq(mxc_tmr_revb_regs_t *tmr, int clksrc_freq);
 int MXC_TMR_RevB_GetClockSourceFreq(mxc_tmr_revb_regs_t *tmr);
 void MXC_TMR_RevB_ConfigGeneric(mxc_tmr_revb_regs_t *tmr, mxc_tmr_cfg_t *cfg);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb.h
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb.h
@@ -23,6 +23,7 @@
 
 /* **** Includes **** */
 #include <stddef.h>
+#include <stdbool.h>
 #include "mxc_assert.h"
 #include "tmr.h"
 #include "gpio.h"
@@ -39,6 +40,9 @@ typedef enum {
 
 /* **** Functions **** */
 int MXC_TMR_RevB_Init(mxc_tmr_revb_regs_t *tmr, mxc_tmr_cfg_t *cfg, uint8_t clk_src);
+void MXC_TMR_RevB_LockClockSource(mxc_tmr_revb_regs_t *tmr, bool lock);
+void MXC_TMR_RevB_SetClockSource(mxc_tmr_revb_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, uint8_t clk_src);
+void MXC_TMR_RevB_SetPrescalar(mxc_tmr_revb_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode, mxc_tmr_pres_t prescalar);
 void MXC_TMR_RevB_SetClockSourceFreq(mxc_tmr_revb_regs_t *tmr, int clksrc_freq);
 int MXC_TMR_RevB_GetClockSourceFreq(mxc_tmr_revb_regs_t *tmr);
 void MXC_TMR_RevB_ConfigGeneric(mxc_tmr_revb_regs_t *tmr, mxc_tmr_cfg_t *cfg);

--- a/Libraries/PeriphDrivers/Source/UART/uart_ai87.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_ai87.c
@@ -52,19 +52,6 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
         return retval;
     }
 
-    switch (clock) {
-    case MXC_UART_ERTCO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
-        break;
-
-    case MXC_UART_IBRO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-        break;
-
-    default:
-        break;
-    }
-
     switch (MXC_UART_GET_IDX(uart)) {
     case 0:
         MXC_GPIO_Config(&gpio_cfg_uart0);
@@ -89,6 +76,8 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     default:
         return E_BAD_PARAM;
     }
+
+    MXC_UART_SetClockSource(uart, clock);
 
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, clock);
 }
@@ -130,54 +119,32 @@ int MXC_UART_ReadyForSleep(mxc_uart_regs_t *uart)
 
 int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
-    int freq, mod = 0, clkdiv = 0;
-
     if (MXC_UART_GET_IDX(uart) < 0) {
         return E_BAD_PARAM;
     }
 
-    // check if the uart is LPUART
-    if (uart == MXC_UART3) {
-        // OSR default value
-        uart->osr = 5;
-
-        switch (clock) {
+    unsigned int input_clock_freq = 0;
+    switch (clock) {
         case MXC_UART_APB_CLK:
-        case MXC_UART_IBRO_CLK:
-            clkdiv = ((IBRO_FREQ) / baud);
-            mod = ((IBRO_FREQ) % baud);
+            input_clock_freq = SystemCoreClock / 2;
             break;
-
+        case MXC_UART_IBRO_CLK:
+            input_clock_freq = IBRO_FREQ;
+            break;
         case MXC_UART_ERTCO_CLK:
-            uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_EXTERNAL_CLOCK;
-            uart->ctrl |= MXC_F_UART_CTRL_FDM;
-            clkdiv = ((ERTCO_FREQ * 2) / baud);
-            mod = ((ERTCO_FREQ * 2) % baud);
-
+            uart->ctrl |= MXC_F_UART_CTRL_FDM; // Enable FDM
+            input_clock_freq = ERTCO_FREQ * 2; // 2x to account for FDM
             if (baud > 2400) {
                 uart->osr = 0;
             } else {
                 uart->osr = 1;
             }
             break;
-
         default:
             return E_BAD_PARAM;
-        }
-
-        if (!clkdiv || mod > (baud / 2)) {
-            clkdiv++;
-        }
-        uart->clkdiv = clkdiv;
-
-        freq = MXC_UART_GetFrequency(uart);
-    } else {
-        if (clock == MXC_UART_ERTCO_CLK) {
-            return E_BAD_PARAM;
-        }
-
-        freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, baud, clock);
     }
+
+    int freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, input_clock_freq, baud);
 
     if (freq > 0) {
         // Enable baud clock and wait for it to become ready.
@@ -270,7 +237,48 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
 
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
-    return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock);
+    int err = E_NO_ERROR;
+
+    // The following interprets table 12-1 from the MAX78002 UG.
+    switch(MXC_UART_GET_IDX(uart)) {
+    case 0:
+    case 1:
+    case 2:
+        // UART0-2 support PCLK and IBRO
+        switch (clock) {
+        case MXC_UART_APB_CLK:
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
+            break;
+
+        case MXC_UART_IBRO_CLK:
+            err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
+            break;
+
+        default:
+            return E_BAD_PARAM;
+        }
+        break;
+    case 3:
+        // UART3 (LPUART0) supports IBRO and ERTCO
+        switch (clock) {
+        case MXC_UART_IBRO_CLK:
+            err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
+            break;
+
+        case MXC_UART_ERTCO_CLK:
+            err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 1);
+            break;
+
+        default:
+            return E_BAD_PARAM;
+        }
+        break;
+    }
+
+    return err;
 }
 
 int MXC_UART_GetActive(mxc_uart_regs_t *uart)

--- a/Libraries/PeriphDrivers/Source/UART/uart_ai87.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_ai87.c
@@ -48,12 +48,16 @@ int MXC_UART_AsyncStop(mxc_uart_regs_t *uart)
 
 void MXC_UART_LockClockSource(mxc_uart_regs_t *uart)
 {
-    g_clock_source_locked[MXC_UART_GET_IDX(uart)] = true;
+    int idx = MXC_UART_GET_IDX(uart);
+    MXC_ASSERT(idx >= 0);
+    g_clock_source_locked[idx] = true;
 }
 
 void MXC_UART_UnlockClockSource(mxc_uart_regs_t *uart)
 {
-    g_clock_source_locked[MXC_UART_GET_IDX(uart)] = false;
+    int idx = MXC_UART_GET_IDX(uart);
+    MXC_ASSERT(idx >= 0);
+    g_clock_source_locked[idx] = false;
 }
 
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
@@ -253,8 +257,10 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
     int err = E_NO_ERROR;
+    int idx = MXC_UART_GET_IDX(uart);
+    if (idx < 0) return E_BAD_PARAM;
 
-    if (g_clock_source_locked[MXC_UART_GET_IDX(uart)]) {
+    if (g_clock_source_locked[idx]) {
         return E_NO_ERROR; // Clock source locked, return silently.
     }
 

--- a/Libraries/PeriphDrivers/Source/UART/uart_ai87.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_ai87.c
@@ -56,33 +56,6 @@ void MXC_UART_UnlockClockSource(mxc_uart_regs_t *uart)
     g_clock_source_locked[MXC_UART_GET_IDX(uart)] = false;
 }
 
-int MXC_UART_Enable(mxc_uart_regs_t *uart)
-{
-    int err = E_NO_ERROR;
-    switch (MXC_UART_GET_IDX(uart)) {
-    case 0:
-        MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_UART0);
-        break;
-
-    case 1:
-        MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_UART1);
-        break;
-
-    case 2:
-        MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_UART2);
-        break;
-
-    case 3:
-        MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_UART3);
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
-
-    return err;
-}
-
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
     int err;
@@ -93,32 +66,33 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
         return err;
     }
 
-    err = MXC_UART_Enable(uart);
-    if (err) return err;
-
-    err = MXC_UART_SetClockSource(uart, clock);
-    if (err) return err;
-
     switch (MXC_UART_GET_IDX(uart)) {
     case 0:
         MXC_GPIO_Config(&gpio_cfg_uart0);
+        MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_UART0);
         break;
 
     case 1:
         MXC_GPIO_Config(&gpio_cfg_uart1);
+        MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_UART1);
         break;
 
     case 2:
         MXC_GPIO_Config(&gpio_cfg_uart2);
+        MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_UART2);
         break;
 
     case 3:
         MXC_GPIO_Config(&gpio_cfg_uart3);
+        MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_UART3);
         break;
 
     default:
         return E_BAD_PARAM;
     }
+
+    err = MXC_UART_SetClockSource(uart, clock);
+    if (err) return err;
 
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, MXC_UART_GetClockSource(uart));
 }

--- a/Libraries/PeriphDrivers/Source/UART/uart_ai87.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_ai87.c
@@ -27,9 +27,7 @@
 #include "lpgcr_regs.h"
 #include "dma.h"
 
-bool g_clock_source_locked[MXC_UART_INSTANCES] = {
-    [0 ... MXC_UART_INSTANCES - 1] = false
-};
+bool g_clock_source_locked[MXC_UART_INSTANCES] = { [0 ... MXC_UART_INSTANCES - 1] = false };
 
 void MXC_UART_DMACallback(int ch, int error)
 {
@@ -96,7 +94,8 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     }
 
     err = MXC_UART_SetClockSource(uart, clock);
-    if (err) return err;
+    if (err)
+        return err;
 
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, MXC_UART_GetClockSource(uart));
 }
@@ -144,23 +143,23 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
 
     unsigned int input_clock_freq = 0;
     switch (clock) {
-        case MXC_UART_APB_CLK:
-            input_clock_freq = SystemCoreClock / 2;
-            break;
-        case MXC_UART_IBRO_CLK:
-            input_clock_freq = IBRO_FREQ;
-            break;
-        case MXC_UART_ERTCO_CLK:
-            uart->ctrl |= MXC_F_UART_CTRL_FDM; // Enable FDM
-            input_clock_freq = ERTCO_FREQ * 2; // 2x to account for FDM
-            if (baud > 2400) {
-                uart->osr = 0;
-            } else {
-                uart->osr = 1;
-            }
-            break;
-        default:
-            return E_BAD_PARAM;
+    case MXC_UART_APB_CLK:
+        input_clock_freq = SystemCoreClock / 2;
+        break;
+    case MXC_UART_IBRO_CLK:
+        input_clock_freq = IBRO_FREQ;
+        break;
+    case MXC_UART_ERTCO_CLK:
+        uart->ctrl |= MXC_F_UART_CTRL_FDM; // Enable FDM
+        input_clock_freq = ERTCO_FREQ * 2; // 2x to account for FDM
+        if (baud > 2400) {
+            uart->osr = 0;
+        } else {
+            uart->osr = 1;
+        }
+        break;
+    default:
+        return E_BAD_PARAM;
     }
 
     int freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, input_clock_freq, baud);
@@ -258,14 +257,15 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
     int err = E_NO_ERROR;
     int idx = MXC_UART_GET_IDX(uart);
-    if (idx < 0) return E_BAD_PARAM;
+    if (idx < 0)
+        return E_BAD_PARAM;
 
     if (g_clock_source_locked[idx]) {
         return E_NO_ERROR; // Clock source locked, return silently.
     }
 
     // The following interprets table 12-1 from the MAX78002 UG.
-    switch(MXC_UART_GET_IDX(uart)) {
+    switch (MXC_UART_GET_IDX(uart)) {
     case 0:
     case 1:
     case 2:
@@ -308,32 +308,32 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 
 mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart)
 {
-    unsigned int clock_option = MXC_UART_RevB_GetClockSource((mxc_uart_revb_regs_t*)uart);
-    switch(MXC_UART_GET_IDX(uart)) {
+    unsigned int clock_option = MXC_UART_RevB_GetClockSource((mxc_uart_revb_regs_t *)uart);
+    switch (MXC_UART_GET_IDX(uart)) {
+    case 0:
+    case 1:
+    case 2:
+        switch (clock_option) {
         case 0:
-        case 1:
+            return MXC_UART_APB_CLK;
         case 2:
-            switch (clock_option) {
-                case 0:
-                    return MXC_UART_APB_CLK;
-                case 2:
-                    return MXC_UART_IBRO_CLK;
-                default:
-                    return E_BAD_STATE;
-            }
-            break;
-        case 3:
-            switch (clock_option) {
-                case 0:
-                    return MXC_UART_IBRO_CLK;
-                case 1:
-                    return MXC_UART_ERTCO_CLK;
-                default:
-                    return E_BAD_STATE;
-            }
-            break;
+            return MXC_UART_IBRO_CLK;
         default:
-            return E_BAD_PARAM;
+            return E_BAD_STATE;
+        }
+        break;
+    case 3:
+        switch (clock_option) {
+        case 0:
+            return MXC_UART_IBRO_CLK;
+        case 1:
+            return MXC_UART_ERTCO_CLK;
+        default:
+            return E_BAD_STATE;
+        }
+        break;
+    default:
+        return E_BAD_PARAM;
     }
 }
 

--- a/Libraries/PeriphDrivers/Source/UART/uart_me18.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me18.c
@@ -53,22 +53,22 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
         return retval;
     }
 
-    switch (clock) {
-    case MXC_UART_ERTCO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
-        break;
+    // switch (clock) {
+    // case MXC_UART_ERTCO_CLK:
+    //     MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+    //     break;
 
-    case MXC_UART_IBRO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-        break;
+    // case MXC_UART_IBRO_CLK:
+    //     MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+    //     break;
 
-    case MXC_UART_ERFO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
-        break;
+    // case MXC_UART_ERFO_CLK:
+    //     MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+    //     break;
 
-    default:
-        break;
-    }
+    // default:
+    //     break;
+    // }
 
     switch (MXC_UART_GET_IDX(uart)) {
     case 0:
@@ -95,12 +95,12 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
         return E_BAD_PARAM;
     }
 
-    // retval = MXC_UART_SetClockSource(uart, clock);
-    // if (retval)
-    //     return retval;
+    retval = MXC_UART_SetClockSource(uart, clock);
+    if (retval)
+        return retval;
 #endif
 
-    return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, (mxc_uart_revb_clock_t)clock);
+    return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, MXC_UART_GetClockSource(uart));
 }
 
 int MXC_UART_Shutdown(mxc_uart_regs_t *uart)
@@ -154,7 +154,6 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
         uart->osr = 5;
 
         switch (clock) {
-        case MXC_UART_APB_CLK:
         case MXC_UART_IBRO_CLK:
             clkdiv = ((IBRO_FREQ) / baud);
             mod = ((IBRO_FREQ) % baud);
@@ -331,14 +330,89 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
 
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
-    if (uart == MXC_UART3 && (clock != MXC_UART_IBRO_CLK || clock != MXC_UART_ERTCO_CLK)) {
+    int err = E_NO_ERROR;
+    int idx = MXC_UART_GET_IDX(uart);
+    if (idx < 0)
         return E_BAD_PARAM;
-    } else if (clock != MXC_UART_APB_CLK || clock != MXC_UART_ERFO_CLK ||
-               clock != MXC_UART_IBRO_CLK) {
-        return E_BAD_PARAM;
+
+    // The following interprets table 12-1 from the MAX78002 UG.
+    switch (MXC_UART_GET_IDX(uart)) {
+    case 0:
+    case 1:
+    case 2:
+        // UART0-2 support PCLK, ERFO, & IBRO
+        switch (clock) {
+        case MXC_UART_APB_CLK:
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
+            break;
+
+        case MXC_UART_ERFO_CLK:
+            err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 1);
+            break;
+
+        case MXC_UART_IBRO_CLK:
+            err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
+            break;
+
+        default:
+            return E_BAD_PARAM;
+        }
+        break;
+    case 3:
+        // UART3 (LPUART0) supports IBRO and ERTCO
+        switch (clock) {
+        case MXC_UART_IBRO_CLK:
+            err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
+            break;
+
+        case MXC_UART_ERTCO_CLK:
+            err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 1);
+            break;
+
+        default:
+            return E_BAD_PARAM;
+        }
+        break;
     }
 
-    return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, (mxc_uart_revb_clock_t)clock);
+    return err;
+}
+
+mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart)
+{
+    unsigned int clock_option = MXC_UART_RevB_GetClockSource((mxc_uart_revb_regs_t *)uart);
+    switch (MXC_UART_GET_IDX(uart)) {
+    case 0:
+    case 1:
+    case 2:
+        switch (clock_option) {
+        case 0:
+            return MXC_UART_APB_CLK;
+        case 1:
+            return MXC_UART_ERFO_CLK;
+        case 2:
+            return MXC_UART_IBRO_CLK;
+        default:
+            return E_BAD_STATE;
+        }
+        break;
+    case 3:
+        switch (clock_option) {
+        case 0:
+            return MXC_UART_IBRO_CLK;
+        case 1:
+            return MXC_UART_ERTCO_CLK;
+        default:
+            return E_BAD_STATE;
+        }
+        break;
+    default:
+        return E_BAD_PARAM;
+    }
 }
 
 void MXC_UART_LockClockSource(mxc_uart_regs_t *uart, bool lock)

--- a/Libraries/PeriphDrivers/Source/UART/uart_me18.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me18.c
@@ -96,7 +96,8 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     }
 
     retval = MXC_UART_SetClockSource(uart, clock);
-    if (retval) return retval;
+    if (retval)
+        return retval;
 #endif
 
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, (mxc_uart_revb_clock_t)clock);
@@ -332,7 +333,8 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
     if (uart == MXC_UART3 && (clock != MXC_UART_IBRO_CLK || clock != MXC_UART_ERTCO_CLK)) {
         return E_BAD_PARAM;
-    } else if (clock != MXC_UART_APB_CLK || clock != MXC_UART_ERFO_CLK || clock != MXC_UART_IBRO_CLK) {
+    } else if (clock != MXC_UART_APB_CLK || clock != MXC_UART_ERFO_CLK ||
+               clock != MXC_UART_IBRO_CLK) {
         return E_BAD_PARAM;
     }
 

--- a/Libraries/PeriphDrivers/Source/UART/uart_me18.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me18.c
@@ -94,6 +94,9 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     default:
         return E_BAD_PARAM;
     }
+
+    retval = MXC_UART_SetClockSource(uart, clock);
+    if (retval) return retval;
 #endif
 
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, (mxc_uart_revb_clock_t)clock);

--- a/Libraries/PeriphDrivers/Source/UART/uart_me18.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me18.c
@@ -327,7 +327,18 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
 
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
+    if (uart == MXC_UART3 && (clock != MXC_UART_IBRO_CLK || clock != MXC_UART_ERTCO_CLK)) {
+        return E_BAD_PARAM;
+    } else if (clock != MXC_UART_APB_CLK || clock != MXC_UART_ERFO_CLK || clock != MXC_UART_IBRO_CLK) {
+        return E_BAD_PARAM;
+    }
+
     return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, (mxc_uart_revb_clock_t)clock);
+}
+
+void MXC_UART_LockClockSource(mxc_uart_regs_t *uart, bool lock)
+{
+    return MXC_UART_RevB_LockClockSource((mxc_uart_revb_regs_t *)uart, lock);
 }
 
 int MXC_UART_GetActive(mxc_uart_regs_t *uart)

--- a/Libraries/PeriphDrivers/Source/UART/uart_me18.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me18.c
@@ -95,9 +95,9 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
         return E_BAD_PARAM;
     }
 
-    retval = MXC_UART_SetClockSource(uart, clock);
-    if (retval)
-        return retval;
+    // retval = MXC_UART_SetClockSource(uart, clock);
+    // if (retval)
+    //     return retval;
 #endif
 
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, (mxc_uart_revb_clock_t)clock);

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -163,55 +163,22 @@ int MXC_UART_RevB_ReadyForSleep(mxc_uart_revb_regs_t *uart)
     return MXC_UART_GetActive((mxc_uart_regs_t *)uart);
 }
 
-int MXC_UART_RevB_SetFrequency(mxc_uart_revb_regs_t *uart, unsigned int baud,
-                               mxc_uart_revb_clock_t clock)
+int MXC_UART_RevB_SetFrequency(mxc_uart_revb_regs_t *uart, unsigned int input_clock_freq, unsigned int baud)
 {
     unsigned clkDiv = 0, mod = 0;
 
     // OSR default value
     uart->osr = 5;
 
-    switch (clock) {
-    case MXC_UART_REVB_APB_CLK:
-        clkDiv = (PeripheralClock / baud);
-        mod = (PeripheralClock % baud);
-        break;
-
-    case MXC_UART_REVB_EXT_CLK:
-        uart->ctrl |= MXC_S_UART_REVB_CTRL_BCLKSRC_EXTERNAL_CLOCK;
-        clkDiv = UART_EXTCLK_FREQ / baud;
-        mod = UART_EXTCLK_FREQ % baud;
-        break;
-
-    //case MXC_UART_IBRO_CLK:
-    case MXC_UART_REVB_CLK2:
-        clkDiv = (IBRO_FREQ / baud);
-        mod = (IBRO_FREQ % baud);
-
-        uart->ctrl |= MXC_S_UART_REVB_CTRL_BCLKSRC_CLK2;
-        break;
-
-    //case MXC_UART_ERFO:
-    case MXC_UART_REVB_CLK3:
-#if (TARGET_NUM == 78000 || TARGET_NUM == 78002)
-        return E_BAD_PARAM;
-#else
-        clkDiv = (ERFO_FREQ / baud);
-        mod = (ERFO_FREQ % baud);
-#endif
-
-        uart->ctrl |= MXC_S_UART_REVB_CTRL_BCLKSRC_CLK3;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
+    clkDiv = (input_clock_freq / baud);
+    mod = (input_clock_freq % baud);
 
     if (!clkDiv || mod > (baud / 2)) {
         clkDiv++;
     }
+
     uart->clkdiv = clkDiv;
-    return MXC_UART_GetFrequency((mxc_uart_regs_t *)uart);
+    return baud;
 }
 
 int MXC_UART_RevB_GetFrequency(mxc_uart_revb_regs_t *uart)
@@ -312,6 +279,30 @@ int MXC_UART_RevB_SetParity(mxc_uart_revb_regs_t *uart, mxc_uart_parity_t parity
     return E_NO_ERROR;
 }
 
+int MXC_UART_RevB_SetClockSource(mxc_uart_revb_regs_t *uart, uint8_t clock_option)
+{
+    MXC_ASSERT(clock_option >= 0 && clock_option <= 3);
+
+    bool is_bclk_enabled = (uart->ctrl & MXC_F_UART_CTRL_BCLKEN) != 0;
+    
+    if (is_bclk_enabled) {
+        // Shut down baud rate clock before changing clock source
+        uart->ctrl &= ~MXC_F_UART_CTRL_BCLKEN;
+    }
+
+    MXC_SETFIELD(uart->ctrl, MXC_F_UART_CTRL_BCLKSRC, clock_option << MXC_F_UART_CTRL_BCLKSRC_POS);
+    
+    if (is_bclk_enabled) {
+        // Turn the baud rate clock back on
+        uart->ctrl |= MXC_F_UART_CTRL_BCLKEN;
+        while (!(uart->ctrl & MXC_F_UART_CTRL_BCLKRDY)) {
+            continue;
+        }
+    }
+
+    return E_NO_ERROR;
+}
+
 int MXC_UART_RevB_SetFlowCtrl(mxc_uart_revb_regs_t *uart, mxc_uart_flow_t flowCtrl,
                               int rtsThreshold)
 {
@@ -330,31 +321,6 @@ int MXC_UART_RevB_SetFlowCtrl(mxc_uart_revb_regs_t *uart, mxc_uart_flow_t flowCt
     }
 
     //FIXME: Fix missing code for CTS threshhold.
-
-    return E_NO_ERROR;
-}
-
-int MXC_UART_RevB_SetClockSource(mxc_uart_revb_regs_t *uart, mxc_uart_revb_clock_t clock)
-{
-    switch (clock) {
-    case MXC_UART_REVB_APB_CLK:
-        break;
-
-    case MXC_UART_REVB_EXT_CLK:
-        uart->ctrl |= MXC_S_UART_REVB_CTRL_BCLKSRC_EXTERNAL_CLOCK;
-        break;
-
-    case MXC_UART_REVB_CLK2:
-        uart->ctrl |= MXC_S_UART_REVB_CTRL_BCLKSRC_CLK2;
-        break;
-
-    case MXC_UART_REVB_CLK3:
-        uart->ctrl |= MXC_S_UART_REVB_CTRL_BCLKSRC_CLK3;
-        break;
-
-    default:
-        return E_BAD_PARAM;
-    }
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -303,6 +303,11 @@ int MXC_UART_RevB_SetClockSource(mxc_uart_revb_regs_t *uart, uint8_t clock_optio
     return E_NO_ERROR;
 }
 
+unsigned int MXC_UART_RevB_GetClockSource(mxc_uart_revb_regs_t *uart)
+{
+    return ((uart->ctrl & MXC_F_UART_CTRL_BCLKSRC) >> MXC_F_UART_CTRL_BCLKSRC_POS);
+}
+
 int MXC_UART_RevB_SetFlowCtrl(mxc_uart_revb_regs_t *uart, mxc_uart_flow_t flowCtrl,
                               int rtsThreshold)
 {

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -62,7 +62,7 @@ uart_revb_req_state_t states[MXC_UART_INSTANCES] = {
     }
 };
 // clang-format on
-bool g_is_clock_locked[MXC_UART_INSTANCES] = {
+static bool g_is_clock_locked[MXC_UART_INSTANCES] = {
     [0 ... MXC_UART_INSTANCES - 1] = false
 };
 

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -62,9 +62,7 @@ uart_revb_req_state_t states[MXC_UART_INSTANCES] = {
     }
 };
 // clang-format on
-static bool g_is_clock_locked[MXC_UART_INSTANCES] = {
-    [0 ... MXC_UART_INSTANCES - 1] = false
-};
+static bool g_is_clock_locked[MXC_UART_INSTANCES] = { [0 ... MXC_UART_INSTANCES - 1] = false };
 
 /* **** Function Prototypes **** */
 
@@ -166,7 +164,8 @@ int MXC_UART_RevB_ReadyForSleep(mxc_uart_revb_regs_t *uart)
     return MXC_UART_GetActive((mxc_uart_regs_t *)uart);
 }
 
-int MXC_UART_RevB_SetFrequency(mxc_uart_revb_regs_t *uart, unsigned int input_clock_freq, unsigned int baud)
+int MXC_UART_RevB_SetFrequency(mxc_uart_revb_regs_t *uart, unsigned int input_clock_freq,
+                               unsigned int baud)
 {
     unsigned clkDiv = 0, mod = 0;
 
@@ -291,14 +290,14 @@ int MXC_UART_RevB_SetClockSource(mxc_uart_revb_regs_t *uart, uint8_t clock_optio
     }
 
     bool is_bclk_enabled = (uart->ctrl & MXC_F_UART_CTRL_BCLKEN) != 0;
-    
+
     if (is_bclk_enabled) {
         // Shut down baud rate clock before changing clock source
         uart->ctrl &= ~MXC_F_UART_CTRL_BCLKEN;
     }
 
     MXC_SETFIELD(uart->ctrl, MXC_F_UART_CTRL_BCLKSRC, clock_option << MXC_F_UART_CTRL_BCLKSRC_POS);
-    
+
     if (is_bclk_enabled) {
         // Turn the baud rate clock back on
         uart->ctrl |= MXC_F_UART_CTRL_BCLKEN;

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -62,6 +62,9 @@ uart_revb_req_state_t states[MXC_UART_INSTANCES] = {
     }
 };
 // clang-format on
+bool g_is_clock_locked[MXC_UART_INSTANCES] = {
+    [0 ... MXC_UART_INSTANCES - 1] = false
+};
 
 /* **** Function Prototypes **** */
 
@@ -283,6 +286,10 @@ int MXC_UART_RevB_SetClockSource(mxc_uart_revb_regs_t *uart, uint8_t clock_optio
 {
     MXC_ASSERT(clock_option >= 0 && clock_option <= 3);
 
+    if (g_is_clock_locked[MXC_UART_GET_IDX((mxc_uart_regs_t *)uart)]) {
+        return E_NO_ERROR; // Return with no error so Init doesn't error out if clock config is locked
+    }
+
     bool is_bclk_enabled = (uart->ctrl & MXC_F_UART_CTRL_BCLKEN) != 0;
     
     if (is_bclk_enabled) {
@@ -306,6 +313,11 @@ int MXC_UART_RevB_SetClockSource(mxc_uart_revb_regs_t *uart, uint8_t clock_optio
 unsigned int MXC_UART_RevB_GetClockSource(mxc_uart_revb_regs_t *uart)
 {
     return ((uart->ctrl & MXC_F_UART_CTRL_BCLKSRC) >> MXC_F_UART_CTRL_BCLKSRC_POS);
+}
+
+void MXC_UART_RevB_LockClockSource(mxc_uart_revb_regs_t *uart, bool lock)
+{
+    g_is_clock_locked[MXC_UART_GET_IDX((mxc_uart_regs_t *)uart)] = lock;
 }
 
 int MXC_UART_RevB_SetFlowCtrl(mxc_uart_revb_regs_t *uart, mxc_uart_flow_t flowCtrl,

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.h
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.h
@@ -55,7 +55,8 @@ struct _mxc_uart_revb_req_t {
 int MXC_UART_RevB_Init(mxc_uart_revb_regs_t *uart, unsigned int baud, mxc_uart_revb_clock_t clock);
 int MXC_UART_RevB_Shutdown(mxc_uart_revb_regs_t *uart);
 int MXC_UART_RevB_ReadyForSleep(mxc_uart_revb_regs_t *uart);
-int MXC_UART_RevB_SetFrequency(mxc_uart_revb_regs_t *uart, unsigned int input_clock_freq, unsigned int baud);
+int MXC_UART_RevB_SetFrequency(mxc_uart_revb_regs_t *uart, unsigned int input_clock_freq,
+                               unsigned int baud);
 int MXC_UART_RevB_GetFrequency(mxc_uart_revb_regs_t *uart);
 int MXC_UART_RevB_SetDataSize(mxc_uart_revb_regs_t *uart, int dataSize);
 int MXC_UART_RevB_SetStopBits(mxc_uart_revb_regs_t *uart, mxc_uart_stop_t stopBits);

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.h
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.h
@@ -64,6 +64,7 @@ int MXC_UART_RevB_SetFlowCtrl(mxc_uart_revb_regs_t *uart, mxc_uart_flow_t flowCt
                               int rtsThreshold);
 int MXC_UART_RevB_SetClockSource(mxc_uart_revb_regs_t *uart, uint8_t clock_option);
 unsigned int MXC_UART_RevB_GetClockSource(mxc_uart_revb_regs_t *uart);
+void MXC_UART_RevB_LockClockSource(mxc_uart_revb_regs_t *uart, bool lock);
 int MXC_UART_RevB_GetActive(mxc_uart_revb_regs_t *uart);
 int MXC_UART_RevB_AbortTransmission(mxc_uart_revb_regs_t *uart);
 int MXC_UART_RevB_ReadCharacterRaw(mxc_uart_revb_regs_t *uart);

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.h
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.h
@@ -63,6 +63,7 @@ int MXC_UART_RevB_SetParity(mxc_uart_revb_regs_t *uart, mxc_uart_parity_t parity
 int MXC_UART_RevB_SetFlowCtrl(mxc_uart_revb_regs_t *uart, mxc_uart_flow_t flowCtrl,
                               int rtsThreshold);
 int MXC_UART_RevB_SetClockSource(mxc_uart_revb_regs_t *uart, uint8_t clock_option);
+unsigned int MXC_UART_RevB_GetClockSource(mxc_uart_revb_regs_t *uart);
 int MXC_UART_RevB_GetActive(mxc_uart_revb_regs_t *uart);
 int MXC_UART_RevB_AbortTransmission(mxc_uart_revb_regs_t *uart);
 int MXC_UART_RevB_ReadCharacterRaw(mxc_uart_revb_regs_t *uart);

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.h
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.h
@@ -55,15 +55,14 @@ struct _mxc_uart_revb_req_t {
 int MXC_UART_RevB_Init(mxc_uart_revb_regs_t *uart, unsigned int baud, mxc_uart_revb_clock_t clock);
 int MXC_UART_RevB_Shutdown(mxc_uart_revb_regs_t *uart);
 int MXC_UART_RevB_ReadyForSleep(mxc_uart_revb_regs_t *uart);
-int MXC_UART_RevB_SetFrequency(mxc_uart_revb_regs_t *uart, unsigned int baud,
-                               mxc_uart_revb_clock_t clock);
+int MXC_UART_RevB_SetFrequency(mxc_uart_revb_regs_t *uart, unsigned int input_clock_freq, unsigned int baud);
 int MXC_UART_RevB_GetFrequency(mxc_uart_revb_regs_t *uart);
 int MXC_UART_RevB_SetDataSize(mxc_uart_revb_regs_t *uart, int dataSize);
 int MXC_UART_RevB_SetStopBits(mxc_uart_revb_regs_t *uart, mxc_uart_stop_t stopBits);
 int MXC_UART_RevB_SetParity(mxc_uart_revb_regs_t *uart, mxc_uart_parity_t parity);
 int MXC_UART_RevB_SetFlowCtrl(mxc_uart_revb_regs_t *uart, mxc_uart_flow_t flowCtrl,
                               int rtsThreshold);
-int MXC_UART_RevB_SetClockSource(mxc_uart_revb_regs_t *uart, mxc_uart_revb_clock_t clock);
+int MXC_UART_RevB_SetClockSource(mxc_uart_revb_regs_t *uart, uint8_t clock_option);
 int MXC_UART_RevB_GetActive(mxc_uart_revb_regs_t *uart);
 int MXC_UART_RevB_AbortTransmission(mxc_uart_revb_regs_t *uart);
 int MXC_UART_RevB_ReadCharacterRaw(mxc_uart_revb_regs_t *uart);

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me18.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me18.c
@@ -162,7 +162,8 @@ int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
     return E_NO_ERROR;
 }
 
-void MXC_WDT_LockClockSource(mxc_wdt_regs_t *wdt, bool lock)
+int MXC_WDT_LockClockSource(mxc_wdt_regs_t *wdt, bool lock)
 {
     g_is_clock_locked[MXC_WDT_GET_IDX(wdt)] = lock;
+    return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me18.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me18.c
@@ -26,7 +26,7 @@
 #include "wdt.h"
 #include "wdt_revb.h"
 
-bool g_is_clock_locked[MXC_CFG_WDT_INSTANCES] = {
+static bool g_is_clock_locked[MXC_CFG_WDT_INSTANCES] = {
     [0 ... MXC_CFG_WDT_INSTANCES - 1] = false
 };
 

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me18.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me18.c
@@ -26,6 +26,10 @@
 #include "wdt.h"
 #include "wdt_revb.h"
 
+bool g_is_clock_locked[MXC_CFG_WDT_INSTANCES] = {
+    [0 ... MXC_CFG_WDT_INSTANCES - 1] = false
+};
+
 /* **** Functions **** */
 
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt, mxc_wdt_cfg_t *cfg)
@@ -125,6 +129,10 @@ void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt)
 
 int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
 {
+    if (g_is_clock_locked[MXC_WDT_GET_IDX(wdt)]) {
+        return E_NO_ERROR; // Return no error so that Init doesn't failed if called after this function
+    }
+
     const uint8_t clock_source_num = 8;
     uint8_t idx = 0;
     uint8_t instance = 0;
@@ -152,4 +160,9 @@ int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
     MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, idx);
 
     return E_NO_ERROR;
+}
+
+void MXC_WDT_LockClockSource(mxc_wdt_regs_t *wdt, bool lock)
+{
+    g_is_clock_locked[MXC_WDT_GET_IDX(wdt)] = lock;
 }

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me18.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me18.c
@@ -26,9 +26,8 @@
 #include "wdt.h"
 #include "wdt_revb.h"
 
-static bool g_is_clock_locked[MXC_CFG_WDT_INSTANCES] = {
-    [0 ... MXC_CFG_WDT_INSTANCES - 1] = false
-};
+static bool g_is_clock_locked[MXC_CFG_WDT_INSTANCES] = { [0 ... MXC_CFG_WDT_INSTANCES - 1] =
+                                                             false };
 
 /* **** Functions **** */
 


### PR DESCRIPTION
### Description

This PR adds various APIs and features to support CFS clock config code generation.

Primarily, this includes clock setter APIs.

Since many of the peripheral's Init APIs also configure the clock source, a locking mechanism was developed to allow the CFS config to take precedence.  This is a temporary solution until CFS can perform full peripheral configuration, which is in the roadmap.

Additionally, it adds the weak `ClockInit()` function to the system startup code.  CFS will override this function.

This PR also adds dual-mode TMR support.  The process involves initializing the TMR instance twice, once with the `16A` bit-mode config, and once with the `16B` bit-mode config.

<details>
  <summary>Dual-Mode Example</summary>

```C
/******************************************************************************
 *
 * Copyright (C) 2024 Analog Devices, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *
 ******************************************************************************/

// Dual mode timer configuration example for MAX78002.

/***** Includes *****/
#include <stdio.h>
#include <stdint.h>
#include "mxc_device.h"
#include "led.h"
#include "board.h"
#include "tmr.h"
#include "nvic_table.h"

/***** Definitions *****/

/***** Globals *****/

/***** Functions *****/
void TMR_ISR(void)
{
    uint32_t flags = MXC_TMR_GetFlags(MXC_TMR0);
    if (flags & MXC_F_TMR_INTFL_IRQ_A) {
        LED_Toggle(0);
        MXC_TMR0->intfl |= MXC_F_TMR_INTFL_IRQ_A;
    }
    
    if (flags & MXC_F_TMR_INTFL_IRQ_B) {
        LED_Toggle(1);
        MXC_TMR0->intfl |= MXC_F_TMR_INTFL_IRQ_B;
    }
}

// *****************************************************************************
int main(void)
{
    mxc_tmr_cfg_t tmr0a_cfg = {
        .bitMode = MXC_TMR_BIT_MODE_16A,
        .clock = MXC_TMR_APB_CLK,
        .cmp_cnt = MXC_TMR_GetPeriod(MXC_TMR0, MXC_TMR_ISO_CLK, 128, 1),
        .mode = MXC_TMR_MODE_CONTINUOUS,
        .pol = 0,
        .pres = MXC_TMR_PRES_128
    };

    mxc_tmr_cfg_t tmr0b_cfg = {
        .bitMode = MXC_TMR_BIT_MODE_16B,
        .clock = MXC_TMR_APB_CLK,  
        .cmp_cnt = MXC_TMR_GetPeriod(MXC_TMR0, MXC_TMR_ISO_CLK, 128, 2),
        .mode = MXC_TMR_MODE_CONTINUOUS,
        .pol = 0,
        .pres = MXC_TMR_PRES_128
    };

    MXC_TMR_Init(MXC_TMR0, &tmr0a_cfg, false);
    MXC_TMR_Init(MXC_TMR0, &tmr0b_cfg, false);

    MXC_TMR_EnableInt(MXC_TMR0);
    NVIC_EnableIRQ(TMR0_IRQn);
    MXC_NVIC_SetVector(TMR0_IRQn, TMR_ISR);

    MXC_TMR_Start(MXC_TMR0);
}
```

</details>

This RISCV system clock input can now also be set with `MXC_SYS_RISCVClockSelect`.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
