### PR TITLE
fix(Boards): Add GPIO2_IRQ_Handler for MAX78000 FTHR_RevA

### DIFF
--- a/Libraries/Boards/MAX78000/FTHR_RevA/Source/board.c
+++ b/Libraries/Boards/MAX78000/FTHR_RevA/Source/board.c
@@ -80,6 +80,16 @@ __weak void GPIO1_IRQHandler(void)
 {
     MXC_GPIO_Handler(MXC_GPIO_GET_IDX(MXC_GPIO1));
 }
+/******************************************************************************/
+/**
+ * NOTE: This weak definition is included to support to catch interrupts from
+ *       GPIO2 pins in case user does not define this interrupt handler in their
+ *       application.
+ **/
+__weak void GPIO2_IRQHandler(void)
+{
+    MXC_GPIO_Handler(MXC_GPIO_GET_IDX(MXC_GPIO2));
+}
 
 /******************************************************************************/
 int Board_Init(void)


### PR DESCRIPTION
## Pull Request Template

### Description
One of the customers reported that they can't use P2.3 pin on MAX78000 FTHR even they enable interrupt and configure callback function. Interrupt is not triggered, and callback function is not called.

I figured out that GPIO2_IRQ_Handler was not defined even as a weak function in board.c file. I thought it might be better to have a weak definition for GPIO2 interrupts as well. So, users can also override this function in their application if needed. 
