### PR TITLE
fix(PeriphDrivers): Correct HART UART Driver Transmit Bugs

### DIFF
--- a/Libraries/PeriphDrivers/Source/AFE/afe.c
+++ b/Libraries/PeriphDrivers/Source/AFE/afe.c
@@ -65,7 +65,7 @@
 
 //
 // Enabling this will use the afe timer to timeout polling of the AFE.
-//  This avoid any chance of the blocking function afe_spi_transceive from never returning.
+//  This avoids any chance of the blocking function afe_spi_transceive from never returning.
 //  However, as this low level function can be called several times for even a single
 //  AFE register read, it decreases throughput to and from the AFE.
 //  When running at lower system clock frequencies this can be more of a concern.
@@ -524,7 +524,7 @@ static int afe_spi_transceive(uint8_t *data, int byte_length)
 #else // Not AFE_SPI_TRANSCEIVE_SAFE_BUT_SLOWER
 
 //
-// This function blocks until transceive is completed, or times out
+// This function blocks until transceive is completed
 //  This version does not use the afe timer to interrupt potential infinite polling.
 //
 static int afe_spi_transceive(uint8_t *data, int byte_length)

--- a/Libraries/PeriphDrivers/Source/AFE/hart_uart.c
+++ b/Libraries/PeriphDrivers/Source/AFE/hart_uart.c
@@ -1009,6 +1009,9 @@ int hart_uart_load_tx_fifo(void)
         return 0;
     }
 
+    // Ensure accurate index, dont allow uart interrupt while we manually load the fifo
+    MXC_UART_DisableInt(HART_UART_INSTANCE, (MXC_F_UART_INT_FL_TX_HE | MXC_F_UART_INT_FL_TX_OB));
+
     num_written = MXC_UART_WriteTXFIFO(
         HART_UART_INSTANCE, (const unsigned char *)(hart_buf + hart_uart_transmission_byte_index),
         load_num);
@@ -1016,6 +1019,9 @@ int hart_uart_load_tx_fifo(void)
     // Advance index based on bytes actually written.
     // This should always equal load_num though.
     hart_uart_transmission_byte_index += num_written;
+
+    // Restore interrupts
+    MXC_UART_EnableInt(HART_UART_INSTANCE, (MXC_F_UART_INT_FL_TX_HE | MXC_F_UART_INT_FL_TX_OB));
 
     // Return the number actually written in case someone is interested.
     return num_written;

--- a/Libraries/PeriphDrivers/Source/AFE/hart_uart.c
+++ b/Libraries/PeriphDrivers/Source/AFE/hart_uart.c
@@ -487,7 +487,7 @@ static int hart_uart_pins_external_test_mode_state(void)
     int retval = 0;
     mxc_gpio_cfg_t hart_pin;
 
-    // RTS Input to AFE, LOW is transmit mode, so Pulling Up
+    // HART_RTS Input to AFE, LOW is transmit mode, so Pulling Up
     hart_pin.port = HART_RTS_GPIO_PORT;
     hart_pin.mask = HART_RTS_GPIO_PIN;
     hart_pin.pad = MXC_GPIO_PAD_PULL_UP;
@@ -498,30 +498,33 @@ static int hart_uart_pins_external_test_mode_state(void)
         return retval;
     }
 
-    // CD output from AFE, Tristate
+    // HART_CD output from AFE, Tristate
     hart_pin.port = HART_CD_GPIO_PORT;
     hart_pin.mask = HART_CD_GPIO_PIN;
     hart_pin.pad = MXC_GPIO_PAD_NONE;
+    hart_pin.func = MXC_GPIO_FUNC_IN;
 
     retval = MXC_AFE_GPIO_Config(&hart_pin);
     if (retval != E_NO_ERROR) {
         return retval;
     }
 
-    // IN input to AFE, pulling Up
+    // HART_IN input to AFE, pulling Up
     hart_pin.port = HART_IN_GPIO_PORT;
     hart_pin.mask = HART_IN_GPIO_PIN;
     hart_pin.pad = MXC_GPIO_PAD_PULL_UP;
+    hart_pin.func = MXC_GPIO_FUNC_IN;
 
     retval = MXC_AFE_GPIO_Config(&hart_pin);
     if (retval != E_NO_ERROR) {
         return retval;
     }
 
-    // IN output from AFE, Tristate
+    // HART_OUT output from AFE, Tristate
     hart_pin.port = HART_OUT_GPIO_PORT;
     hart_pin.mask = HART_OUT_GPIO_PIN;
     hart_pin.pad = MXC_GPIO_PAD_NONE;
+    hart_pin.func = MXC_GPIO_FUNC_IN;
 
     retval = MXC_AFE_GPIO_Config(&hart_pin);
     if (retval != E_NO_ERROR) {


### PR DESCRIPTION
Use APB clock for HART UART to avoid case where UART clock is faster than system/periph clock to ensure UART interrupt actually vector.

Prevent bogus byte transmission due to interrupt occurring during manual FIFO load.

Minor corrections from previous PR code review.

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.