### PR TITLE
fix(PeriphDrivers): Flip strong vs weak pull-up bit values

### DIFF
--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_ai85.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_ai85.c
@@ -175,28 +175,30 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
             gpio->padctrl1 &= ~cfg->mask;
             break;
 
+        // Note: for "ps" field set 1 for weak and 0 for strong.
+        // As of 8-28-2024 most UG tables have this flipped the wrong way
         case MXC_GPIO_PAD_WEAK_PULL_UP:
             gpio->padctrl0 |= cfg->mask;
             gpio->padctrl1 &= ~cfg->mask;
-            gpio->ps &= ~cfg->mask;
+            gpio->ps |= cfg->mask;
             break;
 
         case MXC_GPIO_PAD_PULL_UP:
             gpio->padctrl0 |= cfg->mask;
             gpio->padctrl1 &= ~cfg->mask;
-            gpio->ps |= cfg->mask;
+            gpio->ps &= ~cfg->mask;
             break;
 
         case MXC_GPIO_PAD_WEAK_PULL_DOWN:
             gpio->padctrl0 &= ~cfg->mask;
             gpio->padctrl1 |= cfg->mask;
-            gpio->ps &= ~cfg->mask;
+            gpio->ps |= cfg->mask;
             break;
 
         case MXC_GPIO_PAD_PULL_DOWN:
             gpio->padctrl0 &= ~cfg->mask;
             gpio->padctrl1 |= cfg->mask;
-            gpio->ps |= cfg->mask;
+            gpio->ps &= ~cfg->mask;
             break;
 
         default:

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_ai87.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_ai87.c
@@ -175,28 +175,30 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
             gpio->padctrl1 &= ~cfg->mask;
             break;
 
+        // Note: for "ps" field set 1 for weak and 0 for strong.
+        // As of 8-28-2024 most UG tables have this flipped the wrong way
         case MXC_GPIO_PAD_WEAK_PULL_UP:
             gpio->padctrl0 |= cfg->mask;
             gpio->padctrl1 &= ~cfg->mask;
-            gpio->ps &= ~cfg->mask;
+            gpio->ps |= cfg->mask;
             break;
 
         case MXC_GPIO_PAD_PULL_UP:
             gpio->padctrl0 |= cfg->mask;
             gpio->padctrl1 &= ~cfg->mask;
-            gpio->ps |= cfg->mask;
+            gpio->ps &= ~cfg->mask;
             break;
 
         case MXC_GPIO_PAD_WEAK_PULL_DOWN:
             gpio->padctrl0 &= ~cfg->mask;
             gpio->padctrl1 |= cfg->mask;
-            gpio->ps &= ~cfg->mask;
+            gpio->ps |= cfg->mask;
             break;
 
         case MXC_GPIO_PAD_PULL_DOWN:
             gpio->padctrl0 &= ~cfg->mask;
             gpio->padctrl1 |= cfg->mask;
-            gpio->ps |= cfg->mask;
+            gpio->ps &= ~cfg->mask;
             break;
 
         default:

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_es17.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_es17.c
@@ -99,28 +99,30 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
         gpio->pdpu_sel1 &= ~cfg->mask;
         break;
 
+    // Note: for "ps" field set 1 for weak and 0 for strong.
+    // As of 8-28-2024 most UG tables have this flipped the wrong way
     case MXC_GPIO_PAD_WEAK_PULL_UP:
         gpio->pdpu_sel0 |= cfg->mask;
         gpio->pdpu_sel1 &= ~cfg->mask;
-        gpio->pssel &= ~cfg->mask;
+        gpio->pssel |= cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_UP:
         gpio->pdpu_sel0 |= cfg->mask;
         gpio->pdpu_sel1 &= ~cfg->mask;
-        gpio->pssel |= cfg->mask;
+        gpio->pssel &= ~cfg->mask;
         break;
 
     case MXC_GPIO_PAD_WEAK_PULL_DOWN:
         gpio->pdpu_sel0 &= ~cfg->mask;
         gpio->pdpu_sel1 |= cfg->mask;
-        gpio->pssel &= ~cfg->mask;
+        gpio->pssel |= cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_DOWN:
         gpio->pdpu_sel0 &= ~cfg->mask;
         gpio->pdpu_sel1 |= cfg->mask;
-        gpio->pssel |= cfg->mask;
+        gpio->pssel &= ~cfg->mask;
         break;
 
     default:

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me13.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me13.c
@@ -123,28 +123,30 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
         gpio->pad_cfg2 &= ~cfg->mask;
         break;
 
+    // Note: for "ps" field set 1 for weak and 0 for strong.
+    // As of 8-28-2024 most UG tables have this flipped the wrong way
     case MXC_GPIO_PAD_WEAK_PULL_UP:
         gpio->pad_cfg1 |= cfg->mask;
         gpio->pad_cfg2 &= ~cfg->mask;
-        gpio->ps &= ~cfg->mask;
+        gpio->ps |= cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_UP:
         gpio->pad_cfg1 |= cfg->mask;
         gpio->pad_cfg2 &= ~cfg->mask;
-        gpio->ps |= cfg->mask;
+        gpio->ps &= ~cfg->mask;
         break;
 
     case MXC_GPIO_PAD_WEAK_PULL_DOWN:
         gpio->pad_cfg1 &= ~cfg->mask;
         gpio->pad_cfg2 |= cfg->mask;
-        gpio->ps &= ~cfg->mask;
+        gpio->ps |= cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_DOWN:
         gpio->pad_cfg1 &= ~cfg->mask;
         gpio->pad_cfg2 |= cfg->mask;
-        gpio->ps |= cfg->mask;
+        gpio->ps &= ~cfg->mask;
         break;
 
     default:

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me14.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me14.c
@@ -103,28 +103,30 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
         gpio->pad_cfg2 &= ~cfg->mask;
         break;
 
+    // Note: for "ps" field set 1 for weak and 0 for strong.
+    // As of 8-28-2024 most UG tables have this flipped the wrong way
     case MXC_GPIO_PAD_WEAK_PULL_UP:
         gpio->pad_cfg1 |= cfg->mask;
         gpio->pad_cfg2 &= ~cfg->mask;
-        gpio->ps &= ~cfg->mask;
+        gpio->ps |= cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_UP:
         gpio->pad_cfg1 |= cfg->mask;
         gpio->pad_cfg2 &= ~cfg->mask;
-        gpio->ps |= cfg->mask;
+        gpio->ps &= ~cfg->mask;
         break;
 
     case MXC_GPIO_PAD_WEAK_PULL_DOWN:
         gpio->pad_cfg1 &= ~cfg->mask;
         gpio->pad_cfg2 |= cfg->mask;
-        gpio->ps &= ~cfg->mask;
+        gpio->ps |= cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_DOWN:
         gpio->pad_cfg1 &= ~cfg->mask;
         gpio->pad_cfg2 |= cfg->mask;
-        gpio->ps |= cfg->mask;
+        gpio->ps &= ~cfg->mask;
         break;
 
     default:

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me17.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me17.c
@@ -175,28 +175,30 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
             gpio->padctrl1 &= ~cfg->mask;
             break;
 
+        // Note: for "ps" field set 1 for weak and 0 for strong.
+        // As of 8-28-2024 most UG tables have this flipped the wrong way
         case MXC_GPIO_PAD_WEAK_PULL_UP:
             gpio->padctrl0 |= cfg->mask;
             gpio->padctrl1 &= ~cfg->mask;
-            gpio->ps &= ~cfg->mask;
+            gpio->ps |= cfg->mask;
             break;
 
         case MXC_GPIO_PAD_PULL_UP:
             gpio->padctrl0 |= cfg->mask;
             gpio->padctrl1 &= ~cfg->mask;
-            gpio->ps |= cfg->mask;
+            gpio->ps &= ~cfg->mask;
             break;
 
         case MXC_GPIO_PAD_WEAK_PULL_DOWN:
             gpio->padctrl0 &= ~cfg->mask;
             gpio->padctrl1 |= cfg->mask;
-            gpio->ps &= ~cfg->mask;
+            gpio->ps |= cfg->mask;
             break;
 
         case MXC_GPIO_PAD_PULL_DOWN:
             gpio->padctrl0 &= ~cfg->mask;
             gpio->padctrl1 |= cfg->mask;
-            gpio->ps |= cfg->mask;
+            gpio->ps &= ~cfg->mask;
             break;
 
         default:

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
@@ -194,28 +194,30 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
             gpio->padctrl1 &= ~cfg->mask;
             break;
 
+        // Note: for "ps" field set 1 for weak and 0 for strong.
+        // As of 8-28-2024 most UG tables have this flipped the wrong way
         case MXC_GPIO_PAD_WEAK_PULL_UP:
             gpio->padctrl0 |= cfg->mask;
             gpio->padctrl1 &= ~cfg->mask;
-            gpio->ps &= ~cfg->mask;
+            gpio->ps |= cfg->mask;
             break;
 
         case MXC_GPIO_PAD_PULL_UP:
             gpio->padctrl0 |= cfg->mask;
             gpio->padctrl1 &= ~cfg->mask;
-            gpio->ps |= cfg->mask;
+            gpio->ps &= ~cfg->mask;
             break;
 
         case MXC_GPIO_PAD_WEAK_PULL_DOWN:
             gpio->padctrl0 &= ~cfg->mask;
             gpio->padctrl1 |= cfg->mask;
-            gpio->ps &= ~cfg->mask;
+            gpio->ps |= cfg->mask;
             break;
 
         case MXC_GPIO_PAD_PULL_DOWN:
             gpio->padctrl0 &= ~cfg->mask;
             gpio->padctrl1 |= cfg->mask;
-            gpio->ps |= cfg->mask;
+            gpio->ps &= ~cfg->mask;
             break;
 
         default:

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me20.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me20.c
@@ -172,28 +172,30 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
         gpio->padctrl1 &= ~cfg->mask;
         break;
 
+    // Note: for "ps" field set 1 for weak and 0 for strong.
+    // As of 8-28-2024 most UG tables have this flipped the wrong way
     case MXC_GPIO_PAD_WEAK_PULL_UP:
         gpio->padctrl0 |= cfg->mask;
         gpio->padctrl1 &= ~cfg->mask;
-        gpio->ps &= ~cfg->mask;
+        gpio->ps |= cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_UP:
         gpio->padctrl0 |= cfg->mask;
         gpio->padctrl1 &= ~cfg->mask;
-        gpio->ps |= cfg->mask;
+        gpio->ps &= ~cfg->mask;
         break;
 
     case MXC_GPIO_PAD_WEAK_PULL_DOWN:
         gpio->padctrl0 &= ~cfg->mask;
         gpio->padctrl1 |= cfg->mask;
-        gpio->ps &= ~cfg->mask;
+        gpio->ps |= cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_DOWN:
         gpio->padctrl0 &= ~cfg->mask;
         gpio->padctrl1 |= cfg->mask;
-        gpio->ps |= cfg->mask;
+        gpio->ps &= ~cfg->mask;
         break;
 
     default:

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me30.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me30.c
@@ -107,28 +107,30 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
         gpio->padctrl1 &= ~cfg->mask;
         break;
 
+    // Note: for "ps" field set 1 for weak and 0 for strong.
+    // As of 8-28-2024 most UG tables have this flipped the wrong way
     case MXC_GPIO_PAD_WEAK_PULL_UP:
         gpio->padctrl0 |= cfg->mask;
         gpio->padctrl1 &= ~cfg->mask;
-        // gpio->ps &= ~cfg->mask;
+        // gpio->ps |= cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_UP:
         gpio->padctrl0 |= cfg->mask;
         gpio->padctrl1 &= ~cfg->mask;
-        // gpio->ps |= cfg->mask;
+        // gpio->ps &= ~cfg->mask;
         break;
 
     case MXC_GPIO_PAD_WEAK_PULL_DOWN:
         gpio->padctrl0 &= ~cfg->mask;
         gpio->padctrl1 |= cfg->mask;
-        // gpio->ps &= ~cfg->mask;
+        // gpio->ps |= cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_DOWN:
         gpio->padctrl0 &= ~cfg->mask;
         gpio->padctrl1 |= cfg->mask;
-        // gpio->ps |= cfg->mask;
+        // gpio->ps &= ~cfg->mask;
         break;
 
     default:

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me55.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me55.c
@@ -101,28 +101,30 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
         gpio->padctrl1 &= ~cfg->mask;
         break;
 
+    // Note: for "ps" field set 1 for weak and 0 for strong.
+    // As of 8-28-2024 most UG tables have this flipped the wrong way
     case MXC_GPIO_PAD_WEAK_PULL_UP:
         gpio->padctrl0 |= cfg->mask;
         gpio->padctrl1 &= ~cfg->mask;
-        gpio->pssel &= ~cfg->mask;
+        gpio->pssel |= cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_UP:
         gpio->padctrl0 |= cfg->mask;
         gpio->padctrl1 &= ~cfg->mask;
-        gpio->pssel |= cfg->mask;
+        gpio->pssel &= ~cfg->mask;
         break;
 
     case MXC_GPIO_PAD_WEAK_PULL_DOWN:
         gpio->padctrl0 &= ~cfg->mask;
         gpio->padctrl1 |= cfg->mask;
-        gpio->pssel &= ~cfg->mask;
+        gpio->pssel |= cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_DOWN:
         gpio->padctrl0 &= ~cfg->mask;
         gpio->padctrl1 |= cfg->mask;
-        gpio->pssel |= cfg->mask;
+        gpio->pssel &= ~cfg->mask;
         break;
 
     default:

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_revb.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_revb.c
@@ -78,7 +78,7 @@ int MXC_GPIO_RevB_Config(const mxc_gpio_cfg_t *cfg, uint8_t psMask)
 
     // Configure the pad
     // Note: for "ps" field set 1 for weak and 0 for strong.
-        // As of 8-28-2024 most UG tables have this flipped the wrong way
+    // As of 8-28-2024 most UG tables have this flipped the wrong way
     switch (cfg->pad) {
     case MXC_GPIO_PAD_NONE:
         gpio->padctrl0 &= ~cfg->mask;

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_revb.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_revb.c
@@ -27,6 +27,8 @@
 #include "gpio_common.h"
 
 /* **** Functions **** */
+// NOTE(JC): This function doesn't actually seem to be used anywhere.  The MEXX parts re-implement this...
+// TODO(JC): Consolidate to actually use this (would help with code repetition) but psMask seems dubious
 int MXC_GPIO_RevB_Config(const mxc_gpio_cfg_t *cfg, uint8_t psMask)
 {
     mxc_gpio_regs_t *gpio = cfg->port;
@@ -75,29 +77,25 @@ int MXC_GPIO_RevB_Config(const mxc_gpio_cfg_t *cfg, uint8_t psMask)
     }
 
     // Configure the pad
+    // Note: for "ps" field set 1 for weak and 0 for strong.
+        // As of 8-28-2024 most UG tables have this flipped the wrong way
     switch (cfg->pad) {
     case MXC_GPIO_PAD_NONE:
         gpio->padctrl0 &= ~cfg->mask;
         gpio->padctrl1 &= ~cfg->mask;
-        if (psMask == MXC_GPIO_PS_PULL_SELECT) {
-            gpio->ps &= ~cfg->mask;
-        }
+        gpio->ps &= ~cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_UP:
         gpio->padctrl0 |= cfg->mask;
         gpio->padctrl1 &= ~cfg->mask;
-        if (psMask == MXC_GPIO_PS_PULL_SELECT) {
-            gpio->ps |= cfg->mask;
-        }
+        gpio->ps &= ~cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_DOWN:
         gpio->padctrl0 &= ~cfg->mask;
         gpio->padctrl1 |= cfg->mask;
-        if (psMask == MXC_GPIO_PS_PULL_SELECT) {
-            gpio->ps &= ~cfg->mask;
-        }
+        gpio->ps |= cfg->mask;
         break;
 
     default:

--- a/Libraries/PeriphDrivers/Source/SYS/pins_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_me18.c
@@ -56,36 +56,36 @@ const mxc_gpio_cfg_t gpio_cfg_i2c2c = { MXC_GPIO0, (MXC_GPIO_PIN_13 | MXC_GPIO_P
                                        MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
 const mxc_gpio_cfg_t gpio_cfg_uart0 = { MXC_GPIO2, (MXC_GPIO_PIN_11 | MXC_GPIO_PIN_12), MXC_GPIO_FUNC_ALT1,
-                                        MXC_GPIO_PAD_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+                                        MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart0_flow = { MXC_GPIO2, (MXC_GPIO_PIN_9 | MXC_GPIO_PIN_10), MXC_GPIO_FUNC_ALT1,
-                                             MXC_GPIO_PAD_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+                                             MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart0_flow_disable = { MXC_GPIO2, (MXC_GPIO_PIN_9 | MXC_GPIO_PIN_10), MXC_GPIO_FUNC_IN,
-                                                     MXC_GPIO_PAD_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+                                                     MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart1 = { MXC_GPIO2, (MXC_GPIO_PIN_14 | MXC_GPIO_PIN_16), MXC_GPIO_FUNC_ALT1,
-                                        MXC_GPIO_PAD_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+                                        MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart1_flow = { MXC_GPIO2, (MXC_GPIO_PIN_13 | MXC_GPIO_PIN_15),
-                                             MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_PULL_UP,
+                                             MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_WEAK_PULL_UP,
                                              MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart1_flow_disable = { MXC_GPIO2, (MXC_GPIO_PIN_13 | MXC_GPIO_PIN_15),
-                                                     MXC_GPIO_FUNC_IN, MXC_GPIO_PAD_PULL_UP,
+                                                     MXC_GPIO_FUNC_IN, MXC_GPIO_PAD_WEAK_PULL_UP,
                                                      MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart2 = { MXC_GPIO1, (MXC_GPIO_PIN_9 | MXC_GPIO_PIN_10),
-                                        MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_PULL_UP,
+                                        MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_WEAK_PULL_UP,
                                         MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart2_flow = { MXC_GPIO1, (MXC_GPIO_PIN_7 | MXC_GPIO_PIN_8),
-                                             MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_PULL_UP,
+                                             MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_WEAK_PULL_UP,
                                              MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart2_flow_disable = { MXC_GPIO1, (MXC_GPIO_PIN_7 | MXC_GPIO_PIN_8),
-                                                     MXC_GPIO_FUNC_IN, MXC_GPIO_PAD_PULL_UP,
+                                                     MXC_GPIO_FUNC_IN, MXC_GPIO_PAD_WEAK_PULL_UP,
                                                      MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart3 = { MXC_GPIO3, (MXC_GPIO_PIN_0 | MXC_GPIO_PIN_1),
-                                        MXC_GPIO_FUNC_ALT2, MXC_GPIO_PAD_PULL_UP,
+                                        MXC_GPIO_FUNC_ALT2, MXC_GPIO_PAD_WEAK_PULL_UP,
                                         MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart3_flow = { MXC_GPIO3, (MXC_GPIO_PIN_2 | MXC_GPIO_PIN_3),
-                                             MXC_GPIO_FUNC_ALT2, MXC_GPIO_PAD_PULL_UP,
+                                             MXC_GPIO_FUNC_ALT2, MXC_GPIO_PAD_WEAK_PULL_UP,
                                              MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart3_flow_disable = { MXC_GPIO3, (MXC_GPIO_PIN_2 | MXC_GPIO_PIN_3),
-                                                     MXC_GPIO_FUNC_IN, MXC_GPIO_PAD_PULL_UP,
+                                                     MXC_GPIO_FUNC_IN, MXC_GPIO_PAD_WEAK_PULL_UP,
                                                      MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
 const mxc_gpio_cfg_t antenna_ctrl0 = { MXC_GPIO2, (MXC_GPIO_PIN_17), MXC_GPIO_FUNC_ALT2,


### PR DESCRIPTION
### Description

Apparently most UGs have this flipped.  _Strong_ should set the `ps` field to 0, while _weak_ should set it to `1`.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
