### PR TITLE
fix(Documentation): MAX32690 Hello_World add note on UART

### DIFF
--- a/Examples/MAX32690/Hello_World/README.md
+++ b/Examples/MAX32690/Hello_World/README.md
@@ -31,6 +31,8 @@ If using the AD-APARD32690-SL:
 -   Connect a USB cable between the PC and the P10 (USB-C) connector.
 -   Connect a MAXPICO Debug adapter to P9 (SWD Connector)
 -   Open a terminal application on the PC and connect to the MAXPICO's console UART at 115200, 8-N-1.
+-   Note: Non MAXPICO emulators may not route the UART signals to the SWD
+    connector, limiting your ability to access to serial port.
 
 ## Expected Output
 


### PR DESCRIPTION
Adds a note that the UART pins on the APARD board are only available on the SWD connector, and aren't available on other emulators like a Segger JLink.

## Pull Request Template

### Description

Please include a summary of the changes and related issues. Please also include relevant motivation and context.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
