### PR TITLE
fix(PeriphDrivers): Fix UART Functional Regression for MAX32670, MAX32672, MAX32675, MAX32657

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.h
@@ -438,32 +438,24 @@ typedef enum {
 
 #define MXC_BASE_UART0 ((uint32_t)0x40042000UL)
 #define MXC_UART0 ((mxc_uart_regs_t *)MXC_BASE_UART0)
-#define MXC_BASE_UART1 ((uint32_t)0x40043000UL)
-#define MXC_UART1 ((mxc_uart_regs_t *)MXC_BASE_UART1)
 #define MXC_BASE_UART2 ((uint32_t)0x40044000UL)
 #define MXC_UART2 ((mxc_uart_regs_t *)MXC_BASE_UART2)
-#define MXC_BASE_UART3 ((uint32_t)0x40145000UL)
-#define MXC_UART3 ((mxc_uart_regs_t *)MXC_BASE_UART3)
 
 #define MXC_UART_GET_IRQ(i)             \
     (IRQn_Type)((i) == 0 ? UART0_IRQn : \
-                (i) == 1 ? UART1_IRQn : \
                 (i) == 2 ? UART2_IRQn : \
-                (i) == 3 ? UART3_IRQn : \
                            0)
 
 #define MXC_UART_GET_BASE(i)     \
     ((i) == 0 ? MXC_BASE_UART0 : \
-     (i) == 1 ? MXC_BASE_UART1 : \
      (i) == 2 ? MXC_BASE_UART2 : \
-     (i) == 3 ? MXC_BASE_UART3 : \
                 0)
 
 #define MXC_UART_GET_UART(i) \
-    ((i) == 0 ? MXC_UART0 : (i) == 1 ? MXC_UART1 : (i) == 2 ? MXC_UART2 : (i) == 3 ? MXC_UART3 : 0)
+    ((i) == 0 ? MXC_UART0 : (i) == 2 ? MXC_UART2 : 0)
 
 #define MXC_UART_GET_IDX(p) \
-    ((p) == MXC_UART0 ? 0 : (p) == MXC_UART1 ? 1 : (p) == MXC_UART2 ? 2 : (p) == MXC_UART3 ? 3 : -1)
+    ((p) == MXC_UART0 ? 0 : (p) == MXC_UART2 ? 2 : -1)
 
 /******************************************************************************/
 /*                                                                        SPI */

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.h
@@ -441,21 +441,13 @@ typedef enum {
 #define MXC_BASE_UART2 ((uint32_t)0x40044000UL)
 #define MXC_UART2 ((mxc_uart_regs_t *)MXC_BASE_UART2)
 
-#define MXC_UART_GET_IRQ(i)             \
-    (IRQn_Type)((i) == 0 ? UART0_IRQn : \
-                (i) == 2 ? UART2_IRQn : \
-                           0)
+#define MXC_UART_GET_IRQ(i) (IRQn_Type)((i) == 0 ? UART0_IRQn : (i) == 2 ? UART2_IRQn : 0)
 
-#define MXC_UART_GET_BASE(i)     \
-    ((i) == 0 ? MXC_BASE_UART0 : \
-     (i) == 2 ? MXC_BASE_UART2 : \
-                0)
+#define MXC_UART_GET_BASE(i) ((i) == 0 ? MXC_BASE_UART0 : (i) == 2 ? MXC_BASE_UART2 : 0)
 
-#define MXC_UART_GET_UART(i) \
-    ((i) == 0 ? MXC_UART0 : (i) == 2 ? MXC_UART2 : 0)
+#define MXC_UART_GET_UART(i) ((i) == 0 ? MXC_UART0 : (i) == 2 ? MXC_UART2 : 0)
 
-#define MXC_UART_GET_IDX(p) \
-    ((p) == MXC_UART0 ? 0 : (p) == MXC_UART2 ? 2 : -1)
+#define MXC_UART_GET_IDX(p) ((p) == MXC_UART0 ? 0 : (p) == MXC_UART2 ? 2 : -1)
 
 /******************************************************************************/
 /*                                                                        SPI */

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.h
@@ -438,16 +438,32 @@ typedef enum {
 
 #define MXC_BASE_UART0 ((uint32_t)0x40042000UL)
 #define MXC_UART0 ((mxc_uart_regs_t *)MXC_BASE_UART0)
+#define MXC_BASE_UART1 ((uint32_t)0x40043000UL)
+#define MXC_UART1 ((mxc_uart_regs_t *)MXC_BASE_UART1)
 #define MXC_BASE_UART2 ((uint32_t)0x40044000UL)
 #define MXC_UART2 ((mxc_uart_regs_t *)MXC_BASE_UART2)
+#define MXC_BASE_UART3 ((uint32_t)0x40145000UL)
+#define MXC_UART3 ((mxc_uart_regs_t *)MXC_BASE_UART3)
 
-#define MXC_UART_GET_IRQ(i) (IRQn_Type)((i) == 0 ? UART0_IRQn : (i) == 2 ? UART2_IRQn : 0)
+#define MXC_UART_GET_IRQ(i)             \
+    (IRQn_Type)((i) == 0 ? UART0_IRQn : \
+                (i) == 1 ? UART1_IRQn : \
+                (i) == 2 ? UART2_IRQn : \
+                (i) == 3 ? UART3_IRQn : \
+                           0)
 
-#define MXC_UART_GET_BASE(i) ((i) == 0 ? MXC_BASE_UART0 : (i) == 2 ? MXC_BASE_UART2 : 0)
+#define MXC_UART_GET_BASE(i)     \
+    ((i) == 0 ? MXC_BASE_UART0 : \
+     (i) == 1 ? MXC_BASE_UART1 : \
+     (i) == 2 ? MXC_BASE_UART2 : \
+     (i) == 3 ? MXC_BASE_UART3 : \
+                0)
 
-#define MXC_UART_GET_UART(i) ((i) == 0 ? MXC_UART0 : (i) == 2 ? MXC_UART2 : 0)
+#define MXC_UART_GET_UART(i) \
+    ((i) == 0 ? MXC_UART0 : (i) == 1 ? MXC_UART1 : (i) == 2 ? MXC_UART2 : (i) == 3 ? MXC_UART3 : 0)
 
-#define MXC_UART_GET_IDX(p) ((p) == MXC_UART0 ? 0 : (p) == MXC_UART2 ? 2 : -1)
+#define MXC_UART_GET_IDX(p) \
+    ((p) == MXC_UART0 ? 0 : (p) == MXC_UART1 ? 1 : (p) == MXC_UART2 ? 2 : (p) == MXC_UART3 ? 3 : -1)
 
 /******************************************************************************/
 /*                                                                        SPI */

--- a/Libraries/PeriphDrivers/Include/MAX32670/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/uart.h
@@ -86,6 +86,7 @@ typedef enum {
     /*32K (ERTCO) and INRO clocks can only be used for UART3*/
     MXC_UART_ERTCO_CLK = 4,
     MXC_UART_INRO_CLK = 5,
+    MXC_UART_AOD_CLK = 6
 } mxc_uart_clock_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32672/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/uart.h
@@ -86,6 +86,7 @@ typedef enum {
     /*32K (ERTCO) and 80K (INRO) clocks can only be used for UART3*/
     MXC_UART_ERTCO_CLK = 4,
     MXC_UART_INRO_CLK = 5,
+    MXC_UART_AOD_CLK = 6
 } mxc_uart_clock_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32675/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/uart.h
@@ -84,7 +84,8 @@ typedef enum {
     MXC_UART_IBRO_CLK = 2,
     MXC_UART_ERFO_CLK = 3,
     /*32K (ERTCO) clock can only be used for UART3*/
-    MXC_UART_ERTCO_CLK = 4,
+    MXC_UART_AOD_CLK = 4,
+    MXC_UART_INRO_CLK = 5
 } mxc_uart_clock_t;
 
 /**

--- a/Libraries/PeriphDrivers/Source/AFE/hart_uart.c
+++ b/Libraries/PeriphDrivers/Source/AFE/hart_uart.c
@@ -173,9 +173,11 @@ static int hart_uart_init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
         MXC_AFE_GPIO_Config(&gpio_cfg_extclk);
         break;
 
+#if TARGET_NUM != 32675
     case MXC_UART_ERTCO_CLK:
         return E_BAD_PARAM;
         break;
+#endif
 
     case MXC_UART_IBRO_CLK:
         MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);

--- a/Libraries/PeriphDrivers/Source/UART/uart_me15.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me15.c
@@ -224,6 +224,10 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
         return E_BAD_PARAM;
     }
 
+    if (uart->ctrl & MXC_F_UART_CTRL_FDM) {
+        clock_freq *= 2; // x2 to account for FDM
+    }
+
     freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, clock_freq, baud);
 
     if (freq > 0) {

--- a/Libraries/PeriphDrivers/Source/UART/uart_me15.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me15.c
@@ -18,6 +18,7 @@
  *
  ******************************************************************************/
 
+#include <math.h>
 #include "uart.h"
 #include "mxc_device.h"
 #include "mxc_pins.h"
@@ -110,6 +111,9 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     }
 #endif // MSDK_NO_GPIO_CLK_INIT
 
+    retval = MXC_UART_SetClockSource(uart, clock);
+    if (retval) return retval;
+
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, clock);
 }
 
@@ -153,72 +157,72 @@ int MXC_UART_ReadyForSleep(mxc_uart_regs_t *uart)
 int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
     int freq;
-    int mod = 0;
-    int clkdiv = 0;
-    int div = 8;
+    uint32_t clock_freq = 0;
+    uint8_t aon_clk_div;
 
     if (MXC_UART_GET_IDX(uart) < 0) {
         return E_BAD_PARAM;
     }
 
-    // check if the uart is LPUART
-    if (uart == MXC_UART3) {
-        // OSR default value
-        uart->osr = 5;
+    // Default OSR default value
+    uart->osr = 5;
 
-        switch (clock) {
+    switch(clock) {
         case MXC_UART_APB_CLK:
-            uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_PERIPHERAL_CLOCK;
-            div = (1 << (MXC_GCR->pclkdiv & MXC_F_GCR_PCLKDIV_AON_CLKDIV)) * 8;
-            clkdiv = ((SystemCoreClock / div) / baud);
-            mod = ((SystemCoreClock / div) % baud);
+            clock_freq = PeripheralClock;
             break;
-
         case MXC_UART_EXT_CLK:
-            uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_EXTERNAL_CLOCK;
-            clkdiv = EXTCLK_FREQ / baud;
-            mod = EXTCLK_FREQ % baud;
+            clock_freq = EXTCLK_FREQ;
             break;
-
-        case MXC_UART_ERTCO_CLK:
-            uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_CLK2;
-            uart->ctrl |= MXC_F_UART_CTRL_FDM;
-            clkdiv = ((ERTCO_FREQ * 2) / baud);
-            mod = ((ERTCO_FREQ * 2) % baud);
+        case MXC_UART_IBRO_CLK:
+            clock_freq = IBRO_FREQ;
 
             if (baud > 2400) {
                 uart->osr = 0;
             } else {
                 uart->osr = 1;
             }
+
+            break;
+
+        case MXC_UART_ERFO_CLK:
+            clock_freq = ERFO_FREQ;
+            break;
+        
+        case MXC_UART_ERTCO_CLK:
+            clock_freq = ERTCO_FREQ;
+            uart->ctrl |= MXC_F_UART_CTRL_FDM;
+
+            if (baud > 2400) {
+                uart->osr = 0;
+            } else {
+                uart->osr = 1;
+            }
+
             break;
 
         case MXC_UART_INRO_CLK:
-            uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_CLK3;
+            clock_freq = INRO_FREQ;
             uart->ctrl |= MXC_F_UART_CTRL_FDM;
-            clkdiv = ((INRO_FREQ * 2) / baud);
-            mod = ((INRO_FREQ * 2) % baud);
 
             if (baud > 2400) {
                 uart->osr = 0;
             } else {
                 uart->osr = 1;
             }
+
+            break;
+
+        case MXC_UART_AOD_CLK:
+            aon_clk_div = (MXC_GCR->pclkdiv & MXC_F_GCR_PCLKDIV_AON_CLKDIV) >> MXC_F_GCR_PCLKDIV_AON_CLKDIV_POS;
+            clock_freq = PeripheralClock / (4 * (pow(2, aon_clk_div)));
             break;
 
         default:
             return E_BAD_PARAM;
-        }
-
-        if (!clkdiv || mod > (baud / 2)) {
-            clkdiv++;
-        }
-        uart->clkdiv = clkdiv;
-
-        freq = MXC_UART_GetFrequency(uart);
-    } else {
-        freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, baud, clock);
     }
+
+    freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, clock_freq, baud);
 
     if (freq > 0) {
         // Enable baud clock and wait for it to become ready.
@@ -325,7 +329,51 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
 
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
-    return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock);
+    uint8_t clock_option = 0;
+
+    switch (MXC_UART_GET_IDX(uart)) {
+        case 0:
+        case 1:
+        case 2:
+            switch(clock) {
+                case MXC_UART_APB_CLK:
+                    clock_option = 0;
+                    break;
+                case MXC_UART_EXT_CLK:
+                    clock_option = 1;
+                    break;
+                case MXC_UART_IBRO_CLK:
+                    MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+                    clock_option = 2;
+                    break;
+                case MXC_UART_ERFO_CLK:
+                    MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+                    clock_option = 3;
+                    break;
+                default:
+                    return E_BAD_PARAM;
+            }
+        break;
+        case 3:
+            switch(clock) {
+                case MXC_UART_AOD_CLK:
+                    clock_option = 0;
+                    break;
+                case MXC_UART_EXT_CLK:
+                    clock_option = 1;
+                    break;
+                case MXC_UART_ERTCO_CLK:
+                    clock_option = 2;
+                    break;
+                case MXC_UART_INRO_CLK:
+                    clock_option = 3;
+                    break;
+                default:
+                    return E_BAD_PARAM;
+            }
+    }
+
+    return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock_option);
 }
 
 int MXC_UART_GetActive(mxc_uart_regs_t *uart)

--- a/Libraries/PeriphDrivers/Source/UART/uart_me15.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me15.c
@@ -112,7 +112,8 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
 #endif // MSDK_NO_GPIO_CLK_INIT
 
     retval = MXC_UART_SetClockSource(uart, clock);
-    if (retval) return retval;
+    if (retval)
+        return retval;
 
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, clock);
 }
@@ -167,59 +168,60 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
     // Default OSR default value
     uart->osr = 5;
 
-    switch(clock) {
-        case MXC_UART_APB_CLK:
-            clock_freq = PeripheralClock;
-            break;
-        case MXC_UART_EXT_CLK:
-            clock_freq = EXTCLK_FREQ;
-            break;
-        case MXC_UART_IBRO_CLK:
-            clock_freq = IBRO_FREQ;
+    switch (clock) {
+    case MXC_UART_APB_CLK:
+        clock_freq = PeripheralClock;
+        break;
+    case MXC_UART_EXT_CLK:
+        clock_freq = EXTCLK_FREQ;
+        break;
+    case MXC_UART_IBRO_CLK:
+        clock_freq = IBRO_FREQ;
 
-            if (baud > 2400) {
-                uart->osr = 0;
-            } else {
-                uart->osr = 1;
-            }
+        if (baud > 2400) {
+            uart->osr = 0;
+        } else {
+            uart->osr = 1;
+        }
 
-            break;
+        break;
 
-        case MXC_UART_ERFO_CLK:
-            clock_freq = ERFO_FREQ;
-            break;
-        
-        case MXC_UART_ERTCO_CLK:
-            clock_freq = ERTCO_FREQ;
-            uart->ctrl |= MXC_F_UART_CTRL_FDM;
+    case MXC_UART_ERFO_CLK:
+        clock_freq = ERFO_FREQ;
+        break;
 
-            if (baud > 2400) {
-                uart->osr = 0;
-            } else {
-                uart->osr = 1;
-            }
+    case MXC_UART_ERTCO_CLK:
+        clock_freq = ERTCO_FREQ;
+        uart->ctrl |= MXC_F_UART_CTRL_FDM;
 
-            break;
+        if (baud > 2400) {
+            uart->osr = 0;
+        } else {
+            uart->osr = 1;
+        }
 
-        case MXC_UART_INRO_CLK:
-            clock_freq = INRO_FREQ;
-            uart->ctrl |= MXC_F_UART_CTRL_FDM;
+        break;
 
-            if (baud > 2400) {
-                uart->osr = 0;
-            } else {
-                uart->osr = 1;
-            }
+    case MXC_UART_INRO_CLK:
+        clock_freq = INRO_FREQ;
+        uart->ctrl |= MXC_F_UART_CTRL_FDM;
 
-            break;
+        if (baud > 2400) {
+            uart->osr = 0;
+        } else {
+            uart->osr = 1;
+        }
 
-        case MXC_UART_AOD_CLK:
-            aon_clk_div = (MXC_GCR->pclkdiv & MXC_F_GCR_PCLKDIV_AON_CLKDIV) >> MXC_F_GCR_PCLKDIV_AON_CLKDIV_POS;
-            clock_freq = PeripheralClock / (4 * (pow(2, aon_clk_div)));
-            break;
+        break;
 
-        default:
-            return E_BAD_PARAM;
+    case MXC_UART_AOD_CLK:
+        aon_clk_div = (MXC_GCR->pclkdiv & MXC_F_GCR_PCLKDIV_AON_CLKDIV) >>
+                      MXC_F_GCR_PCLKDIV_AON_CLKDIV_POS;
+        clock_freq = PeripheralClock / (4 * (pow(2, aon_clk_div)));
+        break;
+
+    default:
+        return E_BAD_PARAM;
     }
 
     freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, clock_freq, baud);
@@ -332,45 +334,45 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
     uint8_t clock_option = 0;
 
     switch (MXC_UART_GET_IDX(uart)) {
-        case 0:
-        case 1:
-        case 2:
-            switch(clock) {
-                case MXC_UART_APB_CLK:
-                    clock_option = 0;
-                    break;
-                case MXC_UART_EXT_CLK:
-                    clock_option = 1;
-                    break;
-                case MXC_UART_IBRO_CLK:
-                    MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-                    clock_option = 2;
-                    break;
-                case MXC_UART_ERFO_CLK:
-                    MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
-                    clock_option = 3;
-                    break;
-                default:
-                    return E_BAD_PARAM;
-            }
+    case 0:
+    case 1:
+    case 2:
+        switch (clock) {
+        case MXC_UART_APB_CLK:
+            clock_option = 0;
+            break;
+        case MXC_UART_EXT_CLK:
+            clock_option = 1;
+            break;
+        case MXC_UART_IBRO_CLK:
+            MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+            clock_option = 2;
+            break;
+        case MXC_UART_ERFO_CLK:
+            MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+            clock_option = 3;
+            break;
+        default:
+            return E_BAD_PARAM;
+        }
         break;
-        case 3:
-            switch(clock) {
-                case MXC_UART_AOD_CLK:
-                    clock_option = 0;
-                    break;
-                case MXC_UART_EXT_CLK:
-                    clock_option = 1;
-                    break;
-                case MXC_UART_ERTCO_CLK:
-                    clock_option = 2;
-                    break;
-                case MXC_UART_INRO_CLK:
-                    clock_option = 3;
-                    break;
-                default:
-                    return E_BAD_PARAM;
-            }
+    case 3:
+        switch (clock) {
+        case MXC_UART_AOD_CLK:
+            clock_option = 0;
+            break;
+        case MXC_UART_EXT_CLK:
+            clock_option = 1;
+            break;
+        case MXC_UART_ERTCO_CLK:
+            clock_option = 2;
+            break;
+        case MXC_UART_INRO_CLK:
+            clock_option = 3;
+            break;
+        default:
+            return E_BAD_PARAM;
+        }
     }
 
     return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock_option);

--- a/Libraries/PeriphDrivers/Source/UART/uart_me16.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me16.c
@@ -133,7 +133,7 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
 {
     int freq;
     uint32_t clock_freq = 0;
-    uint32_t aon_clk_div = 0;   
+    uint32_t aon_clk_div = 0;
 
     if (MXC_UART_GET_IDX(uart) < 0) {
         return E_BAD_PARAM;
@@ -142,45 +142,46 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
     // Default OSR default value
     uart->osr = 5;
 
-    switch(clock) {
-        case MXC_UART_APB_CLK:
-            clock_freq = PeripheralClock;
-            break;
-        case MXC_UART_EXT_CLK:
-            clock_freq = EXTCLK_FREQ;
-        case MXC_UART_IBRO_CLK:
-            clock_freq = IBRO_FREQ;
-            uart->ctrl |= MXC_F_UART_CTRL_FDM;
+    switch (clock) {
+    case MXC_UART_APB_CLK:
+        clock_freq = PeripheralClock;
+        break;
+    case MXC_UART_EXT_CLK:
+        clock_freq = EXTCLK_FREQ;
+    case MXC_UART_IBRO_CLK:
+        clock_freq = IBRO_FREQ;
+        uart->ctrl |= MXC_F_UART_CTRL_FDM;
 
-            if (baud > 2400) {
-                uart->osr = 0;
-            } else {
-                uart->osr = 1;
-            }
-            break;
-        case MXC_UART_ERFO_CLK:
-            clock_freq = ERFO_FREQ;
-            break;
-        case MXC_UART_AOD_CLK:
-            aon_clk_div = (MXC_GCR->pclkdiv & MXC_F_GCR_PCLKDIV_AON_CLKDIV) >> MXC_F_GCR_PCLKDIV_AON_CLKDIV_POS;
-            clock_freq = PeripheralClock / (4 * (pow(2, aon_clk_div)));
-            break;
-        case MXC_UART_INRO_CLK:
-            clock_freq = INRO_FREQ;
-            uart->ctrl |= MXC_F_UART_CTRL_FDM;
-            if (baud > 2400) {
-                uart->osr = 0;
-            } else {
-                uart->osr = 1;
-            }
-        default:
-            return E_BAD_PARAM;
+        if (baud > 2400) {
+            uart->osr = 0;
+        } else {
+            uart->osr = 1;
+        }
+        break;
+    case MXC_UART_ERFO_CLK:
+        clock_freq = ERFO_FREQ;
+        break;
+    case MXC_UART_AOD_CLK:
+        aon_clk_div = (MXC_GCR->pclkdiv & MXC_F_GCR_PCLKDIV_AON_CLKDIV) >>
+                      MXC_F_GCR_PCLKDIV_AON_CLKDIV_POS;
+        clock_freq = PeripheralClock / (4 * (pow(2, aon_clk_div)));
+        break;
+    case MXC_UART_INRO_CLK:
+        clock_freq = INRO_FREQ;
+        uart->ctrl |= MXC_F_UART_CTRL_FDM;
+        if (baud > 2400) {
+            uart->osr = 0;
+        } else {
+            uart->osr = 1;
+        }
+    default:
+        return E_BAD_PARAM;
     }
 
     if (uart->ctrl & MXC_F_UART_CTRL_FDM) {
         clock_freq *= 2; // x2 to account for FDM
     }
-    
+
     freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, clock_freq, baud);
 
     if (freq > 0) {
@@ -272,52 +273,52 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
     uint8_t clock_option = 0;
 
-    switch(MXC_UART_GET_IDX(uart)) {
-        case 0:
-        case 1:
-        case 2:
-            switch(clock) {
-                case MXC_UART_APB_CLK:
-                    clock_option = 0;
-                    break;
-                case MXC_UART_EXT_CLK:
-                    clock_option = 1;
-                    break;
-                case MXC_UART_IBRO_CLK:
-                    MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-                    clock_option = 2;
-                    break;
-                case MXC_UART_ERFO_CLK:
-                    MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
-                    clock_option = 3;
-                    break;
-                default:
-                    return E_BAD_PARAM;
-            }
+    switch (MXC_UART_GET_IDX(uart)) {
+    case 0:
+    case 1:
+    case 2:
+        switch (clock) {
+        case MXC_UART_APB_CLK:
+            clock_option = 0;
             break;
-        case 3:
-            switch(clock) {
-                case MXC_UART_AOD_CLK:
-                    clock_option = 0;
-                    break;
-                case MXC_UART_EXT_CLK:
-                    clock_option = 1;
-                    break;
-                case MXC_UART_INRO_CLK:
-                    clock_option = 3;
-                    break;
-                default:
-                    return E_BAD_PARAM;
-            }
+        case MXC_UART_EXT_CLK:
+            clock_option = 1;
+            break;
+        case MXC_UART_IBRO_CLK:
+            MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+            clock_option = 2;
+            break;
+        case MXC_UART_ERFO_CLK:
+            MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+            clock_option = 3;
+            break;
         default:
             return E_BAD_PARAM;
         }
         break;
+    case 3:
+        switch (clock) {
+        case MXC_UART_AOD_CLK:
+            clock_option = 0;
+            break;
+        case MXC_UART_EXT_CLK:
+            clock_option = 1;
+            break;
+        case MXC_UART_INRO_CLK:
+            clock_option = 3;
+            break;
+        default:
+            return E_BAD_PARAM;
+        }
     default:
         return E_BAD_PARAM;
     }
+    break;
+default:
+    return E_BAD_PARAM;
+}
 
-    return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock_option);
+return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock_option);
 }
 
 int MXC_UART_GetActive(mxc_uart_regs_t *uart)

--- a/Libraries/PeriphDrivers/Source/UART/uart_me16.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me16.c
@@ -98,7 +98,8 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
 #endif // MSDK_NO_GPIO_CLK_INIT
 
     retval = MXC_UART_SetClockSource(uart, clock);
-    if (retval) return retval;
+    if (retval)
+        return retval;
 
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, (mxc_uart_revb_clock_t)clock);
 }
@@ -131,29 +132,29 @@ int MXC_UART_ReadyForSleep(mxc_uart_regs_t *uart)
 int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
     int freq;
-    uint32_t clock_freq = 0;     
+    uint32_t clock_freq = 0;
 
-   if (MXC_UART_GET_IDX(uart) < 0) {
+    if (MXC_UART_GET_IDX(uart) < 0) {
         return E_BAD_PARAM;
     }
 
     // Default OSR default value
     uart->osr = 5;
 
-    switch(clock) {
-        case MXC_UART_APB_CLK:
-            clock_freq = PeripheralClock;
-            break;
-        case MXC_UART_IBRO_CLK:
-            clock_freq = IBRO_FREQ;
-            break;
-        case MXC_UART_ERFO_CLK:
-            clock_freq = ERFO_FREQ;
-            break;
-        default:
-            return E_BAD_PARAM;
+    switch (clock) {
+    case MXC_UART_APB_CLK:
+        clock_freq = PeripheralClock;
+        break;
+    case MXC_UART_IBRO_CLK:
+        clock_freq = IBRO_FREQ;
+        break;
+    case MXC_UART_ERFO_CLK:
+        clock_freq = ERFO_FREQ;
+        break;
+    default:
+        return E_BAD_PARAM;
     }
-    
+
     freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, clock_freq, baud);
 
     if (freq > 0) {
@@ -226,27 +227,27 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
     uint8_t clock_option = 0;
 
-    switch(MXC_UART_GET_IDX(uart)) {
-        case 0:
-        case 2:
-            switch(clock) {
-                case MXC_UART_APB_CLK:
-                    clock_option = 0;
-                    break;
-                case MXC_UART_IBRO_CLK:
-                    MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-                    clock_option = 2;
-                    break;
-                case MXC_UART_ERFO_CLK:
-                    MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
-                    clock_option = 3;
-                    break;
-                default:
-                    return E_BAD_PARAM;
-            }
+    switch (MXC_UART_GET_IDX(uart)) {
+    case 0:
+    case 2:
+        switch (clock) {
+        case MXC_UART_APB_CLK:
+            clock_option = 0;
+            break;
+        case MXC_UART_IBRO_CLK:
+            MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+            clock_option = 2;
+            break;
+        case MXC_UART_ERFO_CLK:
+            MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+            clock_option = 3;
             break;
         default:
             return E_BAD_PARAM;
+        }
+        break;
+    default:
+        return E_BAD_PARAM;
     }
 
     return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock_option);

--- a/Libraries/PeriphDrivers/Source/UART/uart_me16.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me16.c
@@ -21,6 +21,7 @@
 #pragma diag_suppress 68 // integer conversion resulted in a change of sign
 #endif
 
+#include <math.h>
 #include "uart.h"
 #include "mxc_device.h"
 #include "mxc_pins.h"
@@ -60,17 +61,16 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
         MXC_GPIO_Config(&gpio_cfg_extclk);
         break;
 
-    case MXC_UART_ERTCO_CLK:
-        // UART0 and UART2 doesn't use ERTCO
-        return E_BAD_PARAM;
-        break;
-
     case MXC_UART_IBRO_CLK:
         MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
         break;
 
     case MXC_UART_ERFO_CLK:
         MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+        break;
+
+    case MXC_UART_INRO_CLK:
+        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_INRO);
         break;
 
     default:
@@ -310,15 +310,12 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
         default:
             return E_BAD_PARAM;
         }
+        break;
     default:
         return E_BAD_PARAM;
     }
-    break;
-default:
-    return E_BAD_PARAM;
-}
 
-return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock_option);
+    return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock_option);
 }
 
 int MXC_UART_GetActive(mxc_uart_regs_t *uart)

--- a/Libraries/PeriphDrivers/Source/UART/uart_me16.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me16.c
@@ -167,30 +167,11 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
 
 int MXC_UART_GetFrequency(mxc_uart_regs_t *uart)
 {
-    int periphClock = 0;
-    int div = 8;
-
     if (MXC_UART_GET_IDX(uart) < 0) {
         return E_BAD_PARAM;
     }
 
-    // check if UARt is LP UART
-    if (uart == MXC_UART3) {
-        if ((uart->ctrl & MXC_F_UART_CTRL_BCLKSRC) == MXC_S_UART_CTRL_BCLKSRC_EXTERNAL_CLOCK) {
-            return EXTCLK_FREQ;
-        } else if ((uart->ctrl & MXC_F_UART_CTRL_BCLKSRC) ==
-                   MXC_S_UART_CTRL_BCLKSRC_PERIPHERAL_CLOCK) {
-            div = (1 << (MXC_GCR->pclkdiv & MXC_F_GCR_PCLKDIV_AON_CLKDIV)) * 8;
-            periphClock = SystemCoreClock / div;
-        } else if ((uart->ctrl & MXC_F_UART_CTRL_BCLKSRC) == MXC_S_UART_CTRL_BCLKSRC_CLK2) {
-            periphClock = ERTCO_FREQ * 2;
-        } else {
-            return E_BAD_PARAM;
-        }
-        return (periphClock / uart->clkdiv);
-    } else {
-        return MXC_UART_RevB_GetFrequency((mxc_uart_revb_regs_t *)uart);
-    }
+    return MXC_UART_RevB_GetFrequency((mxc_uart_revb_regs_t *)uart);
 }
 
 int MXC_UART_SetDataSize(mxc_uart_regs_t *uart, int dataSize)

--- a/Libraries/PeriphDrivers/Source/UART/uart_me21.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me21.c
@@ -26,6 +26,7 @@
 #include "uart_common.h"
 #include "mcr_regs.h"
 #include "dma.h"
+#include <math.h>
 
 sys_map_t uart_pin_mapping[4] = { MAP_A, MAP_A, MAP_A, MAP_A };
 /* Note(JC):               ^ Ideally I use MXC_UART_INSTANCES here...
@@ -147,6 +148,9 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     }
 #endif // MSDK_NO_GPIO_CLK_INIT
 
+    retval = MXC_UART_SetClockSource(uart, clock);
+    if (retval) return retval;
+
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, clock);
 }
 
@@ -185,79 +189,61 @@ int MXC_UART_ReadyForSleep(mxc_uart_regs_t *uart)
 
 int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
-    int freq;
-    int mod = 0;
-    int clkdiv = 0;
-    int div = 8;
+    int freq = 0;
+    uint32_t clock_freq = 0;
+    uint8_t aon_clk_div = 0;
 
     if (MXC_UART_GET_IDX(uart) < 0) {
         return E_BAD_PARAM;
     }
 
-    // check if the uart is LPUART
-    if (uart == MXC_UART3) {
-        // OSR default value
-        uart->osr = 5;
+    // OSR default value
+    uart->osr = 5;
 
-        switch (clock) {
-        case MXC_UART_APB_CLK:
-            uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_PERIPHERAL_CLOCK;
-            div = (1 << (MXC_GCR->pclkdiv & MXC_F_GCR_PCLKDIV_AON_CLKDIV)) * 8;
-            clkdiv = (SystemCoreClock / div) / baud;
-            mod = (SystemCoreClock / div) % baud;
-            break;
+    switch(clock) {
+    case MXC_UART_APB_CLK:
+        clock_freq = PeripheralClock;
+        break;
+    case MXC_UART_EXT_CLK:
+        uart->ctrl |= MXC_F_UART_CTRL_FDM;
+        clock_freq = EXTCLK_FREQ;
+        break;
+    case MXC_UART_IBRO_CLK:
+        clock_freq = IBRO_FREQ;
+        break;
+    case MXC_UART_INRO_CLK:
+        uart->ctrl |= MXC_F_UART_CTRL_FDM;
+        clock_freq = INRO_FREQ;
 
-        case MXC_UART_EXT_CLK:
-            uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_EXTERNAL_CLOCK;
-            uart->ctrl |= MXC_F_UART_CTRL_FDM;
-            clkdiv = ((EXTCLK2_FREQ * 2) / baud);
-            mod = ((EXTCLK2_FREQ * 2) % baud);
-            break;
-
-        case MXC_UART_ERTCO_CLK:
-            uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_CLK2;
-            uart->ctrl |= MXC_F_UART_CTRL_FDM;
-            if (baud == 9600) {
-                clkdiv = 7;
-                mod = 0;
-            } else {
-                clkdiv = ((ERTCO_FREQ * 2) / baud);
-                mod = ((ERTCO_FREQ * 2) % baud);
-            }
-
-            if (baud > 2400) {
-                uart->osr = 0;
-            } else {
-                uart->osr = 1;
-            }
-            break;
-
-        case MXC_UART_INRO_CLK:
-            uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_CLK3;
-            uart->ctrl |= MXC_F_UART_CTRL_FDM;
-            clkdiv = ((INRO_FREQ * 2) / baud);
-            mod = ((INRO_FREQ * 2) % baud);
-
-            if (baud > 2400) {
-                uart->osr = 0;
-            } else {
-                uart->osr = 1;
-            }
-            break;
-
-        default:
-            return E_BAD_PARAM;
+        if (baud > 2400) {
+            uart->osr = 0;
+        } else {
+            uart->osr = 1;
         }
+        break;
+    case MXC_UART_ERTCO_CLK:
+        uart->ctrl |= MXC_F_UART_CTRL_FDM;
+        clock_freq = ERTCO_FREQ;
 
-        if (!clkdiv || mod > (baud / 2)) {
-            clkdiv++;
+        if (baud > 2400) {
+            uart->osr = 0;
+        } else {
+            uart->osr = 1;
         }
-        uart->clkdiv = clkdiv;
-
-        freq = MXC_UART_GetFrequency(uart);
-    } else {
-        freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, baud, clock);
+        break;
+    case MXC_UART_AOD_CLK:
+        aon_clk_div = (MXC_GCR->pclkdiv & MXC_F_GCR_PCLKDIV_AON_CLKDIV) >> MXC_F_GCR_PCLKDIV_AON_CLKDIV_POS;
+        clock_freq = PeripheralClock / (4 * (pow(2, aon_clk_div)));
+    default:
+        return E_BAD_PARAM;
     }
+
+    if (uart->ctrl & MXC_F_UART_CTRL_FDM) {
+        clock_freq *= 2; // x2 to account for FDM
+    }
+
+
+    freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, clock_freq, baud);
 
     if (freq > 0) {
         // Enable baud clock and wait for it to become ready.
@@ -364,7 +350,66 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
 
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
-    return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock);
+    int error = E_NO_ERROR;
+    uint8_t clock_option = 0;
+
+    switch (MXC_UART_GET_IDX(uart)) {
+    case 0:
+    case 1:
+    case 2:
+        // UART0-2 support PCLK and IBRO
+        switch (clock) {
+        case MXC_UART_APB_CLK:
+            clock_option = 0;
+            break;
+
+        case MXC_UART_EXT_CLK:
+            clock_option = 1;
+            break;
+
+        case MXC_UART_IBRO_CLK:
+            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+            clock_option = 2;
+            break;
+
+        default:
+            return E_BAD_PARAM;
+        }
+        break;
+
+    case 3:
+        // UART3 (LPUART0) supports IBRO and ERTCO
+        switch (clock) {
+        case MXC_UART_AOD_CLK:
+            clock_option = 0;
+            break;
+
+        case MXC_UART_EXT_CLK:
+            clock_option = 1;
+            break;
+
+        case MXC_UART_INRO_CLK:
+            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_INRO);
+            clock_option = 2;
+            break;
+
+        case MXC_UART_ERTCO_CLK:
+            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+            clock_option = 3;
+            break;
+
+        default:
+            return E_BAD_PARAM;
+        }
+        break;
+
+    default:
+        return E_BAD_PARAM;
+    }
+
+    if (error) return error;
+
+    return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock_option);
 }
 
 int MXC_UART_GetActive(mxc_uart_regs_t *uart)

--- a/Libraries/PeriphDrivers/Source/UART/uart_me21.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me21.c
@@ -234,6 +234,7 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
     case MXC_UART_AOD_CLK:
         aon_clk_div = (MXC_GCR->pclkdiv & MXC_F_GCR_PCLKDIV_AON_CLKDIV) >> MXC_F_GCR_PCLKDIV_AON_CLKDIV_POS;
         clock_freq = PeripheralClock / (4 * (pow(2, aon_clk_div)));
+        break;
     default:
         return E_BAD_PARAM;
     }

--- a/Libraries/PeriphDrivers/Source/UART/uart_me21.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me21.c
@@ -149,7 +149,8 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
 #endif // MSDK_NO_GPIO_CLK_INIT
 
     retval = MXC_UART_SetClockSource(uart, clock);
-    if (retval) return retval;
+    if (retval)
+        return retval;
 
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, clock);
 }
@@ -200,7 +201,7 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
     // OSR default value
     uart->osr = 5;
 
-    switch(clock) {
+    switch (clock) {
     case MXC_UART_APB_CLK:
         clock_freq = PeripheralClock;
         break;
@@ -232,7 +233,8 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
         }
         break;
     case MXC_UART_AOD_CLK:
-        aon_clk_div = (MXC_GCR->pclkdiv & MXC_F_GCR_PCLKDIV_AON_CLKDIV) >> MXC_F_GCR_PCLKDIV_AON_CLKDIV_POS;
+        aon_clk_div = (MXC_GCR->pclkdiv & MXC_F_GCR_PCLKDIV_AON_CLKDIV) >>
+                      MXC_F_GCR_PCLKDIV_AON_CLKDIV_POS;
         clock_freq = PeripheralClock / (4 * (pow(2, aon_clk_div)));
         break;
     default:
@@ -242,7 +244,6 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
     if (uart->ctrl & MXC_F_UART_CTRL_FDM) {
         clock_freq *= 2; // x2 to account for FDM
     }
-
 
     freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, clock_freq, baud);
 
@@ -408,7 +409,8 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
         return E_BAD_PARAM;
     }
 
-    if (error) return error;
+    if (error)
+        return error;
 
     return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock_option);
 }

--- a/Libraries/PeriphDrivers/Source/UART/uart_me21.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me21.c
@@ -18,6 +18,7 @@
  *
  ******************************************************************************/
 
+#include <math.h>
 #include "uart.h"
 #include "mxc_device.h"
 #include "mxc_pins.h"
@@ -26,7 +27,6 @@
 #include "uart_common.h"
 #include "mcr_regs.h"
 #include "dma.h"
-#include <math.h>
 
 sys_map_t uart_pin_mapping[4] = { MAP_A, MAP_A, MAP_A, MAP_A };
 /* Note(JC):               ^ Ideally I use MXC_UART_INSTANCES here...

--- a/Libraries/PeriphDrivers/Source/UART/uart_me30.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me30.c
@@ -103,6 +103,7 @@ int MXC_UART_ReadyForSleep(mxc_uart_regs_t *uart)
 int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
     int freq;
+    uint32_t clock_freq = 0;
 
     if (MXC_UART_GET_IDX(uart) < 0) {
         return E_BAD_PARAM;
@@ -112,7 +113,22 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
         return E_BAD_PARAM;
     }
 
-    freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, baud, clock);
+    switch(clock) {
+        case MXC_UART_APB_CLK:
+            clock_freq = PeripheralClock;
+            break;
+        case MXC_UART_IBRO_CLK:
+            clock_freq = IBRO_FREQ;
+            break;
+        case MXC_UART_ERTCO_CLK:
+            clock_freq = ERTCO_FREQ;
+            break;
+        default:
+            return E_BAD_PARAM;
+    }
+
+    // TODO(JC): Update this call for ME30
+    freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, clock_freq, baud);
 
     if (freq > 0) {
         // Enable baud clock and wait for it to become ready.

--- a/Libraries/PeriphDrivers/Source/UART/uart_me30.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me30.c
@@ -113,18 +113,18 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
         return E_BAD_PARAM;
     }
 
-    switch(clock) {
-        case MXC_UART_APB_CLK:
-            clock_freq = PeripheralClock;
-            break;
-        case MXC_UART_IBRO_CLK:
-            clock_freq = IBRO_FREQ;
-            break;
-        case MXC_UART_ERTCO_CLK:
-            clock_freq = ERTCO_FREQ;
-            break;
-        default:
-            return E_BAD_PARAM;
+    switch (clock) {
+    case MXC_UART_APB_CLK:
+        clock_freq = PeripheralClock;
+        break;
+    case MXC_UART_IBRO_CLK:
+        clock_freq = IBRO_FREQ;
+        break;
+    case MXC_UART_ERTCO_CLK:
+        clock_freq = ERTCO_FREQ;
+        break;
+    default:
+        return E_BAD_PARAM;
     }
 
     // TODO(JC): Update this call for ME30

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -298,7 +298,8 @@ int MXC_UART_RevB_SetClockSource(mxc_uart_revb_regs_t *uart, uint8_t clock_optio
         uart->ctrl &= ~MXC_F_UART_REVB_CTRL_BCLKEN;
     }
 
-    MXC_SETFIELD(uart->ctrl, MXC_F_UART_REVB_CTRL_BCLKSRC, clock_option << MXC_F_UART_REVB_CTRL_BCLKSRC_POS);
+    MXC_SETFIELD(uart->ctrl, MXC_F_UART_REVB_CTRL_BCLKSRC,
+                 clock_option << MXC_F_UART_REVB_CTRL_BCLKSRC_POS);
 
     if (is_bclk_enabled) {
         // Turn the baud rate clock back on

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -291,19 +291,19 @@ int MXC_UART_RevB_SetClockSource(mxc_uart_revb_regs_t *uart, uint8_t clock_optio
         return E_NO_ERROR; // Return with no error so Init doesn't error out if clock config is locked
     }
 
-    bool is_bclk_enabled = (uart->ctrl & MXC_F_UART_CTRL_BCLKEN) != 0;
+    bool is_bclk_enabled = (uart->ctrl & MXC_F_UART_REVB_CTRL_BCLKEN) != 0;
 
     if (is_bclk_enabled) {
         // Shut down baud rate clock before changing clock source
-        uart->ctrl &= ~MXC_F_UART_CTRL_BCLKEN;
+        uart->ctrl &= ~MXC_F_UART_REVB_CTRL_BCLKEN;
     }
 
-    MXC_SETFIELD(uart->ctrl, MXC_F_UART_CTRL_BCLKSRC, clock_option << MXC_F_UART_CTRL_BCLKSRC_POS);
+    MXC_SETFIELD(uart->ctrl, MXC_F_UART_REVB_CTRL_BCLKSRC, clock_option << MXC_F_UART_REVB_CTRL_BCLKSRC_POS);
 
     if (is_bclk_enabled) {
         // Turn the baud rate clock back on
-        uart->ctrl |= MXC_F_UART_CTRL_BCLKEN;
-        while (!(uart->ctrl & MXC_F_UART_CTRL_BCLKRDY)) {
+        uart->ctrl |= MXC_F_UART_REVB_CTRL_BCLKEN;
+        while (!(uart->ctrl & MXC_F_UART_REVB_CTRL_BCLKRDY)) {
             continue;
         }
     }
@@ -313,7 +313,7 @@ int MXC_UART_RevB_SetClockSource(mxc_uart_revb_regs_t *uart, uint8_t clock_optio
 
 unsigned int MXC_UART_RevB_GetClockSource(mxc_uart_revb_regs_t *uart)
 {
-    return ((uart->ctrl & MXC_F_UART_CTRL_BCLKSRC) >> MXC_F_UART_CTRL_BCLKSRC_POS);
+    return ((uart->ctrl & MXC_F_UART_REVB_CTRL_BCLKSRC) >> MXC_F_UART_REVB_CTRL_BCLKSRC_POS);
 }
 
 void MXC_UART_RevB_LockClockSource(mxc_uart_revb_regs_t *uart, bool lock)


### PR DESCRIPTION
### Description

Fixes functional regression caused by #1113 

Calls to MXC_UART_RevB_SetFrequency weren't updated for these parts after changing the RevB API.  As a result, `MXC_UART_RevB_GetTXFIFOAvailable` would eventually hang as the UART FIFO compeltely fills up and is never emptied due to misconfiguration.

Symptoms were that `printfs` would eventually infinitely hang.  i.e. even `Hello_World` wouldn't work.

This PR should fix the regressions.

Also removed `MXC_UART1` and `MXC_UART3` definitions for ME16.  These don't exist on the micro.

