### PR TITLE
chore(Other, PeriphDrivers): Fix MAX32xxx UART build issue

### DIFF
--- a/Libraries/PeriphDrivers/Source/UART/uart_me12.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me12.c
@@ -43,9 +43,9 @@ int MXC_UART_AsyncStop(mxc_uart_regs_t *uart)
 
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock, sys_map_t map)
 {
-#ifndef MSDK_NO_GPIO_CLK_INIT
     int retval;
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     retval = MXC_UART_Shutdown(uart);
     if (retval) {
         return retval;

--- a/Libraries/PeriphDrivers/Source/UART/uart_me15.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me15.c
@@ -45,9 +45,9 @@ int MXC_UART_AsyncStop(mxc_uart_regs_t *uart)
 
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
-#ifndef MSDK_NO_GPIO_CLK_INIT
     int retval;
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     retval = MXC_UART_Shutdown(uart);
 
     if (retval) {

--- a/Libraries/PeriphDrivers/Source/UART/uart_me16.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me16.c
@@ -48,8 +48,9 @@ int MXC_UART_AsyncStop(mxc_uart_regs_t *uart)
 
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
+    int retval;
 #ifndef MSDK_NO_GPIO_CLK_INIT
-    int retval, error;
+    int error;
 
     retval = MXC_UART_Shutdown(uart);
     if (retval) {

--- a/Libraries/PeriphDrivers/Source/UART/uart_me17.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me17.c
@@ -44,9 +44,9 @@ int MXC_UART_AsyncStop(mxc_uart_regs_t *uart)
 
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
-#ifndef MSDK_NO_GPIO_CLK_INIT
     int retval;
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     retval = MXC_UART_Shutdown(uart);
     if (retval) {
         return retval;

--- a/Libraries/PeriphDrivers/Source/UART/uart_me18.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me18.c
@@ -44,7 +44,6 @@ int MXC_UART_AsyncStop(mxc_uart_regs_t *uart)
 
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
-#ifndef MSDK_NO_GPIO_CLK_INIT
     int retval;
 
     if (!MXC_UART_RevB_IsClockSourceLocked((mxc_uart_revb_regs_t *)uart)) {
@@ -54,6 +53,7 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
         }
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     switch (MXC_UART_GET_IDX(uart)) {
     case 0:
         MXC_GPIO_Config(&gpio_cfg_uart0);
@@ -78,11 +78,11 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     default:
         return E_BAD_PARAM;
     }
+#endif
 
     retval = MXC_UART_SetClockSource(uart, clock);
     if (retval)
         return retval;
-#endif
 
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, MXC_UART_GetClockSource(uart));
 }

--- a/Libraries/PeriphDrivers/Source/UART/uart_me21.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me21.c
@@ -69,8 +69,8 @@ int MXC_UART_AsyncStop(mxc_uart_regs_t *uart)
 
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
-#ifndef MSDK_NO_GPIO_CLK_INIT
     int retval;
+#ifndef MSDK_NO_GPIO_CLK_INIT
     sys_map_t current_pin_mapping = MXC_UART_GetPinMapping(uart);
 
     retval = MXC_UART_Shutdown(uart);


### PR DESCRIPTION
While adding MXC_UART_SetClockSource(uart, clock); function it seems zephyr build been broken
this commit fix them for UART

![image](https://github.com/user-attachments/assets/caa1ff0b-771a-4759-9729-835ca80bcd63)


### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
