### PR TITLE
chore(Other, PeriphDrivers): Fix MAX32657 build issue

### DIFF
--- a/Libraries/PeriphDrivers/Source/SYS/sys_me30.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me30.c
@@ -504,6 +504,7 @@ void MXC_SYS_Reset_Periph(mxc_sys_reset_t reset)
     }
 }
 
+#if CONFIG_TRUSTED_EXECUTION_SECURE
 /* ************************************************************************** */
 int MXC_SYS_LockDAP_Permanent(void)
 {
@@ -542,5 +543,6 @@ int MXC_SYS_LockDAP_Permanent(void)
     return err;
 #endif
 }
+#endif
 
 /**@} end of mxc_sys */

--- a/Libraries/zephyr/MAX/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/CMakeLists.txt
@@ -40,6 +40,7 @@ set(MSDK_PERIPH_INC_DIR  ${MSDK_PERIPH_DIR}/Include/${TARGET_UC})
 
 zephyr_include_directories(
     ./Include
+    ./Source/${TARGET_UC}
     ${MSDK_LIBRARY_DIR}/CMSIS/Include
     ${MSDK_CMSIS_DIR}/Include
     ${MSDK_PERIPH_INC_DIR}

--- a/Libraries/zephyr/MAX/Source/MAX32657/partition_max32657.h
+++ b/Libraries/zephyr/MAX/Source/MAX32657/partition_max32657.h
@@ -1,0 +1,27 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2024 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#ifndef LIBRARIES_ZEPHYR_MAX_SOURCE_MAX32657_PARTITION_MAX32657_H_
+#define LIBRARIES_ZEPHYR_MAX_SOURCE_MAX32657_PARTITION_MAX32657_H_
+
+void TZ_SAU_Setup(void)
+{
+    /* Added empty function to use MSDK file as it is */
+}
+
+#endif // LIBRARIES_ZEPHYR_MAX_SOURCE_MAX32657_PARTITION_MAX32657_H_


### PR DESCRIPTION
This PR apply fix for MAX32657 zephyr.

- MXC_SYS_LockDAP_Permanent should be called only for secure mode
- Empty partition_max32657.h file added to it build on zephyr side as it is

![image](https://github.com/user-attachments/assets/b55184a7-6143-420b-bace-c509e30c0de5)

![image](https://github.com/user-attachments/assets/27a61e0d-4860-47e6-92ae-f184f07d2a81)

### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
