### PR TITLE
fix(BLE): Setting default TIFS time

### DIFF
--- a/Libraries/Cordio/controller/sources/ble/bb/bb_ble_int.h
+++ b/Libraries/Cordio/controller/sources/ble/bb/bb_ble_int.h
@@ -148,7 +148,7 @@ static inline void bbBleClrIfs(void)
 /*************************************************************************************************/
 static inline void bbBleSetTifs(void)
 {
-  PalBbBleOpParam_t opParams = { .ifsMode = PAL_BB_IFS_MODE_TOGGLE_TIFS, .ifsTime = 0, .pIfsChan = NULL };
+  PalBbBleOpParam_t opParams = { .ifsMode = PAL_BB_IFS_MODE_TOGGLE_TIFS, .ifsTime = LL_BLE_TIFS_US, .pIfsChan = NULL };
   PalBbBleSetOpParams(&opParams);
 }
 


### PR DESCRIPTION
### Description

Using definition of 150 us for default TIFS time.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.