### PR TITLE
fix(PeriphDrivers): Don't cache TMR clock frequency if locked

### DIFF
--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
@@ -182,6 +182,11 @@ void MXC_TMR_RevB_SetClockSourceFreq(mxc_tmr_revb_regs_t *tmr, int clksrc_freq)
     (void)tmr_id;
     MXC_ASSERT(tmr_id >= 0);
 
+    // If the clock source is locked, don't update the frequency either, as we will
+    // have rejected the configuration update too in MXC_TMR_RevB_SetClockSource.
+    if (g_is_clock_locked[tmr_id])
+        return;
+
     tmr_clksrc[tmr_id].configured = true;
     tmr_clksrc[tmr_id].freq = clksrc_freq;
 }


### PR DESCRIPTION
### Description

We have a locking mechanism so that if we've locked the TMR clock, then calling MXC_TMR_Init() function doesn't reset them.

However, the lock check is implemented in MXC_TMR_RevB_SetClockSource, which is called by MXC_TMR_SetClockSource. However, MXC_TMR_SetClockSource also calls MXC_TMR_RevB_SetClockSourceFreq, which has no lock check.

The result is that if MXC_TMR_Init is called with a clock source of, say, ERFO, then we cache the new frequency, 32MHz, but then don't reconfigure the MMRs to actually run using ERFO. So the TMR driver operates believing it is running at 32MHz, but actually running at something else. This means that things like the Stop Watch timer report the wrong wall time.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.