### PR TITLE
feat(CMSIS): Add CMSIS 6.0 support to MAX32657

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.h
@@ -152,7 +152,12 @@ typedef enum {
 #define __Vendor_SysTickConfig 0U /**< Is 1 if different SysTick counter is used */
 
 #include <core_cm33.h>
+#if (__CM_CMSIS_VERSION == 0x60000)
+/* If CMSIS version 6.0 use cmsis_gcc_m.h */
+#include <cmsis_gcc_m.h>
+#else
 #include <cmsis_gcc.h>
+#endif
 #include <arm_cmse.h>
 
 #if defined(__GNUC__)


### PR DESCRIPTION
Use cmsis_gcc_m for MAX32657 if CMSIS version equal to [v6.0](https://github.com/ARM-software/CMSIS_6/blob/v6.0.0/CMSIS/Core/Include/cmsis_version.h)
With CMSIS 6.0 cmsis_gcc.h file has been replaced with cmsis_gcc_m.h.
[TF-M uses CMSIS v6.0](https://github.com/zephyrproject-rtos/trusted-firmware-m/blob/main/platform/ext/cmsis/CMSIS/Core/Include/cmsis_version.h) to support TF-M without adding a wrapper file max32657.h file has been updated.

After cmsis v6.0 ([v6.1](https://github.com/ARM-software/CMSIS_6/blob/v6.1.0/CMSIS/Core/Include/cmsis_version.h)) , cmsis_gcc.h file added inside CMSIS files so exception case should be executed just for v6.0

### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
