### PR TITLE
fix(PeriphDrivers): Add UART Clock Setter API for all parts using UART RevB Drivers

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32572/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/uart.h
@@ -78,14 +78,9 @@ typedef enum {
 /**
  * @brief      Clock settings */
 typedef enum {
-    /*For UART3 APB clock source is the 8MHz clock*/
     MXC_UART_APB_CLK = 0,
-    MXC_UART_EXT_CLK = 1,
-    /*IBRO and ERFO clock can only be used for UART 0, 1 & 2*/
     MXC_UART_IBRO_CLK = 2,
     MXC_UART_ERFO_CLK = 3,
-    /*ERTCO clock can only be used for UART3*/
-    MXC_UART_ERTCO_CLK = 4,
 } mxc_uart_clock_t;
 
 /**
@@ -253,6 +248,15 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
  *          for a list of return codes.
  */
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock);
+
+/**
+ * @brief   Gets the clock source used for the UART instance
+ * 
+ * @param   uart         Pointer to UART registers (selects the UART block used.)
+ *
+ * @return  The selected clock source for the UART instance
+ */
+mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart);
 
 /* ************************************************************************* */
 /* Low-level functions                                                       */

--- a/Libraries/PeriphDrivers/Include/MAX32655/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/uart.h
@@ -257,6 +257,15 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
  */
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock);
 
+/**
+ * @brief   Gets the clock source used for the UART instance
+ * 
+ * @param   uart         Pointer to UART registers (selects the UART block used.)
+ *
+ * @return  The selected clock source for the UART instance
+ */
+mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart);
+
 /* ************************************************************************* */
 /* Low-level functions                                                       */
 /* ************************************************************************* */

--- a/Libraries/PeriphDrivers/Include/MAX32662/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/uart.h
@@ -256,6 +256,15 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
  */
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock);
 
+/**
+ * @brief   Gets the clock source used for the UART instance
+ * 
+ * @param   uart         Pointer to UART registers (selects the UART block used.)
+ *
+ * @return  The selected clock source for the UART instance
+ */
+mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart);
+
 /* ************************************************************************* */
 /* Low-level functions                                                       */
 /* ************************************************************************* */

--- a/Libraries/PeriphDrivers/Include/MAX32690/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/uart.h
@@ -255,6 +255,13 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
  */
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock);
 
+/**
+ * @brief   Gets the clock source used for the UART instance
+ * 
+ * @param   uart         Pointer to UART registers (selects the UART block used.)
+ *
+ * @return  The selected clock source for the UART instance
+ */
 mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart);
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX78000/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/uart.h
@@ -252,6 +252,15 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
  */
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock);
 
+/**
+ * @brief   Gets the clock source used for the UART instance
+ * 
+ * @param   uart         Pointer to UART registers (selects the UART block used.)
+ *
+ * @return  The selected clock source for the UART instance
+ */
+mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart);
+
 /* ************************************************************************* */
 /* Low-level functions                                                       */
 /* ************************************************************************* */

--- a/Libraries/PeriphDrivers/Include/MAX78002/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/uart.h
@@ -244,6 +244,13 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
  */
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock);
 
+/**
+ * @brief   Gets the clock source used for the UART instance
+ * 
+ * @param   uart         Pointer to UART registers (selects the UART block used.)
+ *
+ * @return  The selected clock source for the UART instance
+ */
 mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart);
 
 /**

--- a/Libraries/PeriphDrivers/Source/UART/uart_ai85.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_ai85.c
@@ -128,35 +128,35 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
         return E_BAD_PARAM;
     }
 
-    switch(clock) {
-        case MXC_UART_APB_CLK:
-            clock_freq = SystemCoreClock / 2;
-            break;
+    switch (clock) {
+    case MXC_UART_APB_CLK:
+        clock_freq = SystemCoreClock / 2;
+        break;
 
-        case MXC_UART_IBRO_CLK:
-            clock_freq = IBRO_FREQ;
-            break;
-        
-        case MXC_UART_ERTCO_CLK:
-            // Only UART3 (LPUART0) supports ERTCO clock source.
-            if (uart != MXC_UART3) {
-                return E_BAD_PARAM;
-            }
+    case MXC_UART_IBRO_CLK:
+        clock_freq = IBRO_FREQ;
+        break;
 
-            uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_EXTERNAL_CLOCK;
-            uart->ctrl |= MXC_F_UART_CTRL_FDM;
-        
-            if (baud > 2400) {
-                uart->osr = 0;
-            } else {
-                uart->osr = 1;
-            }
-
-            clock_freq = ERTCO_FREQ * 2; // x2 to account for FDM.
-            break;
-        
-        default:
+    case MXC_UART_ERTCO_CLK:
+        // Only UART3 (LPUART0) supports ERTCO clock source.
+        if (uart != MXC_UART3) {
             return E_BAD_PARAM;
+        }
+
+        uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_EXTERNAL_CLOCK;
+        uart->ctrl |= MXC_F_UART_CTRL_FDM;
+
+        if (baud > 2400) {
+            uart->osr = 0;
+        } else {
+            uart->osr = 1;
+        }
+
+        clock_freq = ERTCO_FREQ * 2; // x2 to account for FDM.
+        break;
+
+    default:
+        return E_BAD_PARAM;
     }
 
     freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, clock_freq, baud);
@@ -239,45 +239,45 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
     int error = E_NO_ERROR;
 
     switch (MXC_UART_GET_IDX(uart)) {
-        case 0:
-        case 1:
-        case 2:
-            // UART0-2 support PCLK and IBRO
-            switch (clock) {
-            case MXC_UART_APB_CLK:
-                MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
-                break;
-
-            case MXC_UART_IBRO_CLK:
-                error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-                MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
-                break;
-
-            default:
-                return E_BAD_PARAM;
-            }
+    case 0:
+    case 1:
+    case 2:
+        // UART0-2 support PCLK and IBRO
+        switch (clock) {
+        case MXC_UART_APB_CLK:
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
             break;
 
-        case 3:
-            // UART3 (LPUART0) supports IBRO and ERTCO
-            switch (clock) {
-            case MXC_UART_IBRO_CLK:
-                error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-                MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
-                break;
-
-            case MXC_UART_ERTCO_CLK:
-                error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
-                MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 3);
-                break;
-
-            default:
-                return E_BAD_PARAM;
-            }
+        case MXC_UART_IBRO_CLK:
+            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
             break;
 
         default:
             return E_BAD_PARAM;
+        }
+        break;
+
+    case 3:
+        // UART3 (LPUART0) supports IBRO and ERTCO
+        switch (clock) {
+        case MXC_UART_IBRO_CLK:
+            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
+            break;
+
+        case MXC_UART_ERTCO_CLK:
+            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 3);
+            break;
+
+        default:
+            return E_BAD_PARAM;
+        }
+        break;
+
+    default:
+        return E_BAD_PARAM;
     }
 
     return error;

--- a/Libraries/PeriphDrivers/Source/UART/uart_ai85.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_ai85.c
@@ -47,22 +47,8 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     int retval;
 
     retval = MXC_UART_Shutdown(uart);
-
     if (retval) {
         return retval;
-    }
-
-    switch (clock) {
-    case MXC_UART_ERTCO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
-        break;
-
-    case MXC_UART_IBRO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-        break;
-
-    default:
-        break;
     }
 
     switch (MXC_UART_GET_IDX(uart)) {
@@ -88,6 +74,11 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
 
     default:
         return E_BAD_PARAM;
+    }
+
+    retval = MXC_UART_SetClockSource(uart, clock);
+    if (retval != E_NO_ERROR) {
+        return retval;
     }
 
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, clock);
@@ -130,59 +121,53 @@ int MXC_UART_ReadyForSleep(mxc_uart_regs_t *uart)
 
 int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
-    int frequency, clkDiv = 0, mod = 0;
+    int freq;
+    uint32_t clock_freq = 0;
+
     if (MXC_UART_GET_IDX(uart) < 0) {
         return E_BAD_PARAM;
     }
 
-    // check if the uart is LPUART
-    if (uart == MXC_UART3) {
-        // OSR default value
-        uart->osr = 5;
-
-        switch (clock) {
+    switch(clock) {
         case MXC_UART_APB_CLK:
-        case MXC_UART_IBRO_CLK:
-            clkDiv = ((IBRO_FREQ) / baud);
-            mod = ((IBRO_FREQ) % baud);
+            clock_freq = SystemCoreClock / 2;
             break;
 
+        case MXC_UART_IBRO_CLK:
+            clock_freq = IBRO_FREQ;
+            break;
+        
         case MXC_UART_ERTCO_CLK:
+            // Only UART3 (LPUART0) supports ERTCO clock source.
+            if (uart != MXC_UART3) {
+                return E_BAD_PARAM;
+            }
+
             uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_EXTERNAL_CLOCK;
             uart->ctrl |= MXC_F_UART_CTRL_FDM;
-            clkDiv = ((ERTCO_FREQ * 2) / baud);
-            mod = ((ERTCO_FREQ * 2) % baud);
-
+        
             if (baud > 2400) {
                 uart->osr = 0;
             } else {
                 uart->osr = 1;
             }
-            break;
 
+            clock_freq = ERTCO_FREQ * 2; // x2 to account for FDM.
+            break;
+        
         default:
             return E_BAD_PARAM;
-        }
-        if (!clkDiv || mod > (baud / 2)) {
-            clkDiv++;
-        }
-        uart->clkdiv = clkDiv;
-        frequency = MXC_UART_GetFrequency(uart);
-    } else {
-        if (clock == MXC_UART_ERTCO_CLK) {
-            return E_BAD_PARAM;
-        }
-
-        frequency = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, baud, clock);
     }
 
-    if (frequency > 0) {
+    freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, clock_freq, baud);
+
+    if (freq > 0) {
         // Enable baud clock and wait for it to become ready.
         uart->ctrl |= MXC_F_UART_CTRL_BCLKEN;
         while (((uart->ctrl & MXC_F_UART_CTRL_BCLKRDY) >> MXC_F_UART_CTRL_BCLKRDY_POS) == 0) {}
     }
 
-    return frequency;
+    return freq;
 }
 
 int MXC_UART_GetFrequency(mxc_uart_regs_t *uart)
@@ -251,7 +236,82 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
 
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
-    return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock);
+    int error = E_NO_ERROR;
+
+    switch (MXC_UART_GET_IDX(uart)) {
+        case 0:
+        case 1:
+        case 2:
+            // UART0-2 support PCLK and IBRO
+            switch (clock) {
+            case MXC_UART_APB_CLK:
+                MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
+                break;
+
+            case MXC_UART_IBRO_CLK:
+                error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+                MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
+                break;
+
+            default:
+                return E_BAD_PARAM;
+            }
+            break;
+
+        case 3:
+            // UART3 (LPUART0) supports IBRO and ERTCO
+            switch (clock) {
+            case MXC_UART_IBRO_CLK:
+                error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+                MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
+                break;
+
+            case MXC_UART_ERTCO_CLK:
+                error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+                MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 3);
+                break;
+
+            default:
+                return E_BAD_PARAM;
+            }
+            break;
+
+        default:
+            return E_BAD_PARAM;
+    }
+
+    return error;
+}
+
+mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart)
+{
+    unsigned int clock_option = MXC_UART_RevB_GetClockSource((mxc_uart_revb_regs_t *)uart);
+    switch (MXC_UART_GET_IDX(uart)) {
+    case 0:
+    case 1:
+    case 2:
+        switch (clock_option) {
+        case 0:
+            return MXC_UART_APB_CLK;
+        case 2:
+            return MXC_UART_IBRO_CLK;
+        default:
+            return E_BAD_STATE;
+        }
+        break;
+    case 3:
+        switch (clock_option) {
+        case 0:
+            return MXC_UART_IBRO_CLK;
+        case 1:
+            return MXC_UART_ERTCO_CLK;
+        default:
+            return E_BAD_STATE;
+        }
+        break;
+    default:
+        return E_BAD_PARAM;
+    }
 }
 
 int MXC_UART_GetActive(mxc_uart_regs_t *uart)

--- a/Libraries/PeriphDrivers/Source/UART/uart_me12.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me12.c
@@ -110,25 +110,25 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
         return E_BAD_PARAM;
     }
 
-    switch(clock) {
-        case MXC_UART_APB_CLK:
-            clock_freq = SystemCoreClock / 2;
-            break;
+    switch (clock) {
+    case MXC_UART_APB_CLK:
+        clock_freq = SystemCoreClock / 2;
+        break;
 
-        case MXC_UART_EXT_CLK:
-            clock_freq = HF_EXTCLK_FREQ;
-            break;
+    case MXC_UART_EXT_CLK:
+        clock_freq = HF_EXTCLK_FREQ;
+        break;
 
-        case MXC_UART_IBRO_CLK:
-            clock_freq = IBRO_FREQ;
-            break;
-        
-        case MXC_UART_ERFO_CLK:
-            clock_freq = ERFO_FREQ;
-            break;
-        
-        default:
-            return E_BAD_PARAM;
+    case MXC_UART_IBRO_CLK:
+        clock_freq = IBRO_FREQ;
+        break;
+
+    case MXC_UART_ERFO_CLK:
+        clock_freq = ERFO_FREQ;
+        break;
+
+    default:
+        return E_BAD_PARAM;
     }
 
     freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, clock_freq, baud);
@@ -209,27 +209,27 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 
     // The following interprets table 12-1 from the MAX78002 UG.
     switch (clock) {
-        case MXC_UART_APB_CLK:
-            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
-            break;
-        
-        case MXC_UART_EXT_CLK:
-            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_EXTCLK);
-            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 1);
-            break;
-        
-        case MXC_UART_IBRO_CLK:
-            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
-            break;
+    case MXC_UART_APB_CLK:
+        MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
+        break;
 
-        case MXC_UART_ERFO_CLK:
-            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
-            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 3);
-            break;
+    case MXC_UART_EXT_CLK:
+        error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_EXTCLK);
+        MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 1);
+        break;
 
-        default:
-            return E_BAD_PARAM;
+    case MXC_UART_IBRO_CLK:
+        error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+        MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
+        break;
+
+    case MXC_UART_ERFO_CLK:
+        error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+        MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 3);
+        break;
+
+    default:
+        return E_BAD_PARAM;
     }
 
     return error;

--- a/Libraries/PeriphDrivers/Source/UART/uart_me12.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me12.c
@@ -47,26 +47,8 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     int retval;
 
     retval = MXC_UART_Shutdown(uart);
-
     if (retval) {
         return retval;
-    }
-
-    switch (clock) {
-    case MXC_UART_EXT_CLK:
-        MXC_GPIO_Config(&gpio_cfg_hf_extclk);
-        break;
-
-    case MXC_UART_IBRO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-        break;
-
-    case MXC_UART_ERFO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
-        break;
-
-    default:
-        break;
     }
 
     if (uart == MXC_UART0) {
@@ -85,6 +67,11 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
 #else
     (void)map;
 #endif // MSDK_NO_GPIO_CLK_INIT
+
+    retval = MXC_UART_SetClockSource(uart, clock);
+    if (retval != E_NO_ERROR) {
+        return retval;
+    }
 
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, clock);
 }
@@ -117,12 +104,34 @@ int MXC_UART_ReadyForSleep(mxc_uart_regs_t *uart)
 int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
     int freq;
+    uint32_t clock_freq;
 
     if (MXC_UART_GET_IDX(uart) < 0) {
         return E_BAD_PARAM;
     }
 
-    freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, baud, clock);
+    switch(clock) {
+        case MXC_UART_APB_CLK:
+            clock_freq = SystemCoreClock / 2;
+            break;
+
+        case MXC_UART_EXT_CLK:
+            clock_freq = HF_EXTCLK_FREQ;
+            break;
+
+        case MXC_UART_IBRO_CLK:
+            clock_freq = IBRO_FREQ;
+            break;
+        
+        case MXC_UART_ERFO_CLK:
+            clock_freq = ERFO_FREQ;
+            break;
+        
+        default:
+            return E_BAD_PARAM;
+    }
+
+    freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, clock_freq, baud);
 
     if (freq > 0) {
         // Enable baud clock and wait for it to become ready.
@@ -192,7 +201,55 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
 
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
-    return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock);
+    int error = E_NO_ERROR;
+
+    if (MXC_UART_GET_IDX(uart) < 0 || MXC_UART_GET_IDX(uart) > 1) {
+        return E_BAD_PARAM;
+    }
+
+    // The following interprets table 12-1 from the MAX78002 UG.
+    switch (clock) {
+        case MXC_UART_APB_CLK:
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
+            break;
+        
+        case MXC_UART_EXT_CLK:
+            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_EXTCLK);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 1);
+            break;
+        
+        case MXC_UART_IBRO_CLK:
+            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
+            break;
+
+        case MXC_UART_ERFO_CLK:
+            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 3);
+            break;
+
+        default:
+            return E_BAD_PARAM;
+    }
+
+    return error;
+}
+
+mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart)
+{
+    unsigned int clock_option = MXC_UART_RevB_GetClockSource((mxc_uart_revb_regs_t *)uart);
+    switch (clock_option) {
+    case 0:
+        return MXC_UART_APB_CLK;
+    case 1:
+        return MXC_UART_EXT_CLK;
+    case 2:
+        return MXC_UART_IBRO_CLK;
+    case 3:
+        return MXC_UART_ERFO_CLK;
+    default:
+        return E_BAD_PARAM;
+    }
 }
 
 int MXC_UART_GetActive(mxc_uart_regs_t *uart)

--- a/Libraries/PeriphDrivers/Source/UART/uart_me17.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me17.c
@@ -130,35 +130,35 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
         return E_BAD_PARAM;
     }
 
-    switch(clock) {
-        case MXC_UART_APB_CLK:
-            clock_freq = SystemCoreClock / 2;
-            break;
+    switch (clock) {
+    case MXC_UART_APB_CLK:
+        clock_freq = SystemCoreClock / 2;
+        break;
 
-        case MXC_UART_IBRO_CLK:
-            clock_freq = IBRO_FREQ;
-            break;
-        
-        case MXC_UART_ERTCO_CLK:
-            // Only UART3 (LPUART0) supports ERTCO clock source.
-            if (uart != MXC_UART3) {
-                return E_BAD_PARAM;
-            }
+    case MXC_UART_IBRO_CLK:
+        clock_freq = IBRO_FREQ;
+        break;
 
-            uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_EXTERNAL_CLOCK;
-            uart->ctrl |= MXC_F_UART_CTRL_FDM;
-        
-            if (baud > 2400) {
-                uart->osr = 0;
-            } else {
-                uart->osr = 1;
-            }
-
-            clock_freq = ERTCO_FREQ * 2; // x2 to account for FDM.
-            break;
-        
-        default:
+    case MXC_UART_ERTCO_CLK:
+        // Only UART3 (LPUART0) supports ERTCO clock source.
+        if (uart != MXC_UART3) {
             return E_BAD_PARAM;
+        }
+
+        uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_EXTERNAL_CLOCK;
+        uart->ctrl |= MXC_F_UART_CTRL_FDM;
+
+        if (baud > 2400) {
+            uart->osr = 0;
+        } else {
+            uart->osr = 1;
+        }
+
+        clock_freq = ERTCO_FREQ * 2; // x2 to account for FDM.
+        break;
+
+    default:
+        return E_BAD_PARAM;
     }
 
     freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, clock_freq, baud);
@@ -258,45 +258,45 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
     int error = E_NO_ERROR;
 
     switch (MXC_UART_GET_IDX(uart)) {
-        case 0:
-        case 1:
-        case 2:
-            // UART0-2 support PCLK and IBRO
-            switch (clock) {
-            case MXC_UART_APB_CLK:
-                MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
-                break;
-
-            case MXC_UART_IBRO_CLK:
-                error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-                MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
-                break;
-
-            default:
-                return E_BAD_PARAM;
-            }
+    case 0:
+    case 1:
+    case 2:
+        // UART0-2 support PCLK and IBRO
+        switch (clock) {
+        case MXC_UART_APB_CLK:
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
             break;
 
-        case 3:
-            // UART3 (LPUART0) supports IBRO and ERTCO
-            switch (clock) {
-            case MXC_UART_IBRO_CLK:
-                error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-                MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
-                break;
-
-            case MXC_UART_ERTCO_CLK:
-                error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
-                MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 3);
-                break;
-
-            default:
-                return E_BAD_PARAM;
-            }
+        case MXC_UART_IBRO_CLK:
+            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
             break;
 
         default:
             return E_BAD_PARAM;
+        }
+        break;
+
+    case 3:
+        // UART3 (LPUART0) supports IBRO and ERTCO
+        switch (clock) {
+        case MXC_UART_IBRO_CLK:
+            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
+            break;
+
+        case MXC_UART_ERTCO_CLK:
+            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 3);
+            break;
+
+        default:
+            return E_BAD_PARAM;
+        }
+        break;
+
+    default:
+        return E_BAD_PARAM;
     }
 
     return error;

--- a/Libraries/PeriphDrivers/Source/UART/uart_me17.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me17.c
@@ -140,6 +140,11 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
             break;
         
         case MXC_UART_ERTCO_CLK:
+            // Only UART3 (LPUART0) supports ERTCO clock source.
+            if (uart != MXC_UART3) {
+                return E_BAD_PARAM;
+            }
+
             uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_EXTERNAL_CLOCK;
             uart->ctrl |= MXC_F_UART_CTRL_FDM;
         
@@ -252,7 +257,6 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
     int error = E_NO_ERROR;
 
-    // The following interprets table 12-1 from the MAX78002 UG.
     switch (MXC_UART_GET_IDX(uart)) {
         case 0:
         case 1:

--- a/Libraries/PeriphDrivers/Source/UART/uart_me17.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me17.c
@@ -48,24 +48,8 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     int retval;
 
     retval = MXC_UART_Shutdown(uart);
-
     if (retval) {
         return retval;
-    }
-
-    switch (clock) {
-#if TARGET_NUM != 32680
-    case MXC_UART_ERTCO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
-        break;
-#endif
-
-    case MXC_UART_IBRO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-        break;
-
-    default:
-        break;
     }
 
     switch (MXC_UART_GET_IDX(uart)) {
@@ -94,7 +78,12 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     }
 #endif // MSDK_NO_GPIO_CLK_INIT
 
-    return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, clock);
+    retval = MXC_UART_SetClockSource(uart, clock);
+    if (retval != E_NO_ERROR) {
+        return retval;
+    }
+
+    return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, MXC_UART_GetClockSource(uart));
 }
 
 int MXC_UART_Shutdown(mxc_uart_regs_t *uart)
@@ -135,65 +124,39 @@ int MXC_UART_ReadyForSleep(mxc_uart_regs_t *uart)
 int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
     int freq;
-    unsigned mod = 0;
-    unsigned clkDiv = 0;
+    uint32_t clock_freq = 0;
 
     if (MXC_UART_GET_IDX(uart) < 0) {
         return E_BAD_PARAM;
     }
 
-    // check if the uart is LPUART
-    if (uart == MXC_UART3) {
-        // OSR default value
-        uart->osr = 5;
-
-        switch (clock) {
-        case MXC_UART_IBRO_CLK:
-            uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_PERIPHERAL_CLOCK;
-            clkDiv = ((IBRO_FREQ) / baud);
-            mod = ((IBRO_FREQ) % baud);
+    switch(clock) {
+        case MXC_UART_APB_CLK:
+            clock_freq = SystemCoreClock / 2;
             break;
 
+        case MXC_UART_IBRO_CLK:
+            clock_freq = IBRO_FREQ;
+            break;
+        
         case MXC_UART_ERTCO_CLK:
-            // Only supports up to 9600 baud with ERTCO clock.
-            if (baud > 9600) {
-                return E_NOT_SUPPORTED;
-            }
-
             uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_EXTERNAL_CLOCK;
             uart->ctrl |= MXC_F_UART_CTRL_FDM;
-            if (baud == 9600) {
-                clkDiv = 7;
-                mod = 0;
-            } else {
-                clkDiv = ((ERTCO_FREQ * 2) / baud);
-                mod = ((ERTCO_FREQ * 2) % baud);
-            }
-
+        
             if (baud > 2400) {
                 uart->osr = 0;
             } else {
                 uart->osr = 1;
             }
-            break;
 
+            clock_freq = ERTCO_FREQ * 2; // x2 to account for FDM.
+            break;
+        
         default:
             return E_BAD_PARAM;
-        }
-
-        if (!clkDiv || mod > (baud / 2)) {
-            clkDiv++;
-        }
-        uart->clkdiv = clkDiv;
-
-        freq = MXC_UART_GetFrequency(uart);
-    } else {
-        if (clock == MXC_UART_ERTCO_CLK) {
-            return E_BAD_PARAM;
-        }
-
-        freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, baud, clock);
     }
+
+    freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, clock_freq, baud);
 
     if (freq > 0) {
         // Enable baud clock and wait for it to become ready.
@@ -287,7 +250,83 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
 
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
-    return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock);
+    int error = E_NO_ERROR;
+
+    // The following interprets table 12-1 from the MAX78002 UG.
+    switch (MXC_UART_GET_IDX(uart)) {
+        case 0:
+        case 1:
+        case 2:
+            // UART0-2 support PCLK and IBRO
+            switch (clock) {
+            case MXC_UART_APB_CLK:
+                MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
+                break;
+
+            case MXC_UART_IBRO_CLK:
+                error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+                MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
+                break;
+
+            default:
+                return E_BAD_PARAM;
+            }
+            break;
+
+        case 3:
+            // UART3 (LPUART0) supports IBRO and ERTCO
+            switch (clock) {
+            case MXC_UART_IBRO_CLK:
+                error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+                MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
+                break;
+
+            case MXC_UART_ERTCO_CLK:
+                error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+                MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 3);
+                break;
+
+            default:
+                return E_BAD_PARAM;
+            }
+            break;
+
+        default:
+            return E_BAD_PARAM;
+    }
+
+    return error;
+}
+
+mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart)
+{
+    unsigned int clock_option = MXC_UART_RevB_GetClockSource((mxc_uart_revb_regs_t *)uart);
+    switch (MXC_UART_GET_IDX(uart)) {
+    case 0:
+    case 1:
+    case 2:
+        switch (clock_option) {
+        case 0:
+            return MXC_UART_APB_CLK;
+        case 2:
+            return MXC_UART_IBRO_CLK;
+        default:
+            return E_BAD_STATE;
+        }
+        break;
+    case 3:
+        switch (clock_option) {
+        case 0:
+            return MXC_UART_IBRO_CLK;
+        case 1:
+            return MXC_UART_ERTCO_CLK;
+        default:
+            return E_BAD_STATE;
+        }
+        break;
+    default:
+        return E_BAD_PARAM;
+    }
 }
 
 int MXC_UART_GetActive(mxc_uart_regs_t *uart)

--- a/Libraries/PeriphDrivers/Source/UART/uart_me55.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me55.c
@@ -127,21 +127,21 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
         return E_BAD_PARAM;
     }
 
-    switch(clock) {
-        case MXC_UART_APB_CLK:
-            clock_freq = SystemCoreClock / 2;
-            break;
+    switch (clock) {
+    case MXC_UART_APB_CLK:
+        clock_freq = SystemCoreClock / 2;
+        break;
 
-        case MXC_UART_IBRO_CLK:
-            clock_freq = IBRO_FREQ;
-            break;
-        
-        case MXC_UART_ERFO_CLK:
-            clock_freq = ERFO_FREQ;
-            break;
-        
-        default:
-            return E_BAD_PARAM;
+    case MXC_UART_IBRO_CLK:
+        clock_freq = IBRO_FREQ;
+        break;
+
+    case MXC_UART_ERFO_CLK:
+        clock_freq = ERFO_FREQ;
+        break;
+
+    default:
+        return E_BAD_PARAM;
     }
 
     freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, clock_freq, baud);
@@ -238,22 +238,22 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 
     // The following interprets table 12-1 from the MAX78002 UG.
     switch (clock) {
-        case MXC_UART_APB_CLK:
-            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
-            break;
-        
-        case MXC_UART_IBRO_CLK:
-            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
-            break;
+    case MXC_UART_APB_CLK:
+        MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
+        break;
 
-        case MXC_UART_ERFO_CLK:
-            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
-            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 3);
-            break;
+    case MXC_UART_IBRO_CLK:
+        error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+        MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
+        break;
 
-        default:
-            return E_BAD_PARAM;
+    case MXC_UART_ERFO_CLK:
+        error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+        MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 3);
+        break;
+
+    default:
+        return E_BAD_PARAM;
     }
 
     return error;

--- a/Libraries/PeriphDrivers/Source/UART/uart_me55.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me55.c
@@ -46,22 +46,8 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     int retval;
 
     retval = MXC_UART_Shutdown(uart);
-
     if (retval) {
         return retval;
-    }
-
-    switch (clock) {
-    case MXC_UART_ERTCO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
-        break;
-
-    case MXC_UART_IBRO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-        break;
-
-    default:
-        break;
     }
 
     switch (MXC_UART_GET_IDX(uart)) {
@@ -87,6 +73,11 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
 
     default:
         return E_BAD_PARAM;
+    }
+
+    retval = MXC_UART_SetClockSource(uart, clock);
+    if (retval != E_NO_ERROR) {
+        return retval;
     }
 
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, clock);
@@ -130,12 +121,30 @@ int MXC_UART_ReadyForSleep(mxc_uart_regs_t *uart)
 int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
     int freq;
+    uint32_t clock_freq;
 
     if (MXC_UART_GET_IDX(uart) < 0) {
         return E_BAD_PARAM;
     }
 
-    freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, baud, clock);
+    switch(clock) {
+        case MXC_UART_APB_CLK:
+            clock_freq = SystemCoreClock / 2;
+            break;
+
+        case MXC_UART_IBRO_CLK:
+            clock_freq = IBRO_FREQ;
+            break;
+        
+        case MXC_UART_ERFO_CLK:
+            clock_freq = ERFO_FREQ;
+            break;
+        
+        default:
+            return E_BAD_PARAM;
+    }
+
+    freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, clock_freq, baud);
 
     if (freq > 0) {
         // Enable baud clock and wait for it to become ready.
@@ -221,7 +230,48 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
 
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
-    return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock);
+    int error = E_NO_ERROR;
+
+    if (MXC_UART_GET_IDX(uart) < 0 || MXC_UART_GET_IDX(uart) > 3) {
+        return E_BAD_PARAM;
+    }
+
+    // The following interprets table 12-1 from the MAX78002 UG.
+    switch (clock) {
+        case MXC_UART_APB_CLK:
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
+            break;
+        
+        case MXC_UART_IBRO_CLK:
+            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
+            break;
+
+        case MXC_UART_ERFO_CLK:
+            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 3);
+            break;
+
+        default:
+            return E_BAD_PARAM;
+    }
+
+    return error;
+}
+
+mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart)
+{
+    unsigned int clock_option = MXC_UART_RevB_GetClockSource((mxc_uart_revb_regs_t *)uart);
+    switch (clock_option) {
+    case 0:
+        return MXC_UART_APB_CLK;
+    case 2:
+        return MXC_UART_IBRO_CLK;
+    case 3:
+        return MXC_UART_ERFO_CLK;
+    default:
+        return E_BAD_PARAM;
+    }
 }
 
 int MXC_UART_GetActive(mxc_uart_regs_t *uart)


### PR DESCRIPTION
### Description

This PR is an extended addon to https://github.com/analogdevicesinc/msdk/pull/1108 for the UART RevB drivers. Since the parameters for the `MXC_UART_RevB_SetFrequency` were changed, the parts without these new functions did not properly set the baud rate.

Only tested on ME17 so far.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.