### PR TITLE
fix(Other): Add I3C to MAX32657 Zephyr build

### DIFF
--- a/Libraries/zephyr/MAX/Source/MAX32657/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32657/CMakeLists.txt
@@ -39,7 +39,7 @@ zephyr_include_directories(
     ${MSDK_PERIPH_SRC_DIR}/DMA
     ${MSDK_PERIPH_SRC_DIR}/FLC
     ${MSDK_PERIPH_SRC_DIR}/GPIO
-    ${MSDK_PERIPH_SRC_DIR}/I2C
+    ${MSDK_PERIPH_SRC_DIR}/I3C
     ${MSDK_PERIPH_SRC_DIR}/ICC
     ${MSDK_PERIPH_SRC_DIR}/LP
     ${MSDK_PERIPH_SRC_DIR}/RTC
@@ -97,10 +97,10 @@ zephyr_library_sources(
 )
 endif()
 
-if (CONFIG_I2C_MAX32)
+if (CONFIG_I3C_MAX32)
 zephyr_library_sources(
-    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_me30.c
-    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_reva.c
+    ${MSDK_PERIPH_SRC_DIR}/I3C/i3c_me30.c
+    ${MSDK_PERIPH_SRC_DIR}/I3C/i3c_reva.c
 )
 endif()
 


### PR DESCRIPTION
### Description

MAX32657 does not have a separate I2C controller. Replace I2C with I3C in Zephyr's CMakeLists.txt.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
