### PR TITLE
chore(BLE): Added BLE stack to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ package.json
 .python-version
 mxc_version.h
 mxc_version.mk
+Packetcraft-ADI
+packetcraft-adi

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_max32690.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_max32690.c
@@ -134,6 +134,7 @@ __weak void PalSysInit(void) {}
  */
 __weak void SystemInit(void)
 {
+    __NOP();
 #ifdef DEBUG
     /* Delay to prevent bricks */
     volatile int i;


### PR DESCRIPTION
### Description

- Added new BLE stack to gitignore
- Added NOP to fix cache issue on legacy MAX32690 parts.