### PR TITLE
fix(PeriphDrivers): Static scoping for UART driver variables

### DIFF
--- a/Libraries/PeriphDrivers/Source/UART/uart_reva.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_reva.c
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by
  * Analog Devices, Inc.),
  * Copyright (C) 2023-2024 Analog Devices, Inc.
  *
@@ -54,7 +54,7 @@ typedef struct {
 } uart_reva_req_state_t;
 
 // clang-format off
-uart_reva_req_state_t states[MXC_UART_INSTANCES] = {
+static uart_reva_req_state_t states[MXC_UART_INSTANCES] = {
     [0 ... MXC_UART_INSTANCES - 1] = {
         .tx_req = NULL,
         .rx_req = NULL,
@@ -1050,14 +1050,14 @@ void MXC_UART_RevA_DMACallback(int ch, int error)
 
     for (int i = 0; i < MXC_UART_INSTANCES; i++) {
         if (states[i].channelTx == ch) {
-            /* Populate txLen.  The number of "remainder" bytes is what's left on the 
+            /* Populate txLen.  The number of "remainder" bytes is what's left on the
             DMA channel's count register. */
             states[i].tx_req->txCnt = states[i].tx_req->txLen - states[i].dma->ch[ch].cnt;
 
             temp_req = states[i].tx_req;
 
             if (states[i].auto_dma_handlers) {
-                /* Release channel _before_ running callback in case 
+                /* Release channel _before_ running callback in case
                 user wants to start another transaction inside it */
                 MXC_DMA_ReleaseChannel(ch);
                 states[i].channelTx = -1;

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by
  * Analog Devices, Inc.),
  * Copyright (C) 2023-2024 Analog Devices, Inc. All Rights Reserved. This software
  * is proprietary to Analog Devices, Inc. and its licensors.
@@ -52,7 +52,7 @@ typedef struct {
 } uart_revb_req_state_t;
 
 // clang-format off
-uart_revb_req_state_t states[MXC_UART_INSTANCES] = {
+static uart_revb_req_state_t states[MXC_UART_INSTANCES] = {
     [0 ... MXC_UART_INSTANCES - 1] = {
         .tx_req = NULL,
         .rx_req = NULL,
@@ -101,9 +101,9 @@ static void emptyRxAsync(mxc_uart_revb_req_t *req)
          * from threshold-1 to threshold. If we happened to receive a byte between emptying the FIFO
          * and setting the threshold, we will miss the threshold interrupt.
          *
-         * If we still have data to read and the threshold value we just set is less than or equal to 
+         * If we still have data to read and the threshold value we just set is less than or equal to
          * the number of bytes currently in the FIFO, then we need to read from the FIFO and reset the
-         * threshold again. 
+         * threshold again.
          */
     } while (numToRead && numToRead <= MXC_UART_GetRXFIFOAvailable((mxc_uart_regs_t *)(req->uart)));
 }
@@ -1123,14 +1123,14 @@ void MXC_UART_RevB_DMACallback(int ch, int error)
 
     for (int i = 0; i < MXC_UART_INSTANCES; i++) {
         if (states[i].channelTx == ch) {
-            /* Populate txLen.  The number of "remainder" bytes is what's left on the 
+            /* Populate txLen.  The number of "remainder" bytes is what's left on the
             DMA channel's count register. */
             states[i].tx_req->txCnt = states[i].tx_req->txLen - states[i].dma->ch[ch].cnt;
 
             temp_req = states[i].tx_req;
 
             if (states[i].auto_dma_handlers) {
-                /* Release channel _before_ running callback in case 
+                /* Release channel _before_ running callback in case
                 user wants to start another transaction inside it */
                 MXC_DMA_ReleaseChannel(ch);
                 states[i].channelTx = -1;

--- a/Libraries/PeriphDrivers/Source/UART/uart_revc.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revc.c
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by
  * Analog Devices, Inc.),
  * Copyright (C) 2023-2024 Analog Devices, Inc.
  *
@@ -45,7 +45,7 @@ typedef struct {
     int channelRx;
 } uart_revc_req_state_t;
 
-uart_revc_req_state_t states[MXC_UART_INSTANCES];
+static uart_revc_req_state_t states[MXC_UART_INSTANCES];
 
 /* **** Function Prototypes **** */
 


### PR DESCRIPTION
The UART drivers' 'states' variable was not statically limited in scope to their respective files. Aside from potentially corrupting data, since the name 'states' is fairly common, could cause conflict with user's legacy code which might have a 'states' global.
