### PR TITLE
fix(Build): Don't update version when working in non-GitHub environments

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
@@ -24,7 +24,7 @@
 
 ifeq "$(PYTHON_CMD)" ""
 # Try python
-ifneq "$(wildcard $(MAXIM_PATH)/.git)" ""
+ifneq "$(wildcard $(MAXIM_PATH)/.github)" ""
 PYTHON_VERSION := $(shell python --version)
 ifneq ($(.SHELLSTATUS),0)
 PYTHON_CMD := none
@@ -46,11 +46,17 @@ endif
 export PYTHON_CMD
 endif
 
-# Run script
+# Make sure script exists before running. This won't run when working in the official MSDK release (non-GitHub)
+ifneq ("$(wildcard $(MAXIM_PATH)/.github)", "")
+# Run script if exists.
 ifneq "$(PYTHON_CMD)" "none"
 UPDATE_VERSION_OUTPUT := $(shell python $(MAXIM_PATH)/.github/workflows/scripts/update_version.py)
 else
 $(warning No Python installation detected on your system!  Will not automatically update version info.)
+endif 
+
+else 
+$(info Not working from GitHub repo.  Will not automatically update version info.)
 endif
 endif
 

--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
@@ -54,9 +54,6 @@ UPDATE_VERSION_OUTPUT := $(shell python $(MAXIM_PATH)/.github/workflows/scripts/
 else
 $(warning No Python installation detected on your system!  Will not automatically update version info.)
 endif 
-
-else 
-$(info Not working from GitHub repo.  Will not automatically update version info.)
 endif
 endif
 

--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
@@ -55,9 +55,6 @@ UPDATE_VERSION_OUTPUT := $(shell python $(MAXIM_PATH)/.github/workflows/scripts/
 else
 $(warning No Python installation detected on your system!  Will not automatically update version info.)
 endif 
-
-else 
-$(info Not working from GitHub repo.  Will not automatically update version info.)
 endif
 endif
 

--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
@@ -47,11 +47,17 @@ endif
 export PYTHON_CMD
 endif
 
-# Run script
+# Make sure script exists before running. This won't run when working in the official MSDK release (non-GitHub)
+ifneq ("$(wildcard $(MAXIM_PATH)/.github)", "")
+# Run script if exists.
 ifneq "$(PYTHON_CMD)" "none"
 UPDATE_VERSION_OUTPUT := $(shell python $(MAXIM_PATH)/.github/workflows/scripts/update_version.py)
 else
 $(warning No Python installation detected on your system!  Will not automatically update version info.)
+endif 
+
+else 
+$(info Not working from GitHub repo.  Will not automatically update version info.)
 endif
 endif
 


### PR DESCRIPTION
### Description

This was added after the March 2024 release. Before this change, I noticed a non-critical python error at the beginning of the build.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.