### PR TITLE
perf(Boards, MiscDrivers): Removed TFT CS delay and added new TFT function

### DIFF
--- a/Libraries/Boards/MAX32690/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX32690/EvKit_V1/Source/board.c
@@ -191,7 +191,6 @@ void TFT_SPI_Write(uint8_t *datain, uint32_t count, bool data)
     }
 
     MXC_GPIO_OutClr(tft_cs.port, tft_cs.mask); // Assert chip select (active low)
-    MXC_Delay(10);
 
     for (int i = 0; i < count; i++) {
         tx_byte = datain[i];
@@ -214,15 +213,14 @@ void TFT_SPI_Write(uint8_t *datain, uint32_t count, bool data)
                 tx_byte = tx_byte << 1;
             }
 
-            for (int k = 0; k < 2; k++) {}
+            for (volatile int k = 0; k < 2; k++) {}
 
             tft_clk.port->out_set = tft_clk.mask; // Clk high
 
-            for (int k = 0; k < 2; k++) {}
+            for (volatile int k = 0; k < 2; k++) {}
         }
     }
 
-    MXC_Delay(10);
     MXC_GPIO_OutSet(tft_cs.port, tft_cs.mask); // De-assert chip select (active low)
 
     return;

--- a/Libraries/MiscDrivers/Display/tft_st7735.c
+++ b/Libraries/MiscDrivers/Display/tft_st7735.c
@@ -753,6 +753,15 @@ void MXC_TFT_PrintFont(int x0, int y0, int id, text_t *str, area_t *area)
     }
 }
 
+void MXC_TFT_PrintFontColor(int x0, int y0, int id, text_t *str, unsigned int font_color,
+                            unsigned int fill_color)
+{
+    MXC_TFT_SetForeGroundColor(font_color);
+    g_background_color = fill_color;
+
+    MXC_TFT_PrintFont(x0, y0, id, str, NULL);
+}
+
 void MXC_TFT_Print(int x0, int y0, text_t *str, area_t *area)
 {
     MXC_TFT_PrintFont(x0, y0, (int)g_font, str, area);

--- a/Libraries/MiscDrivers/Display/tft_st7735.h
+++ b/Libraries/MiscDrivers/Display/tft_st7735.h
@@ -216,7 +216,7 @@ void MXC_TFT_ResetCursor(void);
  *
  * @param       x0              x location on screen
  * @param       y0              y location on screen
- * @param       fon_id          Font number
+ * @param       font_id         Font number ID
  * @param       str             String which will be display
  * @param       area            Location of printf outputs
  */


### PR DESCRIPTION
Slight modifications to the TFT LCD display drivers on the MAX32690 EV Kit V1 board.
- Removed delays in ``TFT_SPI_Write()`` to reduce the screen refresh time from 0.87129 seconds to 0.120858 seconds -- an 86% improvement.
- ``MXC_TFT_PrintFont()`` would use the initially set background color around the printed text. Added a function to offer color selection of both the background and the font text.

