### PR TITLE
fix(BLE): PHY features and Window Widening constant

### DIFF
--- a/Libraries/Cordio/controller/sources/ble/init/init.c
+++ b/Libraries/Cordio/controller/sources/ble/init/init.c
@@ -152,8 +152,8 @@ void LlInitLlInit(void)
       #if defined(INIT_EXTENDED) 
         LlExtScanMasterInit();
         LlExtInitMasterInit();
-        LlPhyMasterInit();
       #endif
+      LlPhyMasterInit();
       
       #if (BT_VER >= LL_VER_BT_CORE_SPEC_5_2)
         LlCisMasterInit();

--- a/Libraries/Cordio/platform/targets/maxim/build/config_maxim.mk
+++ b/Libraries/Cordio/platform/targets/maxim/build/config_maxim.mk
@@ -47,7 +47,7 @@ CFG_DEV         += DTM_RX_SCHEDULING=1
 # Set to 0 to improve RX performance, set to 16 to comply with the specification
 # and reduce chances of synchronization loss. Accuracy of the 32 kHz crystal is critical
 # to performance when using standby mode.
-CFG_DEV         += LL_WW_RX_DEVIATION_USEC=0
+CFG_DEV         += LL_WW_RX_DEVIATION_USEC=16
 
 # Third party software config
 ifneq ($(RISCV_CORE),)


### PR DESCRIPTION
### Description

Separating PHY features from EXT. Using default 16 us for window widening constant. 

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.