### PR TITLE
fix(PeriphDrivers): Fix Mismatched Implementation for MAX32662 `MXC_LP_EnterShutDownMode`

### DIFF
--- a/Libraries/PeriphDrivers/Source/LP/lp_me12.c
+++ b/Libraries/PeriphDrivers/Source/LP/lp_me12.c
@@ -58,7 +58,7 @@ void MXC_LP_EnterBackupMode(void)
     // Should never reach this line - device will jump to backup vector on exit from background mode.
 }
 
-void MXC_LP_EnterPowerDownMode(void)
+void MXC_LP_EnterShutDownMode(void)
 {
     MXC_GCR->pm &= ~MXC_F_GCR_PM_MODE;
     MXC_GCR->pm |= MXC_S_GCR_PM_MODE_SHUTDOWN;


### PR DESCRIPTION
### Description

Shutdown function is defined as `MXC_LP_EnterShutDownMode` in lp.h however is implemented as `MXC_LP_EnterPowerDownMode` in lp_me12.c. Change its name in lp_me12.c to `MXC_LP_EnterShutDownMode` to make it consistent.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
