### PR TITLE
fix(PeriphDrivers): Improve accuracy of timer stop watch

### DIFF
--- a/Libraries/PeriphDrivers/Source/TMR/tmr_reva.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_reva.c
@@ -235,7 +235,7 @@ int MXC_TMR_RevA_GetTime(mxc_tmr_reva_regs_t *tmr, uint32_t ticks, uint32_t *tim
         ((tmr->cn & MXC_F_TMR_REVA_CN_PRES) >> MXC_F_TMR_REVA_CN_PRES_POS) |
         (((tmr->cn & MXC_F_TMR_REVA_CN_PRES3) >> (MXC_F_TMR_REVA_CN_PRES3_POS)) << 3);
 
-    temp_time = (uint64_t)ticks * 1000 * (1 << (prescale & 0xF)) / (timerClock / 1000000);
+    temp_time = (uint64_t)ticks * 1000000 * (1 << (prescale & 0xF)) / (timerClock / 1000);
 
     if (!(temp_time & 0xffffffff00000000)) {
         *time = temp_time;
@@ -243,7 +243,7 @@ int MXC_TMR_RevA_GetTime(mxc_tmr_reva_regs_t *tmr, uint32_t ticks, uint32_t *tim
         return E_NO_ERROR;
     }
 
-    temp_time = (uint64_t)ticks * 1000 * (1 << (prescale & 0xF)) / (timerClock / 1000);
+    temp_time = (uint64_t)ticks * 1000000 * (1 << (prescale & 0xF)) / timerClock;
 
     if (!(temp_time & 0xffffffff00000000)) {
         *time = temp_time;

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
@@ -507,7 +507,7 @@ int MXC_TMR_RevB_GetTime(mxc_tmr_revb_regs_t *tmr, uint32_t ticks, uint32_t *tim
         return timerClock;
     }
 
-    temp_time = (uint64_t)ticks * 1000 * (1 << (prescale & 0xF)) / (timerClock / 1000000);
+    temp_time = (uint64_t)ticks * 1000000 * (1 << (prescale & 0xF)) / (timerClock / 1000);
 
     if (!(temp_time & 0xffffffff00000000)) {
         *time = temp_time;
@@ -515,7 +515,7 @@ int MXC_TMR_RevB_GetTime(mxc_tmr_revb_regs_t *tmr, uint32_t ticks, uint32_t *tim
         return E_NO_ERROR;
     }
 
-    temp_time = (uint64_t)ticks * 1000 * (1 << (prescale & 0xF)) / (timerClock / 1000);
+    temp_time = (uint64_t)ticks * 1000000 * (1 << (prescale & 0xF)) / timerClock;
 
     if (!(temp_time & 0xffffffff00000000)) {
         *time = temp_time;

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revc.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revc.c
@@ -293,7 +293,7 @@ int MXC_TMR_RevC_GetTime(mxc_tmr_regs_t *tmr, uint32_t ticks, uint32_t *time, mx
     uint32_t prescale = (((tmr->cn & MXC_F_TMR_CN_PRES) >> MXC_F_TMR_CN_PRES_POS) |
                          ((((tmr->cn & MXC_F_TMR_CN_PRES3) >> (MXC_F_TMR_CN_PRES3_POS)) << 3)));
 
-    temp_time = (uint64_t)ticks * 1000 * (1 << (prescale & 0xF)) / (timerClock / 1000000);
+    temp_time = (uint64_t)ticks * 1000000 * (1 << (prescale & 0xF)) / (timerClock / 1000);
 
     if (!(temp_time & 0xffffffff00000000)) {
         *time = temp_time;
@@ -301,7 +301,7 @@ int MXC_TMR_RevC_GetTime(mxc_tmr_regs_t *tmr, uint32_t ticks, uint32_t *time, mx
         return E_NO_ERROR;
     }
 
-    temp_time = (uint64_t)ticks * 1000 * (1 << (prescale & 0xF)) / (timerClock / 1000);
+    temp_time = (uint64_t)ticks * 1000000 * (1 << (prescale & 0xF)) / timerClock;
 
     if (!(temp_time & 0xffffffff00000000)) {
         *time = temp_time;


### PR DESCRIPTION
### Description

When the timer frequency is small, e.g. 1.8MHz, then dividing this frequency by 1000000 as an integer gives a huge error since it will round down to 1. Improve things by only dividing by 1000 rather than 1000000. We can multiply by 1000 in the numerator, because the prescale value is at most 128, and so 128 * 1000000 fits in uint32_t, and this is then multiplied by ticks which is also 32 bits but widened to 64 bits for the multiply. So the numerator won't overflow.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.