### PR TITLE
chore(PeriphDrivers): Adding option for MAX32655 B1 0x4231.

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32655/mxc_device.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/mxc_device.h
@@ -43,6 +43,10 @@
 // A1
 #define MXC_TMR_REV 0
 #define MXC_UART_REV 0
+#elif (TARGET_REV == 0x4231)
+// B1
+#define MXC_TMR_REV 0
+#define MXC_UART_REV 0
 #else
 
 #error TARGET_REV NOT SUPPORTED


### PR DESCRIPTION
### Description

Adding PeriphDriver option for MAX32655 B1

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.

