### PR TITLE
fix(PeriphDrivers): Fix I2C DMA Issues When Slave Does Not ACK Address, Fix 1-length I2C DMA Transactions

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32665/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/dma.h
@@ -445,6 +445,28 @@ int MXC_DMA_Stop(int ch);
  */
 mxc_dma_ch_regs_t *MXC_DMA_GetCHRegs(int ch);
 
+typedef void (*dma_handler_t)(void);
+/**
+ * @brief      Get the appropriate "hard" DMA handler for the specified DMA instance.
+ *             @ref MXC_DMA_DMA0_Handler or @ref MXC_DMA_DMA1_Handler.
+ *             Mostly used by internal drivers.
+ */
+dma_handler_t MXC_DMA_Get_DMA_Handler(mxc_dma_regs_t *dma);
+
+/**
+ * @brief      Interrupt handler function for DMA0
+ * @details    Used by some internal drivers that automatically assign DMA handlers.
+ *             This is equivalent to "MXC_DMA_Handler(MXC_DMA0);"
+ */
+void MXC_DMA_DMA0_Handler(void);
+
+/**
+ * @brief      Interrupt handler function for DMA0
+ * @details    Used by some internal drivers that automatically assign DMA handlers.
+ *             This is equivalent to "MXC_DMA_Handler(MXC_DMA1);"
+ */
+void MXC_DMA_DMA1_Handler(void);
+
 /**
  * @brief      Interrupt handler function
  * @param 	   dma 	Pointer to DMA registers.

--- a/Libraries/PeriphDrivers/Source/DMA/dma_me14.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_me14.c
@@ -177,6 +177,23 @@ mxc_dma_ch_regs_t *MXC_DMA_GetCHRegs(int ch)
     return MXC_DMA_RevA_GetCHRegs(ch);
 }
 
+dma_handler_t MXC_DMA_Get_DMA_Handler(mxc_dma_regs_t *dma)
+{
+    if (dma == MXC_DMA0) return MXC_DMA_DMA0_Handler;
+    else if (dma == MXC_DMA1) return MXC_DMA_DMA1_Handler;
+    else return NULL;
+}
+
+void MXC_DMA_DMA0_Handler(void)
+{
+    MXC_DMA_RevA_Handler((mxc_dma_reva_regs_t *)MXC_DMA0);
+}
+
+void MXC_DMA_DMA1_Handler(void)
+{
+    MXC_DMA_RevA_Handler((mxc_dma_reva_regs_t *)MXC_DMA1);
+}
+
 void MXC_DMA_Handler(mxc_dma_regs_t *dma)
 {
     if (MXC_DMA_GET_IDX(dma) != -1) {

--- a/Libraries/PeriphDrivers/Source/DMA/dma_me14.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_me14.c
@@ -179,9 +179,12 @@ mxc_dma_ch_regs_t *MXC_DMA_GetCHRegs(int ch)
 
 dma_handler_t MXC_DMA_Get_DMA_Handler(mxc_dma_regs_t *dma)
 {
-    if (dma == MXC_DMA0) return MXC_DMA_DMA0_Handler;
-    else if (dma == MXC_DMA1) return MXC_DMA_DMA1_Handler;
-    else return NULL;
+    if (dma == MXC_DMA0)
+        return MXC_DMA_DMA0_Handler;
+    else if (dma == MXC_DMA1)
+        return MXC_DMA_DMA1_Handler;
+    else
+        return NULL;
 }
 
 void MXC_DMA_DMA0_Handler(void)

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
@@ -32,6 +32,7 @@
 #include "i2c_reva.h"
 #include "dma.h"
 #include "dma_reva.h"
+#include "nvic_table.h"
 
 /* **** Variable Declaration **** */
 typedef struct {
@@ -354,6 +355,10 @@ int MXC_I2C_RevA_DMA_Init(mxc_i2c_reva_regs_t *i2c, mxc_dma_reva_regs_t *dma, bo
         MXC_DMA_SetChannelInterruptEn(txChannel, 0, 1);
 
         states[i2cNum].channelTx = txChannel;
+#ifdef __arm__
+        NVIC_EnableIRQ(MXC_DMA_CH_GET_IRQ(txChannel));
+        MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(txChannel), MXC_DMA_Handler);
+#endif
     }
 
     // Set up I2C DMA RX.
@@ -384,6 +389,10 @@ int MXC_I2C_RevA_DMA_Init(mxc_i2c_reva_regs_t *i2c, mxc_dma_reva_regs_t *dma, bo
 
         MXC_DMA_EnableInt(rxChannel);
         MXC_DMA_SetChannelInterruptEn(rxChannel, 0, 1);
+#ifdef __arm__
+        NVIC_EnableIRQ(MXC_DMA_CH_GET_IRQ(rxChannel));
+        MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(rxChannel), MXC_DMA_Handler);
+#endif
 
         states[i2cNum].channelRx = rxChannel;
     }
@@ -1082,8 +1091,8 @@ int MXC_I2C_RevA_MasterTransactionDMA(mxc_i2c_reva_req_t *req, mxc_dma_regs_t *d
     MXC_I2C_SetRXThreshold((mxc_i2c_regs_t *)i2c, 1);
 
     states[i2cNum].req = req;
-    states[i2cNum].writeDone = 0;
-    states[i2cNum].readDone = 0;
+    states[i2cNum].writeDone = (req->tx_len == 0);
+    states[i2cNum].readDone = (req->rx_len == 0);
 
     // If MXC_I2C_DMA_Init(...) was not already called, then configure both DMA TX/RXchannels by default.
     if (states[i2cNum].dma_initialized == false) {
@@ -1122,17 +1131,30 @@ int MXC_I2C_RevA_MasterTransactionDMA(mxc_i2c_reva_req_t *req, mxc_dma_regs_t *d
                 i2c->rxctrl1 = req->rx_len; // 0 for 256, otherwise number of bytes to read
             }
 
-            MXC_I2C_Start((mxc_i2c_regs_t *)i2c); // Start or Restart as needed
-
-            while (i2c->mstctrl & MXC_F_I2C_REVA_MSTCTRL_RESTART) {}
-
-            i2c->fifo = ((req->addr) << 1) | 0x1; // Load the slave address with write bit set
-
 #if TARGET_NUM == 32665
             MXC_I2C_ReadRXFIFODMA((mxc_i2c_regs_t *)i2c, req->rx_buf, req->rx_len, NULL, dma);
 #else
             MXC_I2C_ReadRXFIFODMA((mxc_i2c_regs_t *)i2c, req->rx_buf, req->rx_len, NULL);
 #endif
+
+            MXC_I2C_Start((mxc_i2c_regs_t *)i2c); // Start or Restart as needed
+
+            while (i2c->mstctrl & MXC_F_I2C_REVA_MSTCTRL_RESTART) {}
+
+            i2c->fifo = ((req->addr) << 1) | 0x1; // Load the slave address with write bit set
+            while(!((i2c->intfl0 & MXC_F_I2C_REVA_INTFL0_ADDR_ACK) || (i2c->intfl0 & MXC_F_I2C_REVA_INTFL0_ADDR_NACK_ERR))) {
+                // Wait for an ACK or NACK from the slave
+            }
+            if (!(i2c->intfl0 & MXC_F_I2C_REVA_INTFL0_ADDR_ACK)) {
+                // If we did not get an ACK, then something went wrong.  
+                // Abort the transaction and signal the user's callback
+                MXC_I2C_RevA_Stop(i2c);
+                MXC_DMA_Stop(states[i2cNum].channelRx);
+                if (states[i2cNum].req->callback != NULL) {
+                    states[i2cNum].req->callback(states[i2cNum].req, E_COMM_ERR);                    
+                }
+                return E_COMM_ERR;
+            }
         }
     } else {
         states[i2cNum].readDone = 1;

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
@@ -358,7 +358,8 @@ int MXC_I2C_RevA_DMA_Init(mxc_i2c_reva_regs_t *i2c, mxc_dma_reva_regs_t *dma, bo
 #ifdef __arm__
         NVIC_EnableIRQ(MXC_DMA_CH_GET_IRQ(txChannel));
 #if TARGET_NUM == 32665
-        MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(txChannel), MXC_DMA_Get_DMA_Handler((mxc_dma_regs_t *)dma));
+        MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(txChannel),
+                           MXC_DMA_Get_DMA_Handler((mxc_dma_regs_t *)dma));
 #else
         MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(txChannel), MXC_DMA_Handler);
 #endif
@@ -396,7 +397,8 @@ int MXC_I2C_RevA_DMA_Init(mxc_i2c_reva_regs_t *i2c, mxc_dma_reva_regs_t *dma, bo
 #ifdef __arm__
         NVIC_EnableIRQ(MXC_DMA_CH_GET_IRQ(rxChannel));
 #if TARGET_NUM == 32665
-        MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(txChannel), MXC_DMA_Get_DMA_Handler((mxc_dma_regs_t *)dma));
+        MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(txChannel),
+                           MXC_DMA_Get_DMA_Handler((mxc_dma_regs_t *)dma));
 #else
         MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(txChannel), MXC_DMA_Handler);
 #endif
@@ -1150,16 +1152,17 @@ int MXC_I2C_RevA_MasterTransactionDMA(mxc_i2c_reva_req_t *req, mxc_dma_regs_t *d
             while (i2c->mstctrl & MXC_F_I2C_REVA_MSTCTRL_RESTART) {}
 
             i2c->fifo = ((req->addr) << 1) | 0x1; // Load the slave address with write bit set
-            while(!((i2c->intfl0 & MXC_F_I2C_REVA_INTFL0_ADDR_ACK) || (i2c->intfl0 & MXC_F_I2C_REVA_INTFL0_ADDR_NACK_ERR))) {
+            while (!((i2c->intfl0 & MXC_F_I2C_REVA_INTFL0_ADDR_ACK) ||
+                     (i2c->intfl0 & MXC_F_I2C_REVA_INTFL0_ADDR_NACK_ERR))) {
                 // Wait for an ACK or NACK from the slave
             }
             if (!(i2c->intfl0 & MXC_F_I2C_REVA_INTFL0_ADDR_ACK)) {
-                // If we did not get an ACK, then something went wrong.  
+                // If we did not get an ACK, then something went wrong.
                 // Abort the transaction and signal the user's callback
                 MXC_I2C_RevA_Stop(i2c);
                 MXC_DMA_Stop(states[i2cNum].channelRx);
                 if (states[i2cNum].req->callback != NULL) {
-                    states[i2cNum].req->callback(states[i2cNum].req, E_COMM_ERR);                    
+                    states[i2cNum].req->callback(states[i2cNum].req, E_COMM_ERR);
                 }
                 return E_COMM_ERR;
             }

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
@@ -298,8 +298,8 @@ int MXC_I2C_RevA_DMA_Init(mxc_i2c_reva_regs_t *i2c, mxc_dma_reva_regs_t *dma, bo
                           bool use_dma_rx)
 {
     int8_t i2cNum;
-    int8_t rxChannel;
-    int8_t txChannel;
+    int8_t rxChannel = -1;
+    int8_t txChannel = -1;
 
     if (i2c == NULL || dma == NULL) {
         return E_NULL_PTR;
@@ -357,7 +357,11 @@ int MXC_I2C_RevA_DMA_Init(mxc_i2c_reva_regs_t *i2c, mxc_dma_reva_regs_t *dma, bo
         states[i2cNum].channelTx = txChannel;
 #ifdef __arm__
         NVIC_EnableIRQ(MXC_DMA_CH_GET_IRQ(txChannel));
+#if TARGET_NUM == 32665
+        MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(txChannel), MXC_DMA_Get_DMA_Handler((mxc_dma_regs_t *)dma));
+#else
         MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(txChannel), MXC_DMA_Handler);
+#endif
 #endif
     }
 
@@ -391,7 +395,11 @@ int MXC_I2C_RevA_DMA_Init(mxc_i2c_reva_regs_t *i2c, mxc_dma_reva_regs_t *dma, bo
         MXC_DMA_SetChannelInterruptEn(rxChannel, 0, 1);
 #ifdef __arm__
         NVIC_EnableIRQ(MXC_DMA_CH_GET_IRQ(rxChannel));
-        MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(rxChannel), MXC_DMA_Handler);
+#if TARGET_NUM == 32665
+        MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(txChannel), MXC_DMA_Get_DMA_Handler((mxc_dma_regs_t *)dma));
+#else
+        MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(txChannel), MXC_DMA_Handler);
+#endif
 #endif
 
         states[i2cNum].channelRx = rxChannel;


### PR DESCRIPTION
### Description

This PR fixes various I2C DMA issues that are caused by slaves that intentionally NACK their I2C address, such as the [MS8607](https://www.te.com/commerce/DocumentDelivery/DDEController?Action=showdoc&DocId=Data+Sheet%7FMS8607-02BA01%7FB3%7Fpdf%7FEnglish%7FENG_DS_MS8607-02BA01_B3.pdf%7FCAT-BLPS0018).

Fixes #987 

Ex:

![image](https://github.com/user-attachments/assets/762f0972-6bda-4940-8e4b-9e47feb85ea6)

Previously, `MXC_I2C_MasterTransactionDMA` would send the read request and then immediately start reading from the I2C RX FIFO with DMA.  If the slave NACKs that address, no further bytes will be sent.  Therefore the DMA request will never complete and DMA callbacks will never be hit, all the while the master locks up and holds the SCL line low.

Now, we wait to see if we got an ACK or a NACK immediately after we send the read request.  If we get a NACK, we abort the transaction, issue a STOP signal, and pass the communication error along to the user's callback and the return code.  This solves the master "lockup" and allows the user application to decide what to do from here, such as retry the transaction.

It also applies a logical fix that corrects issues with TX/RX transactions with a length of 1.

Tested with an [MS8607 Adafruit module](https://www.adafruit.com/product/4716) and MAX78002EVKIT
<details>
  <summary>Test Code</summary>

  ```C
  /******************************************************************************
   *
   * Copyright (C) 2024 Analog Devices, Inc.
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.
   * You may obtain a copy of the License at
   *
   *     http://www.apache.org/licenses/LICENSE-2.0
   *
   * Unless required by applicable law or agreed to in writing, software
   * distributed under the License is distributed on an "AS IS" BASIS,
   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   * See the License for the specific language governing permissions and
   * limitations under the License.
   *
   ******************************************************************************/
  
  /**
   * @file    main.c
   * @brief   Hello World!
   * @details This example uses the UART to print to a terminal and flashes an LED.
   */
  
  /***** Includes *****/
  #include <stdio.h>
  #include <stdint.h>
  #include <stdbool.h>
  #include <math.h>
  #include "mxc_device.h"
  #include "led.h"
  #include "board.h"
  #include "mxc_delay.h"
  #include "i2c.h"
  
  /***** Definitions *****/
  #define ADDR_PT 0x76
  #define ADDR_RH 0x40
  #define MS8607_CMD_RESET_RH 0b11111110
  #define MS8607_CMD_MEASURE_RH_HOLD 0b11100101
  #define MS8607_CMD_MEASURE_RH_NOHOLD 0b11110101
  
  static volatile bool g_dma_complete = false;
  static volatile int g_dma_status = E_NO_ERROR;
  
  #define I2C_INSTANCE MXC_I2C0
  
  void DMA_Callback(mxc_i2c_req_t *req, int result)
  {
      g_dma_complete = true;
      g_dma_status = result;
  }
  
  /***** Globals *****/
  static mxc_i2c_req_t g_req = {
          .i2c = I2C_INSTANCE,
          .addr = ADDR_RH,
          .rx_buf = NULL,
          .rx_len = 0,
          .tx_buf = NULL,
          .tx_len = 0,
          .callback = DMA_Callback
      };
  
  /***** Functions *****/
  // Utility function for resetting flags and launching the I2C DMA transaction
  static inline int launch_DMA_Transaction(void)
  {
      g_dma_complete = false;
      g_dma_status = E_NO_ERROR;
      int err = MXC_I2C_MasterTransactionDMA(&g_req);
      return err;
  }
  
  int MS8607_Reset(void)
  {
      uint8_t tx_buf = MS8607_CMD_RESET_RH;
      g_req.addr = ADDR_RH;
      g_req.tx_buf = &tx_buf;
      g_req.tx_len = 1;
      int err = launch_DMA_Transaction();
      MXC_Delay(MXC_DELAY_MSEC(15));
      return err;
  }
  
  int MS8607_MeasureRH_NoHold(double *out_RH)
  {
      uint8_t tx_buf = MS8607_CMD_MEASURE_RH_NOHOLD;
      uint8_t rx_buf[3] = { 0, 0, 0 };
      
      // Send command
      g_req.addr = ADDR_RH;
      g_req.tx_buf = &tx_buf;
      g_req.rx_buf = NULL;
      g_req.tx_len = 1;
      g_req.rx_len = 0;
      int err = launch_DMA_Transaction();
      while(!g_dma_complete) {} // Wait for command to be sent
  
      do {
          MXC_Delay(MXC_DELAY_MSEC(2));
          // ^ RH measurement seems to take about 15ms.
          // If we constantly spam the MS8607 with polling reads then
          // the measurement will never finish.  It needs some space to
          // perform the calculations, so we delay ~2ms between each poll.
          g_req.tx_len = 0;
          g_req.rx_len = 3;
          g_req.rx_buf = rx_buf;
          err = launch_DMA_Transaction();
          while(!g_dma_complete) {} // Wait for read to complete.
      } while (g_dma_status != E_NO_ERROR && err != E_NO_ERROR);
      // ^ The MS8607 will NACK our read request if the measurement is not ready.
      // In that case, the callback function will receive E_COMM_ERR and MXC_I2C_MasterTransactionDMA 
      // will return E_COMM_ERR.  We want to keep re-trying until the sensors ACKs our read request.
      
      uint16_t D3 = rx_buf[0] << 8 | (rx_buf[1] & 0b11111100);
      int16_t RH = -600 + 12500 * (D3 / (pow(2, 16)));
      *out_RH = RH / 100.0f;
      return err;
  }
  
  // *****************************************************************************
  int main(void)
  {
      MXC_I2C_Init(I2C_INSTANCE, true, ADDR_RH);
      MXC_I2C_SetFrequency(I2C_INSTANCE, 400000);
      MXC_I2C_DMA_Init(I2C_INSTANCE, MXC_DMA, true, true);
  
      int err = MS8607_Reset();
      if (err) {
          printf("Failed to reset MS8607, error %i\n", err);
          return err;
      }
  
      double RH = 0;
      err = MS8607_MeasureRH_NoHold(&RH);
      if (err) {
          printf("RH Measurement error %i\n", err);
      } else {
          printf("RH Success, result: %.2f%%\n", RH);
      }
  }
  ```

</details>

Complete analyzer trace:  [gh-987-fixed.zip](https://github.com/user-attachments/files/16567504/gh-987-fixed.zip)

![image](https://github.com/user-attachments/assets/75039f58-b69a-42e1-8717-5237a9d1d77a)

Master issues the TX Command...

![image](https://github.com/user-attachments/assets/5e91edac-a875-4999-b2db-5437b9779d52)

... Polls the device with an RX command that is NACK'd...

![image](https://github.com/user-attachments/assets/c590c023-47a0-417e-b18c-9721729daaee)

... Continues polling...

![image](https://github.com/user-attachments/assets/6b4e087d-537b-4b21-a9ad-b4bce0c45f68)

... Until an ACK is received.  DMA unloads the data bytes successfully...

![image](https://github.com/user-attachments/assets/a9080188-9237-47d6-8bd2-e819e72a03ea)



### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
