### PR TITLE
fix(PeriphDrivers): Fix LPUART GetClockSource Settings for MAX32655 and MAX78000

### DIFF
--- a/Libraries/PeriphDrivers/Source/UART/uart_ai85.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_ai85.c
@@ -301,9 +301,9 @@ mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart)
         break;
     case 3:
         switch (clock_option) {
-        case 0:
+        case 2:
             return MXC_UART_IBRO_CLK;
-        case 1:
+        case 3:
             return MXC_UART_ERTCO_CLK;
         default:
             return E_BAD_STATE;

--- a/Libraries/PeriphDrivers/Source/UART/uart_me17.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me17.c
@@ -320,9 +320,9 @@ mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart)
         break;
     case 3:
         switch (clock_option) {
-        case 0:
+        case 2:
             return MXC_UART_IBRO_CLK;
-        case 1:
+        case 3:
             return MXC_UART_ERTCO_CLK;
         default:
             return E_BAD_STATE;


### PR DESCRIPTION
### Description

Fixed the incorrect clock source settings for LPUART.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.