### PR TITLE
feat(Build): Add --print-memory-usage to linker options

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
@@ -125,7 +125,7 @@ UNAME_RESULT := $(shell uname -s 2>&1)
 # variable will still be set to Windows_NT since we configure
 # MSYS2 to inherit from Windows by default.
 # Here we'll attempt to call uname (only present on MSYS2)
-# while routing stderr -> stdout to avoid throwing an error 
+# while routing stderr -> stdout to avoid throwing an error
 # if uname can't be found.
 ifneq ($(findstring CYGWIN, $(UNAME_RESULT)), )
 CYGWIN=True
@@ -406,7 +406,8 @@ LDFLAGS=-mthumb                                                                \
         -mfloat-abi=$(MFLOAT_ABI)                                              \
         -mfpu=$(MFPU)                                                          \
         -Xlinker --gc-sections                                                 \
-	-Xlinker -Map -Xlinker ${BUILD_DIR}/$(PROJECT).map
+        -Xlinker -Map -Xlinker ${BUILD_DIR}/$(PROJECT).map                     \
+        -Xlinker --print-memory-usage
 
 # Add --no-warn-rwx-segments on GCC 12+
 # This is not universally supported or enabled by default, so we need to check whether the linker supports it first

--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
@@ -117,7 +117,7 @@ UNAME_RESULT := $(shell uname -s 2>&1)
 # variable will still be set to Windows_NT since we configure
 # MSYS2 to inherit from Windows by default.
 # Here we'll attempt to call uname (only present on MSYS2)
-# while routing stderr -> stdout to avoid throwing an error 
+# while routing stderr -> stdout to avoid throwing an error
 # if uname can't be found.
 ifneq ($(findstring CYGWIN, $(UNAME_RESULT)), )
 CYGWIN=True
@@ -244,7 +244,7 @@ GCCVERSIONGTEQ4 := 1
 # GCCVERSIONGTEQ4 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \> 4)
 # ifeq "$(GCCVERSIONGTEQ4)" "0"
 # GCCVERSIONGTEQ4 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 4)
-	
+
 # ifeq "$(GCCVERSIONGTEQ4)" "1"
 # GCCVERSIONGTEQ4 := $(shell expr `$(CC) -dumpversion | cut -f2 -d.` \>= 8)
 # endif
@@ -367,7 +367,7 @@ CFLAGS += -Wstrict-prototypes
 # ifeq "$(RISCV_NOT_COMPRESSED)" ""
 # LDFLAGS=-march=rv32imafdc
 # else
-# LDFLAGS=-march=rv32imafd 
+# LDFLAGS=-march=rv32imafd
 # endif
 # ----
 
@@ -376,7 +376,8 @@ LDFLAGS+=-Xlinker --gc-sections       \
       -nostartfiles 	\
 	  -march=$(MARCH) 	\
 	  -mabi=$(MABI)		\
-      -Xlinker -Map -Xlinker ${BUILD_DIR}/$(PROJECT).map
+      -Xlinker -Map -Xlinker ${BUILD_DIR}/$(PROJECT).map \
+      -Xlinker --print-memory-usage
 
 # Add --no-warn-rwx-segments on GCC 12+
 # This is not universally supported or enabled by default, so we need to check whether the linker supports it first


### PR DESCRIPTION
Add the --print-memory-usage option to the linker arguments for a end-of-build breakdown of usage.

```
- LD /c/Workspace/MSDK_Development/brentk-adi-fork/Examples/MAX32650/CLCD_FreeRTOS/build/CLCD_FreeRTOS.elf
Memory region         Used Size  Region Size  %age Used
             ROM:          0 GB        64 KB      0.00%
           FLASH:       60880 B         3 MB      1.94%
            SRAM:      637696 B         1 MB     60.82%
arm-none-eabi-size --format=berkeley /c/Workspace/MSDK_Development/brentk-adi-fork/Examples/MAX32650/CLCD_FreeRTOS/build/CLCD_FreeRTOS.elf
   text    data     bss     dec     hex filename
  58300    2580  634624  695504   a9cd0 C:/Workspace/MSDK_Development/brentk-adi-fork/Examples/MAX32650/CLCD_FreeRTOS/build/CLCD_FreeRTOS.elf
```
