### PR TITLE
fix(PeriphDrivers): Fix UART clock source issues

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32670/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/uart.h
@@ -260,6 +260,15 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
  */
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock);
 
+/**
+ * @brief   Gets the clock source used for the UART instance
+ * 
+ * @param   uart         Pointer to UART registers (selects the UART block used.)
+ *
+ * @return  The selected clock source for the UART instance
+ */
+mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart);
+
 /* ************************************************************************* */
 /* Low-level functions                                                       */
 /* ************************************************************************* */

--- a/Libraries/PeriphDrivers/Include/MAX32672/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/uart.h
@@ -276,6 +276,15 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
  */
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock);
 
+/**
+ * @brief   Gets the clock source used for the UART instance
+ * 
+ * @param   uart         Pointer to UART registers (selects the UART block used.)
+ *
+ * @return  The selected clock source for the UART instance
+ */
+mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart);
+
 /* ************************************************************************* */
 /* Low-level functions                                                       */
 /* ************************************************************************* */

--- a/Libraries/PeriphDrivers/Include/MAX32672/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/uart.h
@@ -82,11 +82,10 @@ typedef enum {
     MXC_UART_EXT_CLK = 1,
     /*8M (IBRO) and 32M (EFRO) clocks can be used for UARTs 0,1 and 2*/
     MXC_UART_IBRO_CLK = 2,
-    MXC_UART_ERFO_CLK = 3,
     /*32K (ERTCO) and 80K (INRO) clocks can only be used for UART3*/
-    MXC_UART_ERTCO_CLK = 4,
-    MXC_UART_INRO_CLK = 5,
-    MXC_UART_AOD_CLK = 6
+    MXC_UART_ERTCO_CLK = 3,
+    MXC_UART_INRO_CLK = 4,
+    MXC_UART_AOD_CLK = 5
 } mxc_uart_clock_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32675/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/uart.h
@@ -80,12 +80,9 @@ typedef enum {
 typedef enum {
     MXC_UART_APB_CLK = 0,
     MXC_UART_EXT_CLK = 1,
-    /*8M (IBRO) and 32M (EFRO) clocks can be used for UARTs 0,1 and 2*/
+    /*8M (IBRO) and 32M (EFRO) clocks can be used for UARTs 0 and 2*/
     MXC_UART_IBRO_CLK = 2,
     MXC_UART_ERFO_CLK = 3,
-    /*32K (ERTCO) clock can only be used for UART3*/
-    MXC_UART_AOD_CLK = 4,
-    MXC_UART_INRO_CLK = 5
 } mxc_uart_clock_t;
 
 /**

--- a/Libraries/PeriphDrivers/Source/UART/uart_ai85.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_ai85.c
@@ -45,7 +45,7 @@ int MXC_UART_AsyncStop(mxc_uart_regs_t *uart)
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
     int retval;
-
+#ifndef MSDK_NO_GPIO_CLK_INIT
     retval = MXC_UART_Shutdown(uart);
     if (retval) {
         return retval;
@@ -75,6 +75,7 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     default:
         return E_BAD_PARAM;
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     retval = MXC_UART_SetClockSource(uart, clock);
     if (retval != E_NO_ERROR) {
@@ -254,7 +255,9 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
             break;
 
         case MXC_UART_IBRO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 2;
             break;
 
@@ -267,12 +270,16 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
         // UART3 (LPUART0) supports IBRO and ERTCO
         switch (clock) {
         case MXC_UART_IBRO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 2;
             break;
 
         case MXC_UART_ERTCO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 3;
             break;
 

--- a/Libraries/PeriphDrivers/Source/UART/uart_ai85.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_ai85.c
@@ -81,7 +81,7 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
         return retval;
     }
 
-    return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, clock);
+    return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, MXC_UART_GetClockSource(uart));
 }
 
 int MXC_UART_Shutdown(mxc_uart_regs_t *uart)

--- a/Libraries/PeriphDrivers/Source/UART/uart_ai87.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_ai87.c
@@ -61,7 +61,7 @@ void MXC_UART_UnlockClockSource(mxc_uart_regs_t *uart)
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
     int err;
-
+#ifndef MSDK_NO_GPIO_CLK_INIT
     err = MXC_UART_Shutdown(uart);
 
     if (err) {
@@ -92,6 +92,7 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     default:
         return E_BAD_PARAM;
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     err = MXC_UART_SetClockSource(uart, clock);
     if (err)
@@ -282,7 +283,9 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
             break;
 
         case MXC_UART_IBRO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 2;
             break;
 
@@ -294,12 +297,16 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
         // UART3 (LPUART0) supports IBRO and ERTCO
         switch (clock) {
         case MXC_UART_IBRO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 0;
             break;
 
         case MXC_UART_ERTCO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 1;
             break;
 

--- a/Libraries/PeriphDrivers/Source/UART/uart_ai87.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_ai87.c
@@ -261,6 +261,7 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
     int err = E_NO_ERROR;
+    uint8_t clock_option = 0;
     int idx = MXC_UART_GET_IDX(uart);
     if (idx < 0)
         return E_BAD_PARAM;
@@ -277,12 +278,12 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
         // UART0-2 support PCLK and IBRO
         switch (clock) {
         case MXC_UART_APB_CLK:
-            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
+            clock_option = 0;
             break;
 
         case MXC_UART_IBRO_CLK:
             err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
+            clock_option = 2;
             break;
 
         default:
@@ -294,12 +295,12 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
         switch (clock) {
         case MXC_UART_IBRO_CLK:
             err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
+            clock_option = 0;
             break;
 
         case MXC_UART_ERTCO_CLK:
             err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
-            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 1);
+            clock_option = 1;
             break;
 
         default:
@@ -308,7 +309,10 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
         break;
     }
 
-    return err;
+    if (err)
+        return err;
+
+    return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock_option);
 }
 
 mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart)

--- a/Libraries/PeriphDrivers/Source/UART/uart_me12.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me12.c
@@ -217,17 +217,23 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
         break;
 
     case MXC_UART_EXT_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
         error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_EXTCLK);
+#endif // MSDK_NO_GPIO_CLK_INIT
         MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 1);
         break;
 
     case MXC_UART_IBRO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
         error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+#endif // MSDK_NO_GPIO_CLK_INIT
         MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
         break;
 
     case MXC_UART_ERFO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
         error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+#endif // MSDK_NO_GPIO_CLK_INIT
         MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 3);
         break;
 

--- a/Libraries/PeriphDrivers/Source/UART/uart_me15.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me15.c
@@ -317,15 +317,21 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
             clock_option = 0;
             break;
         case MXC_UART_EXT_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             MXC_GPIO_Config(&gpio_cfg_hfextclk);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 1;
             break;
         case MXC_UART_IBRO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 2;
             break;
         case MXC_UART_ERFO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 3;
             break;
         default:
@@ -338,11 +344,15 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
             clock_option = 0;
             break;
         case MXC_UART_EXT_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             MXC_GPIO_Config(&gpio_cfg_lpextclk);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 1;
             break;
         case MXC_UART_ERTCO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 2;
             break;
         case MXC_UART_INRO_CLK:

--- a/Libraries/PeriphDrivers/Source/UART/uart_me15.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me15.c
@@ -86,7 +86,7 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     if (retval)
         return retval;
 
-    return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, clock);
+    return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, MXC_UART_GetClockSource(uart));
 }
 
 int MXC_UART_Shutdown(mxc_uart_regs_t *uart)
@@ -354,6 +354,45 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
     }
 
     return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock_option);
+}
+
+mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart)
+{
+    unsigned int clock_option = MXC_UART_RevB_GetClockSource((mxc_uart_revb_regs_t *)uart);
+    switch (MXC_UART_GET_IDX(uart)) {
+    case 0:
+    case 1:
+    case 2:
+        switch (clock_option) {
+        case 0:
+            return MXC_UART_APB_CLK;
+        case 1:
+            return MXC_UART_EXT_CLK;
+        case 2:
+            return MXC_UART_IBRO_CLK;
+        case 3:
+            return MXC_UART_ERFO_CLK;
+        default:
+            return E_BAD_STATE;
+        }
+        break;
+    case 3:
+        switch (clock_option) {
+        case 0:
+            return MXC_UART_AOD_CLK;
+        case 1:
+            return MXC_UART_EXT_CLK;
+        case 2:
+            return MXC_UART_ERTCO_CLK;
+        case 3:
+            return MXC_UART_INRO_CLK;
+        default:
+            return E_BAD_STATE;
+        }
+        break;
+    default:
+        return E_BAD_PARAM;
+    }
 }
 
 int MXC_UART_GetActive(mxc_uart_regs_t *uart)

--- a/Libraries/PeriphDrivers/Source/UART/uart_me15.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me15.c
@@ -54,35 +54,6 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
         return retval;
     }
 
-    switch (clock) {
-    case MXC_UART_EXT_CLK:
-        if (uart == MXC_UART3) {
-            MXC_GPIO_Config(&gpio_cfg_lpextclk);
-        } else {
-            MXC_GPIO_Config(&gpio_cfg_hfextclk);
-        }
-        break;
-
-    case MXC_UART_ERTCO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
-        break;
-
-    case MXC_UART_IBRO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-        break;
-
-    case MXC_UART_ERFO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
-        break;
-
-    case MXC_UART_INRO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_INRO);
-        break;
-
-    default:
-        break;
-    }
-
     switch (MXC_UART_GET_IDX(uart)) {
     case 0:
         MXC_GPIO_Config(&gpio_cfg_uart0);
@@ -346,6 +317,7 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
             clock_option = 0;
             break;
         case MXC_UART_EXT_CLK:
+            MXC_GPIO_Config(&gpio_cfg_hfextclk);
             clock_option = 1;
             break;
         case MXC_UART_IBRO_CLK:
@@ -366,9 +338,11 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
             clock_option = 0;
             break;
         case MXC_UART_EXT_CLK:
+            MXC_GPIO_Config(&gpio_cfg_lpextclk);
             clock_option = 1;
             break;
         case MXC_UART_ERTCO_CLK:
+            MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
             clock_option = 2;
             break;
         case MXC_UART_INRO_CLK:

--- a/Libraries/PeriphDrivers/Source/UART/uart_me16.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me16.c
@@ -246,15 +246,21 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
         MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
         break;
     case MXC_UART_EXT_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
         MXC_GPIO_Config(&gpio_cfg_extclk);
+#endif // MSDK_NO_GPIO_CLK_INIT
         MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 1);
         break;
     case MXC_UART_IBRO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
         MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+#endif // MSDK_NO_GPIO_CLK_INIT
         MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
         break;
     case MXC_UART_ERFO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
         MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+#endif // MSDK_NO_GPIO_CLK_INIT
         MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 3);
         break;
     default:

--- a/Libraries/PeriphDrivers/Source/UART/uart_me16.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me16.c
@@ -50,32 +50,9 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
 {
     int retval;
 #ifndef MSDK_NO_GPIO_CLK_INIT
-    int error;
-
     retval = MXC_UART_Shutdown(uart);
     if (retval) {
         return retval;
-    }
-
-    switch (clock) {
-    case MXC_UART_EXT_CLK:
-        MXC_GPIO_Config(&gpio_cfg_extclk);
-        break;
-
-    case MXC_UART_IBRO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-        break;
-
-    case MXC_UART_ERFO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
-        break;
-
-    case MXC_UART_INRO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_INRO);
-        break;
-
-    default:
-        break;
     }
 
     switch (MXC_UART_GET_IDX(uart)) {
@@ -85,9 +62,9 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
         break;
 
     case 2: // Can't use UART2 when HART Modem is used for MAX32675.
-        error = MXC_GPIO_Config(&gpio_cfg_uart2);
-        if (error != E_NO_ERROR) {
-            return error;
+        retval = MXC_GPIO_Config(&gpio_cfg_uart2);
+        if (retval) {
+            return retval;
         }
 
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_UART2);
@@ -134,7 +111,6 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
 {
     int freq;
     uint32_t clock_freq = 0;
-    uint32_t aon_clk_div = 0;
 
     if (MXC_UART_GET_IDX(uart) < 0) {
         return E_BAD_PARAM;
@@ -162,19 +138,6 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
     case MXC_UART_ERFO_CLK:
         clock_freq = ERFO_FREQ;
         break;
-    case MXC_UART_AOD_CLK:
-        aon_clk_div = (MXC_GCR->pclkdiv & MXC_F_GCR_PCLKDIV_AON_CLKDIV) >>
-                      MXC_F_GCR_PCLKDIV_AON_CLKDIV_POS;
-        clock_freq = PeripheralClock / (4 * (pow(2, aon_clk_div)));
-        break;
-    case MXC_UART_INRO_CLK:
-        clock_freq = INRO_FREQ;
-        uart->ctrl |= MXC_F_UART_CTRL_FDM;
-        if (baud > 2400) {
-            uart->osr = 0;
-        } else {
-            uart->osr = 1;
-        }
     default:
         return E_BAD_PARAM;
     }
@@ -272,51 +235,33 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
 
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
-    uint8_t clock_option = 0;
+    uint8_t retval = E_NO_ERROR;
 
-    switch (MXC_UART_GET_IDX(uart)) {
-    case 0:
-    case 1:
-    case 2:
-        switch (clock) {
-        case MXC_UART_APB_CLK:
-            clock_option = 0;
-            break;
-        case MXC_UART_EXT_CLK:
-            clock_option = 1;
-            break;
-        case MXC_UART_IBRO_CLK:
-            MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-            clock_option = 2;
-            break;
-        case MXC_UART_ERFO_CLK:
-            MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
-            clock_option = 3;
-            break;
-        default:
-            return E_BAD_PARAM;
-        }
+    if (MXC_UART_GET_IDX(uart) != 0 || MXC_UART_GET_IDX(uart) != 2) {
+        return E_BAD_PARAM;
+    }
+
+    switch (clock) {
+    case MXC_UART_APB_CLK:
+        MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
         break;
-    case 3:
-        switch (clock) {
-        case MXC_UART_AOD_CLK:
-            clock_option = 0;
-            break;
-        case MXC_UART_EXT_CLK:
-            clock_option = 1;
-            break;
-        case MXC_UART_INRO_CLK:
-            clock_option = 3;
-            break;
-        default:
-            return E_BAD_PARAM;
-        }
+    case MXC_UART_EXT_CLK:
+        MXC_GPIO_Config(&gpio_cfg_extclk);
+        MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 1);
+        break;
+    case MXC_UART_IBRO_CLK:
+        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+        MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
+        break;
+    case MXC_UART_ERFO_CLK:
+        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+        MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 3);
         break;
     default:
         return E_BAD_PARAM;
     }
 
-    return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock_option);
+    return retval;
 }
 
 int MXC_UART_GetActive(mxc_uart_regs_t *uart)

--- a/Libraries/PeriphDrivers/Source/UART/uart_me17.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me17.c
@@ -270,7 +270,9 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
             break;
 
         case MXC_UART_IBRO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
             break;
 
@@ -283,12 +285,16 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
         // UART3 (LPUART0) supports IBRO and ERTCO
         switch (clock) {
         case MXC_UART_IBRO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
             break;
 
         case MXC_UART_ERTCO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 1);
             break;
 

--- a/Libraries/PeriphDrivers/Source/UART/uart_me18.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me18.c
@@ -78,7 +78,7 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     default:
         return E_BAD_PARAM;
     }
-#endif
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     retval = MXC_UART_SetClockSource(uart, clock);
     if (retval)
@@ -332,12 +332,16 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
             break;
 
         case MXC_UART_ERFO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 1;
             break;
 
         case MXC_UART_IBRO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 2;
             break;
 
@@ -349,12 +353,16 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
         // UART3 (LPUART0) supports IBRO and ERTCO
         switch (clock) {
         case MXC_UART_IBRO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 0;
             break;
 
         case MXC_UART_ERTCO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 1;
             break;
 

--- a/Libraries/PeriphDrivers/Source/UART/uart_me18.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me18.c
@@ -314,7 +314,8 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
 
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
-    int err = E_NO_ERROR;
+    int retval = E_NO_ERROR;
+    uint8_t clock_option = 0;
     int idx = MXC_UART_GET_IDX(uart);
     if (idx < 0)
         return E_BAD_PARAM;
@@ -327,17 +328,17 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
         // UART0-2 support PCLK, ERFO, & IBRO
         switch (clock) {
         case MXC_UART_APB_CLK:
-            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
+            clock_option = 0;
             break;
 
         case MXC_UART_ERFO_CLK:
-            err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
-            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 1);
+            retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
+            clock_option = 1;
             break;
 
         case MXC_UART_IBRO_CLK:
-            err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 2);
+            retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+            clock_option = 2;
             break;
 
         default:
@@ -348,22 +349,28 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
         // UART3 (LPUART0) supports IBRO and ERTCO
         switch (clock) {
         case MXC_UART_IBRO_CLK:
-            err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 0);
+            retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+            clock_option = 0;
             break;
 
         case MXC_UART_ERTCO_CLK:
-            err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
-            MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, 1);
+            retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+            clock_option = 1;
             break;
 
         default:
             return E_BAD_PARAM;
         }
         break;
+
+    default:
+        return E_BAD_PARAM;
     }
 
-    return err;
+    if (retval)
+        return retval;
+
+    return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock_option);
 }
 
 mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart)

--- a/Libraries/PeriphDrivers/Source/UART/uart_me21.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me21.c
@@ -79,35 +79,6 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
         return retval;
     }
 
-    switch (clock) {
-    case MXC_UART_EXT_CLK:
-        if (uart == MXC_UART3) {
-            MXC_GPIO_Config(&gpio_cfg_lpextclk);
-        } else {
-            MXC_GPIO_Config(&gpio_cfg_hfextclk);
-        }
-        break;
-
-    case MXC_UART_ERTCO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
-        break;
-
-    case MXC_UART_IBRO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
-        break;
-
-    case MXC_UART_ERFO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
-        break;
-
-    case MXC_UART_INRO_CLK:
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_INRO);
-        break;
-
-    default:
-        break;
-    }
-
     switch (MXC_UART_GET_IDX(uart)) {
     case 0:
         if (current_pin_mapping == MAP_A) {
@@ -352,7 +323,7 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
 
 int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
-    int error = E_NO_ERROR;
+    int retval = E_NO_ERROR;
     uint8_t clock_option = 0;
 
     switch (MXC_UART_GET_IDX(uart)) {
@@ -366,11 +337,12 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
             break;
 
         case MXC_UART_EXT_CLK:
+            retval = MXC_GPIO_Config(&gpio_cfg_hfextclk);
             clock_option = 1;
             break;
 
         case MXC_UART_IBRO_CLK:
-            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+            retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
             clock_option = 2;
             break;
 
@@ -387,16 +359,16 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
             break;
 
         case MXC_UART_EXT_CLK:
+            retval = MXC_GPIO_Config(&gpio_cfg_lpextclk);
             clock_option = 1;
             break;
 
         case MXC_UART_INRO_CLK:
-            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_INRO);
             clock_option = 2;
             break;
 
         case MXC_UART_ERTCO_CLK:
-            error = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+            retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
             clock_option = 3;
             break;
 
@@ -409,8 +381,8 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
         return E_BAD_PARAM;
     }
 
-    if (error)
-        return error;
+    if (retval)
+        return retval;
 
     return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock_option);
 }

--- a/Libraries/PeriphDrivers/Source/UART/uart_me21.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me21.c
@@ -123,7 +123,7 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     if (retval)
         return retval;
 
-    return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, clock);
+    return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, MXC_UART_GetClockSource(uart));
 }
 
 int MXC_UART_Shutdown(mxc_uart_regs_t *uart)
@@ -385,6 +385,43 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
         return retval;
 
     return MXC_UART_RevB_SetClockSource((mxc_uart_revb_regs_t *)uart, clock_option);
+}
+
+mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart)
+{
+    unsigned int clock_option = MXC_UART_RevB_GetClockSource((mxc_uart_revb_regs_t *)uart);
+    switch (MXC_UART_GET_IDX(uart)) {
+    case 0:
+    case 1:
+    case 2:
+        switch (clock_option) {
+        case 0:
+            return MXC_UART_APB_CLK;
+        case 1:
+            return MXC_UART_EXT_CLK;
+        case 2:
+            return MXC_UART_IBRO_CLK;
+        default:
+            return E_BAD_STATE;
+        }
+        break;
+    case 3:
+        switch (clock_option) {
+        case 0:
+            return MXC_UART_AOD_CLK;
+        case 1:
+            return MXC_UART_EXT_CLK;
+        case 2:
+            return MXC_UART_INRO_CLK;
+        case 3:
+            return MXC_UART_ERTCO_CLK;
+        default:
+            return E_BAD_STATE;
+        }
+        break;
+    default:
+        return E_BAD_PARAM;
+    }
 }
 
 int MXC_UART_GetActive(mxc_uart_regs_t *uart)

--- a/Libraries/PeriphDrivers/Source/UART/uart_me21.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me21.c
@@ -337,12 +337,16 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
             break;
 
         case MXC_UART_EXT_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             retval = MXC_GPIO_Config(&gpio_cfg_hfextclk);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 1;
             break;
 
         case MXC_UART_IBRO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 2;
             break;
 
@@ -359,7 +363,9 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
             break;
 
         case MXC_UART_EXT_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             retval = MXC_GPIO_Config(&gpio_cfg_lpextclk);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 1;
             break;
 
@@ -368,7 +374,9 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
             break;
 
         case MXC_UART_ERTCO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
             retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+#endif // MSDK_NO_GPIO_CLK_INIT
             clock_option = 3;
             break;
 


### PR DESCRIPTION
### Description

With new UART RevB clock source selection updates, some problems occurred on Zephyr RTOS side. Also, I noticed some problems about MSDK side too. In this PR, 

- Fixed these build issues.
- Disabled GPIO and clock enablement for Zephyr side.
- To avoid from duplication, I moved clock source enablement from init function to clock source selection function.
- Added get function for clock source for ME15 and ME21

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.