### PR TITLE
fix(BLE): Enable IRQ in PalUartInit

### DIFF
--- a/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_uart.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_uart.c
@@ -295,6 +295,9 @@ void PalUartInit(PalUartId_t id, const PalUartConfig_t *pCfg)
   palUartCb[uartNum].rdCback = pCfg->rdCback;
   palUartCb[uartNum].wrCback = pCfg->wrCback;
 
+
+
+
   /* Initialize the UART */
   if(uartNum == 3) {
     /* Use the IBRO clock for UART3 */
@@ -313,6 +316,10 @@ void PalUartInit(PalUartId_t id, const PalUartConfig_t *pCfg)
   if(pCfg->hwFlow) {
     MXC_UART_SetFlowCtrl(MXC_UART_GET_UART(uartNum), MXC_UART_FLOW_EN, 1);
   }
+  
+  const IRQn_Type uartIrqn = MXC_UART_GET_IRQ(uartNum);
+  NVIC_ClearPendingIRQ(uartIrqn);
+  NVIC_EnableIRQ(uartIrqn); 
 
   palUartCb[uartNum].state = PAL_UART_STATE_READY;
 }

--- a/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_uart.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_uart.c
@@ -295,9 +295,6 @@ void PalUartInit(PalUartId_t id, const PalUartConfig_t *pCfg)
   palUartCb[uartNum].rdCback = pCfg->rdCback;
   palUartCb[uartNum].wrCback = pCfg->wrCback;
 
-
-
-
   /* Initialize the UART */
   if(uartNum == 3) {
     /* Use the IBRO clock for UART3 */

--- a/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_uart.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_uart.c
@@ -319,7 +319,11 @@ void PalUartInit(PalUartId_t id, const PalUartConfig_t *pCfg)
   if(pCfg->hwFlow) {
     MXC_UART_SetFlowCtrl(MXC_UART_GET_UART(uartNum), MXC_UART_FLOW_EN, 1);
   }
-
+  
+  const IRQn_Type uartIrqn = MXC_UART_GET_IRQ(uartNum);
+  NVIC_ClearPendingIRQ(uartIrqn);
+  NVIC_EnableIRQ(uartIrqn); 
+  
   palUartCb[uartNum].state = PAL_UART_STATE_READY;
 }
 


### PR DESCRIPTION
## Pull Request Template

### Description
PalUartInit operates in an async fashion and relies on interrupts, but did not enable them as needed. This PR handles that.



