### PR TITLE
fix(PeriphDrivers): Leaving UART HE interrupt disabled during initial fill.

### DIFF
--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -673,15 +673,18 @@ int MXC_UART_RevB_TransactionAsync(mxc_uart_revb_req_t *req)
         // Save TX Request
         AsyncTxRequests[MXC_UART_GET_IDX((mxc_uart_regs_t *)(req->uart))] = (void *)req;
 
-        MXC_UART_EnableInt((mxc_uart_regs_t *)(req->uart), MXC_F_UART_REVB_INT_EN_TX_HE);
+        /* Leave the half empty interrupt flag cleared while we're writing */
         numToWrite = MXC_UART_GetTXFIFOAvailable((mxc_uart_regs_t *)(req->uart));
         numToWrite = numToWrite > (req->txLen - req->txCnt) ? req->txLen - req->txCnt : numToWrite;
         req->txCnt += MXC_UART_WriteTXFIFO((mxc_uart_regs_t *)(req->uart), &req->txData[req->txCnt],
                                            numToWrite);
 
-        /* If we're finished writing to the TX FIFO, pend the interrupt */
         if (req->txCnt == req->txLen) {
+            /* If we're finished writing to the TX FIFO, pend the interrupt */
             NVIC_SetPendingIRQ(MXC_UART_GET_IRQ(uart_num));
+        } else {
+            /* Else enable the half empty interrupt */
+            MXC_UART_EnableInt((mxc_uart_regs_t *)(req->uart), MXC_F_UART_REVB_INT_EN_TX_HE);
         }
     }
 

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -673,7 +673,7 @@ int MXC_UART_RevB_TransactionAsync(mxc_uart_revb_req_t *req)
         // Save TX Request
         AsyncTxRequests[MXC_UART_GET_IDX((mxc_uart_regs_t *)(req->uart))] = (void *)req;
 
-        /* Leave the half empty interrupt flag cleared while we're writing */
+        /* Leave the half empty interrupt disabled while we're writing */
         numToWrite = MXC_UART_GetTXFIFOAvailable((mxc_uart_regs_t *)(req->uart));
         numToWrite = numToWrite > (req->txLen - req->txCnt) ? req->txLen - req->txCnt : numToWrite;
         req->txCnt += MXC_UART_WriteTXFIFO((mxc_uart_regs_t *)(req->uart), &req->txData[req->txCnt],


### PR DESCRIPTION
### Description

This prevent un-intended interrupts, causing txCnt to exceend txLen. If the HE interrupt is enabled while we're filling the FIFO, then we can get the interrupt while we're filling. This interrupts the filling process, leading to txCnt exceeding txLen. 

This is only an issue in the initial fill, since we're probably not in the interrupt context. When we're in the interrupt context, we may get another HE interrupt flag from the UART, but it won't interrupt the CPU, and we clear the flag after completing the fill.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.

