### PR TITLE
fix(PeriphDrivers): MAX32690 Only Reset ADC, TMR, UART if Clock is not Locked

### DIFF
--- a/Libraries/PeriphDrivers/Source/ADC/adc_me18.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me18.c
@@ -103,7 +103,9 @@ static void initGPIOForTrigSrc(mxc_adc_trig_sel_t hwTrig)
 int MXC_ADC_Init(mxc_adc_req_t *req)
 {
 #ifndef MSDK_NO_GPIO_CLK_INIT
-    MXC_SYS_Reset_Periph(MXC_SYS_RESET0_ADC);
+    if (!MXC_ADC_RevB_IsClockSourceLocked((mxc_adc_revb_regs_t *)MXC_ADC)) {
+        MXC_SYS_Reset_Periph(MXC_SYS_RESET0_ADC);
+    }
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_ADC);
 
     /* This is required for temperature sensor only */

--- a/Libraries/PeriphDrivers/Source/ADC/adc_revb.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_revb.c
@@ -130,6 +130,11 @@ int MXC_ADC_RevB_LockClockSource(mxc_adc_revb_regs_t *adc, bool lock)
     }
 }
 
+bool MXC_ADC_RevB_IsClockSourceLocked(mxc_adc_revb_regs_t *adc)
+{
+    return g_is_clock_locked;
+}
+
 int MXC_ADC_RevB_Shutdown(mxc_adc_revb_regs_t *adc)
 {
     if (async_callback != NULL) {

--- a/Libraries/PeriphDrivers/Source/ADC/adc_revb.h
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_revb.h
@@ -41,6 +41,8 @@ int MXC_ADC_RevB_SetClockDiv(mxc_adc_revb_regs_t *adc, mxc_adc_clkdiv_t div);
 
 int MXC_ADC_RevB_LockClockSource(mxc_adc_revb_regs_t *adc, bool lock);
 
+bool MXC_ADC_RevB_IsClockSourceLocked(mxc_adc_revb_regs_t *adc);
+
 int MXC_ADC_RevB_Shutdown(mxc_adc_revb_regs_t *adc);
 
 void MXC_ADC_RevB_EnableInt(mxc_adc_revb_regs_t *adc, uint32_t flags);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
@@ -46,7 +46,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
                 which requires two Init calls.  We don't want to reset because that would
                 wipe out any previous initializations.
              */
-            MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR0);
+            if (!MXC_TMR_RevB_IsClockSourceLocked((mxc_tmr_revb_regs_t *)tmr)) {
+                MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR0);
+            }
         }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR0);
 
@@ -62,7 +64,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
 
     case 1:
         if (cfg->bitMode == MXC_TMR_BIT_MODE_32) {
-            MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR1);
+            if (!MXC_TMR_RevB_IsClockSourceLocked((mxc_tmr_revb_regs_t *)tmr)) {
+                MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR1);
+            }
         }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR1);
 
@@ -78,7 +82,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
 
     case 2:
         if (cfg->bitMode == MXC_TMR_BIT_MODE_32) {
-            MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR2);
+            if (!MXC_TMR_RevB_IsClockSourceLocked((mxc_tmr_revb_regs_t *)tmr)) {
+                MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR2);
+            }
         }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR2);
 
@@ -94,7 +100,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
 
     case 3:
         if (cfg->bitMode == MXC_TMR_BIT_MODE_32) {
-            MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR3);
+            if (!MXC_TMR_RevB_IsClockSourceLocked((mxc_tmr_revb_regs_t *)tmr)) {
+                MXC_SYS_Reset_Periph(MXC_SYS_RESET0_TMR3);
+            }
         }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR3);
 
@@ -110,13 +118,17 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
 
     case 4:
         MXC_GPIO_Config(&gpio_cfg_tmr4);
-        MXC_SYS_Reset_Periph(MXC_SYS_RESET_TMR4);
+        if (!MXC_TMR_RevB_IsClockSourceLocked((mxc_tmr_revb_regs_t *)tmr)) {
+            MXC_SYS_Reset_Periph(MXC_SYS_RESET_TMR4);
+        }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR4);
         break;
 
     case 5:
         MXC_GPIO_Config(&gpio_cfg_tmr5);
-        MXC_SYS_Reset_Periph(MXC_SYS_RESET_TMR5);
+        if (!MXC_TMR_RevB_IsClockSourceLocked((mxc_tmr_revb_regs_t *)tmr)) {
+            MXC_SYS_Reset_Periph(MXC_SYS_RESET_TMR5);
+        }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR5);
         break;
     }

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
@@ -136,6 +136,11 @@ void MXC_TMR_RevB_LockClockSource(mxc_tmr_revb_regs_t *tmr, bool lock)
     g_is_clock_locked[MXC_TMR_GET_IDX((mxc_tmr_regs_t *)tmr)] = lock;
 }
 
+bool MXC_TMR_RevB_IsClockSourceLocked(mxc_tmr_revb_regs_t *tmr)
+{
+    return g_is_clock_locked[MXC_TMR_GET_IDX((mxc_tmr_regs_t *)tmr)];
+}
+
 void MXC_TMR_RevB_SetClockSource(mxc_tmr_revb_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
                                  uint8_t clk_src)
 {

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb.h
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb.h
@@ -41,6 +41,7 @@ typedef enum {
 /* **** Functions **** */
 int MXC_TMR_RevB_Init(mxc_tmr_revb_regs_t *tmr, mxc_tmr_cfg_t *cfg, uint8_t clk_src);
 void MXC_TMR_RevB_LockClockSource(mxc_tmr_revb_regs_t *tmr, bool lock);
+bool MXC_TMR_RevB_IsClockSourceLocked(mxc_tmr_revb_regs_t *tmr);
 void MXC_TMR_RevB_SetClockSource(mxc_tmr_revb_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
                                  uint8_t clk_src);
 void MXC_TMR_RevB_SetPrescalar(mxc_tmr_revb_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,

--- a/Libraries/PeriphDrivers/Source/UART/uart_me18.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me18.c
@@ -47,11 +47,12 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
 #ifndef MSDK_NO_GPIO_CLK_INIT
     int retval;
 
-    retval = MXC_UART_Shutdown(uart);
-
-    if (retval) {
-        return retval;
-    }
+    if (!MXC_UART_RevB_IsClockSourceLocked((mxc_uart_revb_regs_t *)uart)) {
+        retval = MXC_UART_Shutdown(uart);
+        if (retval) {
+            return retval;
+        }
+    }    
 
     switch (MXC_UART_GET_IDX(uart)) {
     case 0:

--- a/Libraries/PeriphDrivers/Source/UART/uart_me18.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me18.c
@@ -52,7 +52,7 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
         if (retval) {
             return retval;
         }
-    }    
+    }
 
     switch (MXC_UART_GET_IDX(uart)) {
     case 0:

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -321,6 +321,11 @@ void MXC_UART_RevB_LockClockSource(mxc_uart_revb_regs_t *uart, bool lock)
     g_is_clock_locked[MXC_UART_GET_IDX((mxc_uart_regs_t *)uart)] = lock;
 }
 
+bool MXC_UART_RevB_IsClockSourceLocked(mxc_uart_revb_regs_t *uart)
+{
+    return g_is_clock_locked[MXC_UART_GET_IDX((mxc_uart_regs_t *)uart)];
+}
+
 int MXC_UART_RevB_SetFlowCtrl(mxc_uart_revb_regs_t *uart, mxc_uart_flow_t flowCtrl,
                               int rtsThreshold)
 {

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.h
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.h
@@ -66,6 +66,7 @@ int MXC_UART_RevB_SetFlowCtrl(mxc_uart_revb_regs_t *uart, mxc_uart_flow_t flowCt
 int MXC_UART_RevB_SetClockSource(mxc_uart_revb_regs_t *uart, uint8_t clock_option);
 unsigned int MXC_UART_RevB_GetClockSource(mxc_uart_revb_regs_t *uart);
 void MXC_UART_RevB_LockClockSource(mxc_uart_revb_regs_t *uart, bool lock);
+bool MXC_UART_RevB_IsClockSourceLocked(mxc_uart_revb_regs_t *uart);
 int MXC_UART_RevB_GetActive(mxc_uart_revb_regs_t *uart);
 int MXC_UART_RevB_AbortTransmission(mxc_uart_revb_regs_t *uart);
 int MXC_UART_RevB_ReadCharacterRaw(mxc_uart_revb_regs_t *uart);


### PR DESCRIPTION
### Description

Closes [CFSIO-2300](jira.analog.com/browse/CFSIO-2300)

Only issue a full reset to ADC, TMR, & UART if the clock source has not already been previously locked.  Otherwise CFS's clock config will be clobbered.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.