### PR TITLE
fix(PeriphDrivers): Resize the USN buffer in checksum verification for MAX32655, MAX32662, and MAX32670

### DIFF
--- a/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
@@ -103,7 +103,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         // Set NULL Key
         MXC_AES_SetExtKey((const void *)aes_key, MXC_AES_128BITS);
 
-        uint8_t usn_copy[MXC_SYS_USN_LEN] = { 0 };
+        uint8_t usn_copy[MXC_SYS_USN_CHECKSUM_LEN] = { 0 };
         memcpy(usn_copy, usn, MXC_SYS_USN_LEN);
         // Compute Checksum
         mxc_aes_req_t aes_req;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
@@ -110,7 +110,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         // Set NULL Key
         MXC_AES_SetExtKey((const void *)aes_key, MXC_AES_128BITS);
 
-        uint8_t usn_copy[MXC_SYS_USN_LEN] = { 0 };
+        uint8_t usn_copy[MXC_SYS_USN_CHECKSUM_LEN] = { 0 };
         memcpy(usn_copy, usn, MXC_SYS_USN_LEN);
 
         // Compute Checksum

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
@@ -105,7 +105,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         // Set NULL Key
         MXC_AES_SetExtKey((const void *)aes_key, MXC_AES_128BITS);
 
-        uint8_t usn_copy[MXC_SYS_USN_LEN] = { 0 };
+        uint8_t usn_copy[MXC_SYS_USN_CHECKSUM_LEN] = { 0 };
         memcpy(usn_copy, usn, MXC_SYS_USN_LEN);
 
         // Compute Checksum


### PR DESCRIPTION
### Description

#### Error
- On ME17, the **BLE4_ctrl** and **BLE5_ctrl** examples were failing a checksum verification in `MXC_SYS_GetUSN()` and were unable to finish executing `PalCfgLoadData()`.
- This error was also found on boards with a similar implementation of `MXC_SYS_GetUSN()`. Namely, ME12 and ME15.

#### Solution
- Change the length of a USN buffer from 13 to 16, which is 4-byte aligned, to successfully pass the checksum verification in `MXC_SYS_GetUSN()`.
- Only the board's respective `sys_me1x.c` file is affected.


The following code snippet may be used to duplicate the error:

```C
/**
 * @file    main.c
 * @brief   Hello World!
 * @details This example uses the UART to print to a terminal and flashes an LED.
 */

/***** Includes *****/
#include <stdio.h>
#include <stdint.h>
#include "mxc_device.h"
#include "led.h"
#include "board.h"
#include "mxc_delay.h"
#include "mxc_sys.h"

int main(void)
{
    uint8_t id[MXC_SYS_USN_LEN] = {0};
    uint8_t checksum[MXC_SYS_USN_CHECKSUM_LEN] = {0};
    int flag = 0;

    if(MXC_SYS_GetUSN((uint8_t*)id, (uint8_t*)checksum) != E_NO_ERROR) {
        flag = 1;
        return;
    }

    
    int count = 0;

    printf("Hello World!\n");

    while (1) {
        LED_On(0);
        MXC_Delay(500000);
        LED_Off(0);
        MXC_Delay(500000);
        printf("count = %d\n", count++);
    }
}

```


