### PR TITLE
fix(PeriphDrivers): Add SPI hardware SS control function for AI87

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX78002/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/spi.h
@@ -707,6 +707,18 @@ unsigned int MXC_SPI_ReadRXFIFO(mxc_spi_regs_t *spi, unsigned char *bytes, unsig
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
  */
 int MXC_SPI_SetDefaultTXData(mxc_spi_regs_t *spi, unsigned int defaultTXData);
+
+/**
+ * @brief   Enable/Disable HW CS control feature.
+ *
+ * Depending on the application, the user might need to manually drive the slave select pin.
+ * The SPI driver automatically drives the SS pin and this function enables/disables this
+ * feature.
+ *
+ * @param   spi             Pointer to SPI registers (selects the SPI block used.)
+ * @param   state           Non-zero values: enable HW SS mode. Zero: disable HW SS mode.
+ */
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
 //////<<< Previous Implementation
 
 /* ** DMA Functions ** */

--- a/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
@@ -477,6 +477,11 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi)
     MXC_SPI_RevA1_AsyncHandler((mxc_spi_reva_regs_t *)spi);
 }
 
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state)
+{
+    MXC_SPI_RevA1_HWSSControl((mxc_spi_reva_regs_t *)spi, state);
+}
+
 /* ** SPI v2 functions to prevent build errors ** */
 
 int MXC_SPI_Config(mxc_spi_cfg_t *cfg)

--- a/Libraries/PeriphDrivers/Source/SPI/spi_ai87_v2.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_ai87_v2.c
@@ -812,3 +812,8 @@ int MXC_SPI_SetDefaultTXData(mxc_spi_regs_t *spi, unsigned int defaultTXData)
 {
     return MXC_SPI_RevA2_SetDummyTX((mxc_spi_reva_regs_t *)spi, defaultTXData);
 }
+
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state)
+{
+    MXC_ASSERT(0);
+}


### PR DESCRIPTION
## Pull Request Template

### Description

AI87 SPI drivers don't have 'MXC_SPI_HWSSControl' function. I added this function to both SPI driver. For v1, I called related revA1 function and for v2, do nothing.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.