### PR TITLE
fix(Examples): Fix warning in MAX32655/UART_DMA example and increase Bootloader app size for MAX32665

### DIFF
--- a/Examples/MAX32655/UART_DMA/main.c
+++ b/Examples/MAX32655/UART_DMA/main.c
@@ -71,7 +71,7 @@ void readCallback(mxc_uart_req_t *req, int error)
     READ_FLAG = error;
 }
 
-void buttonHandler(void)
+void buttonHandler(void *pb)
 {
     buttonPressed = 1;
 }

--- a/Examples/MAX32665/Bluetooth/Bootloader/README.md
+++ b/Examples/MAX32665/Bluetooth/Bootloader/README.md
@@ -9,12 +9,12 @@ the main flash section is erased and replaced with the update image. If no valid
 is identified, the Bootloader will boot the exiting image in the main flash space.
 
 __0x10000000__: Bootloader  
-__0x10004000__: Main flash space  
+__0x10008000__: Main flash space  
 __0x10080000__: Update flash space
 
 ## Setup
 
-This Bootloader application needs to be loaded to the first two flash pages. The main application
+This Bootloader application needs to be loaded at the beginning of Flash. The main application
 will run on top of this application. The linker file for the main application must coincide 
 with the memory sections defined in this application. The main application is responsible 
 for updating the update flash space.

--- a/Examples/MAX32665/Bluetooth/Bootloader/boot_lower.S
+++ b/Examples/MAX32665/Bluetooth/Bootloader/boot_lower.S
@@ -31,7 +31,7 @@
 /* Boot from the lower flash array */
 Boot_Lower:
 
-    ldr     r0,=0x10004000      /* Address for main flash image */
+    ldr     r0,=0x10008000      /* Address for main flash image */
     ldr     r1,=0xE000ED08      /* Address for SCB_VTOR_REG */
 
     /* First 32-bit word in image is initial stack pointer */

--- a/Examples/MAX32665/Bluetooth/Bootloader/bootloader.ld
+++ b/Examples/MAX32665/Bluetooth/Bootloader/bootloader.ld
@@ -19,7 +19,7 @@
  ******************************************************************************/
 
 BOOTLOADER_ORIGIN = 0x10000000;
-BOOTLOADER_LEN = 0x4000;
+BOOTLOADER_LEN = 0x8000;
 FLASH_SECTION_LEN = 0x80000 - BOOTLOADER_LEN;
 FLASH0_ORIGIN = BOOTLOADER_ORIGIN + BOOTLOADER_LEN;
 


### PR DESCRIPTION
### Description

Final PR to fix a warning for release.

Also tacks on a fix for failing Build_Examples workflow with a memory overflow issue.

**Create a merge commit**, NOT a squash and merge.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.