### PR TITLE
fix(PeriphDrivers): Corrected pin definitions for BLE chips

### DIFF
--- a/Libraries/PeriphDrivers/Source/SYS/pins_me17.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_me17.c
@@ -31,7 +31,7 @@
 /***** Global Variables *****/
 
 // clang-format off
-const mxc_gpio_cfg_t gpio_cfg_extclk = { MXC_GPIO0, (MXC_GPIO_PIN_12 | MXC_GPIO_PIN_13), MXC_GPIO_FUNC_ALT2,
+const mxc_gpio_cfg_t gpio_cfg_extclk = { MXC_GPIO0, MXC_GPIO_PIN_3 , MXC_GPIO_FUNC_ALT1,
                                          MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
 const mxc_gpio_cfg_t gpio_cfg_i2c0 = { MXC_GPIO0, (MXC_GPIO_PIN_10 | MXC_GPIO_PIN_11), MXC_GPIO_FUNC_ALT1,

--- a/Libraries/PeriphDrivers/Source/SYS/pins_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_me18.c
@@ -88,9 +88,9 @@ const mxc_gpio_cfg_t gpio_cfg_uart3_flow_disable = { MXC_GPIO3, (MXC_GPIO_PIN_2 
                                                      MXC_GPIO_FUNC_IN, MXC_GPIO_PAD_WEAK_PULL_UP,
                                                      MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
-const mxc_gpio_cfg_t antenna_ctrl0 = { MXC_GPIO2, (MXC_GPIO_PIN_17), MXC_GPIO_FUNC_ALT2,
+const mxc_gpio_cfg_t antenna_ctrl0 = { MXC_GPIO2, (MXC_GPIO_PIN_18), MXC_GPIO_FUNC_ALT2,
                                        MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t antenna_ctrl1 = { MXC_GPIO2, (MXC_GPIO_PIN_18), MXC_GPIO_FUNC_ALT2,
+const mxc_gpio_cfg_t antenna_ctrl1 = { MXC_GPIO2, (MXC_GPIO_PIN_17), MXC_GPIO_FUNC_ALT2,
                                        MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t antenna_ctrl2 = { MXC_GPIO2, (MXC_GPIO_PIN_20), MXC_GPIO_FUNC_ALT2,
                                        MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };

--- a/Libraries/PeriphDrivers/Source/SYS/pins_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_me18.c
@@ -173,6 +173,9 @@ const mxc_gpio_cfg_t gpio_cfg_spixr = { MXC_GPIO0, (MXC_GPIO_PIN_1 | MXC_GPIO_PI
 const mxc_gpio_cfg_t gpio_cfg_spixf = { MXC_GPIO0, (MXC_GPIO_PIN_1 | MXC_GPIO_PIN_2 | MXC_GPIO_PIN_3 | MXC_GPIO_PIN_4 | MXC_GPIO_PIN_5 |
                                         MXC_GPIO_PIN_6), MXC_GPIO_FUNC_ALT2, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
+const mxc_gpio_cfg_t gpio_cfg_rtcsqw = { MXC_GPIO4, MXC_GPIO_PIN_1, MXC_GPIO_FUNC_ALT1,
+                                         MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+
 const mxc_gpio_cfg_t gpio_cfg_hpb = { MXC_GPIO1, (MXC_GPIO_PIN_12 | MXC_GPIO_PIN_13 | MXC_GPIO_PIN_14 | MXC_GPIO_PIN_15 |
                                       MXC_GPIO_PIN_16 | MXC_GPIO_PIN_18 | MXC_GPIO_PIN_19 | MXC_GPIO_PIN_20 | MXC_GPIO_PIN_21),
                                       MXC_GPIO_FUNC_ALT3, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };

--- a/Libraries/PeriphDrivers/Source/SYS/pins_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_me18.c
@@ -173,9 +173,6 @@ const mxc_gpio_cfg_t gpio_cfg_spixr = { MXC_GPIO0, (MXC_GPIO_PIN_1 | MXC_GPIO_PI
 const mxc_gpio_cfg_t gpio_cfg_spixf = { MXC_GPIO0, (MXC_GPIO_PIN_1 | MXC_GPIO_PIN_2 | MXC_GPIO_PIN_3 | MXC_GPIO_PIN_4 | MXC_GPIO_PIN_5 |
                                         MXC_GPIO_PIN_6), MXC_GPIO_FUNC_ALT2, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
-const mxc_gpio_cfg_t gpio_cfg_rtcsqw = { MXC_GPIO4, MXC_GPIO_PIN_1, MXC_GPIO_FUNC_ALT1,
-                                         MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-
 const mxc_gpio_cfg_t gpio_cfg_hpb = { MXC_GPIO1, (MXC_GPIO_PIN_12 | MXC_GPIO_PIN_13 | MXC_GPIO_PIN_14 | MXC_GPIO_PIN_15 |
                                       MXC_GPIO_PIN_16 | MXC_GPIO_PIN_18 | MXC_GPIO_PIN_19 | MXC_GPIO_PIN_20 | MXC_GPIO_PIN_21),
                                       MXC_GPIO_FUNC_ALT3, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };


### PR DESCRIPTION
### Description

Addresses issues #1182 and #1181

The pins definition for the external clock was wrong. 
It is only available on P0.3, not P0.12 and P0..13. Furthermore, the alternate function was wrong. It is ALT1 not ALT2 

![Screenshot from 2024-09-25 09-46-04](https://github.com/user-attachments/assets/f448c280-a1f3-4659-8edf-2f3b0d25c8c6)

The image above is for the WLP, but the pin mapping is true for all package variants. 


Antenna control 0 and 1 was flipped for ME18

![Screenshot from 2024-09-25 09-56-15](https://github.com/user-attachments/assets/ed67ccb6-cdac-495e-a1af-6aaf16119845)
