### PR TITLE
chore(CMSIS): Remove unused includes for MAX32672

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.h
@@ -29,13 +29,6 @@
 
 #include <stdint.h>
 
-// TODO(ADI): Remove below after grace period. Temporarily added these includes to resolve errors
-// for grace period before eventually removing support for deprecated features. 10-24-2022
-//>>>
-#include "trimsir_regs.h"
-#include "aes_regs.h"
-//<<<
-
 #ifndef FALSE
 #define FALSE (0)
 #endif
@@ -314,10 +307,6 @@ typedef enum {
 #define MXC_BASE_AES ((uint32_t)0x40207400UL)
 #define MXC_AES ((mxc_aes_regs_t *)MXC_BASE_AES)
 
-// DEPRECATED(10-24-2022): Scheduled for removal.
-typedef __attribute__((deprecated(
-    "Use MXC_AES (mxc_aes_regs_t), not the deprecated MXC_SYS_AES (mxc_sys_aes_regs_t) instance name and struct. 10-24-2022")))
-mxc_aes_regs_t mxc_sys_aes_regs_t;
 #define MXC_SYS_AES ((mxc_sys_aes_regs_t *)MXC_BASE_AES)
 
 /******************************************************************************/


### PR DESCRIPTION
### Description

Remove inclusion of trimsir_regs.h and aes_regs.h from max32672.h. They are causing redefinition warnings for `#define __I volatile const` macro in some cases.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

