### PR TITLE
feat(PeriphDrivers): Allow info block unlock function be overwritten

### DIFF
--- a/Libraries/PeriphDrivers/Source/FLC/flc_me30.c
+++ b/Libraries/PeriphDrivers/Source/FLC/flc_me30.c
@@ -183,9 +183,9 @@ int MXC_FLC_MassErase(void)
 }
 
 //******************************************************************************
-int MXC_FLC_UnlockInfoBlock(uint32_t address)
+__weak int MXC_FLC_UnlockInfoBlock(uint32_t address)
 {
-    return MXC_FLC_RevA_UnlockInfoBlock((mxc_flc_reva_regs_t *)MXC_FLC, address);
+    return E_NOT_SUPPORTED;
 }
 
 //******************************************************************************


### PR DESCRIPTION
### Description

Info block unlock sequence changes device to device to use same function as it is unlock function need to be overwritten.
This PR make it weak to it be done.

### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.