### PR TITLE
fix(CMSIS,PeriphDrivers): Remove SPI TS3, fix GPIO pad controls, and fix build errors for MAX32657

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/gpio_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/gpio_regs.h
@@ -96,8 +96,8 @@ typedef struct {
     __IO uint32_t wken_clr;             /**< <tt>\b 0x54:</tt> GPIO WKEN_CLR Register */
     __R  uint32_t rsv_0x58;
     __IO uint32_t dualedge;             /**< <tt>\b 0x5C:</tt> GPIO DUALEDGE Register */
-    __IO uint32_t padctrl0;             /**< <tt>\b 0x60:</tt> GPIO PADCTRL0 Register */
-    __IO uint32_t padctrl1;             /**< <tt>\b 0x64:</tt> GPIO PADCTRL1 Register */
+    __IO uint32_t padctrl;              /**< <tt>\b 0x60:</tt> GPIO PADCTRL Register */
+    __R  uint32_t rsv_0x64;
     __IO uint32_t en1;                  /**< <tt>\b 0x68:</tt> GPIO EN1 Register */
     __IO uint32_t en1_set;              /**< <tt>\b 0x6C:</tt> GPIO EN1_SET Register */
     __IO uint32_t en1_clr;              /**< <tt>\b 0x70:</tt> GPIO EN1_CLR Register */
@@ -143,8 +143,7 @@ typedef struct {
 #define MXC_R_GPIO_WKEN_SET                ((uint32_t)0x00000050UL) /**< Offset from GPIO Base Address: <tt> 0x0050</tt> */
 #define MXC_R_GPIO_WKEN_CLR                ((uint32_t)0x00000054UL) /**< Offset from GPIO Base Address: <tt> 0x0054</tt> */
 #define MXC_R_GPIO_DUALEDGE                ((uint32_t)0x0000005CUL) /**< Offset from GPIO Base Address: <tt> 0x005C</tt> */
-#define MXC_R_GPIO_PADCTRL0                ((uint32_t)0x00000060UL) /**< Offset from GPIO Base Address: <tt> 0x0060</tt> */
-#define MXC_R_GPIO_PADCTRL1                ((uint32_t)0x00000064UL) /**< Offset from GPIO Base Address: <tt> 0x0064</tt> */
+#define MXC_R_GPIO_PADCTRL                 ((uint32_t)0x00000060UL) /**< Offset from GPIO Base Address: <tt> 0x0060</tt> */
 #define MXC_R_GPIO_EN1                     ((uint32_t)0x00000068UL) /**< Offset from GPIO Base Address: <tt> 0x0068</tt> */
 #define MXC_R_GPIO_EN1_SET                 ((uint32_t)0x0000006CUL) /**< Offset from GPIO Base Address: <tt> 0x006C</tt> */
 #define MXC_R_GPIO_EN1_CLR                 ((uint32_t)0x00000070UL) /**< Offset from GPIO Base Address: <tt> 0x0070</tt> */
@@ -473,39 +472,21 @@ typedef struct {
 
 /**
  * @ingroup  gpio_registers
- * @defgroup GPIO_PADCTRL0 GPIO_PADCTRL0
- * @brief    GPIO Input Mode Config 0. Each bit in this register enables the weak pull-up for
- *           the associated GPIO pin in this port.
+ * @defgroup GPIO_PADCTRL GPIO_PADCTRL
+ * @brief    GPIO Pad Control. Each bit in this register configures the pad for the
+ *           associated GPIO pin in this port.
  * @{
  */
-#define MXC_F_GPIO_PADCTRL0_ALL_POS                    0 /**< PADCTRL0_ALL Position */
-#define MXC_F_GPIO_PADCTRL0_ALL                        ((uint32_t)(0xFFFFFFFFUL << MXC_F_GPIO_PADCTRL0_ALL_POS)) /**< PADCTRL0_ALL Mask */
-#define MXC_V_GPIO_PADCTRL0_ALL_IMPEDANCE              ((uint32_t)0x0UL) /**< PADCTRL0_ALL_IMPEDANCE Value */
-#define MXC_S_GPIO_PADCTRL0_ALL_IMPEDANCE              (MXC_V_GPIO_PADCTRL0_ALL_IMPEDANCE << MXC_F_GPIO_PADCTRL0_ALL_POS) /**< PADCTRL0_ALL_IMPEDANCE Setting */
-#define MXC_V_GPIO_PADCTRL0_ALL_PU                     ((uint32_t)0x1UL) /**< PADCTRL0_ALL_PU Value */
-#define MXC_S_GPIO_PADCTRL0_ALL_PU                     (MXC_V_GPIO_PADCTRL0_ALL_PU << MXC_F_GPIO_PADCTRL0_ALL_POS) /**< PADCTRL0_ALL_PU Setting */
-#define MXC_V_GPIO_PADCTRL0_ALL_PD                     ((uint32_t)0x2UL) /**< PADCTRL0_ALL_PD Value */
-#define MXC_S_GPIO_PADCTRL0_ALL_PD                     (MXC_V_GPIO_PADCTRL0_ALL_PD << MXC_F_GPIO_PADCTRL0_ALL_POS) /**< PADCTRL0_ALL_PD Setting */
+#define MXC_F_GPIO_PADCTRL_ALL_POS                     0 /**< PADCTRL_ALL Position */
+#define MXC_F_GPIO_PADCTRL_ALL                         ((uint32_t)(0xFFFFFFFFUL << MXC_F_GPIO_PADCTRL_ALL_POS)) /**< PADCTRL_ALL Mask */
+#define MXC_V_GPIO_PADCTRL_ALL_IMPEDANCE               ((uint32_t)0x0UL) /**< PADCTRL_ALL_IMPEDANCE Value */
+#define MXC_S_GPIO_PADCTRL_ALL_IMPEDANCE               (MXC_V_GPIO_PADCTRL_ALL_IMPEDANCE << MXC_F_GPIO_PADCTRL_ALL_POS) /**< PADCTRL_ALL_IMPEDANCE Setting */
+#define MXC_V_GPIO_PADCTRL_ALL_PU                      ((uint32_t)0x1UL) /**< PADCTRL_ALL_PU Value */
+#define MXC_S_GPIO_PADCTRL_ALL_PU                      (MXC_V_GPIO_PADCTRL_ALL_PU << MXC_F_GPIO_PADCTRL_ALL_POS) /**< PADCTRL_ALL_PU Setting */
+#define MXC_V_GPIO_PADCTRL_ALL_PD                      ((uint32_t)0x2UL) /**< PADCTRL_ALL_PD Value */
+#define MXC_S_GPIO_PADCTRL_ALL_PD                      (MXC_V_GPIO_PADCTRL_ALL_PD << MXC_F_GPIO_PADCTRL_ALL_POS) /**< PADCTRL_ALL_PD Setting */
 
-/**@} end of group GPIO_PADCTRL0_Register */
-
-/**
- * @ingroup  gpio_registers
- * @defgroup GPIO_PADCTRL1 GPIO_PADCTRL1
- * @brief    GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for
- *           the associated GPIO pin in this port.
- * @{
- */
-#define MXC_F_GPIO_PADCTRL1_ALL_POS                    0 /**< PADCTRL1_ALL Position */
-#define MXC_F_GPIO_PADCTRL1_ALL                        ((uint32_t)(0xFFFFFFFFUL << MXC_F_GPIO_PADCTRL1_ALL_POS)) /**< PADCTRL1_ALL Mask */
-#define MXC_V_GPIO_PADCTRL1_ALL_IMPEDANCE              ((uint32_t)0x0UL) /**< PADCTRL1_ALL_IMPEDANCE Value */
-#define MXC_S_GPIO_PADCTRL1_ALL_IMPEDANCE              (MXC_V_GPIO_PADCTRL1_ALL_IMPEDANCE << MXC_F_GPIO_PADCTRL1_ALL_POS) /**< PADCTRL1_ALL_IMPEDANCE Setting */
-#define MXC_V_GPIO_PADCTRL1_ALL_PU                     ((uint32_t)0x1UL) /**< PADCTRL1_ALL_PU Value */
-#define MXC_S_GPIO_PADCTRL1_ALL_PU                     (MXC_V_GPIO_PADCTRL1_ALL_PU << MXC_F_GPIO_PADCTRL1_ALL_POS) /**< PADCTRL1_ALL_PU Setting */
-#define MXC_V_GPIO_PADCTRL1_ALL_PD                     ((uint32_t)0x2UL) /**< PADCTRL1_ALL_PD Value */
-#define MXC_S_GPIO_PADCTRL1_ALL_PD                     (MXC_V_GPIO_PADCTRL1_ALL_PD << MXC_F_GPIO_PADCTRL1_ALL_POS) /**< PADCTRL1_ALL_PD Setting */
-
-/**@} end of group GPIO_PADCTRL1_Register */
+/**@} end of group GPIO_PADCTRL_Register */
 
 /**
  * @ingroup  gpio_registers

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.svd
@@ -3353,39 +3353,9 @@
      </fields>
     </register>
     <register>
-     <name>PADCTRL0</name>
-     <description>GPIO Input Mode Config 0. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <name>PADCTRL</name>
+     <description>GPIO Pad Control. Each bit in this register configures the pad for the associated GPIO pin in this port.</description>
      <addressOffset>0x60</addressOffset>
-     <fields>
-      <field>
-       <name>ALL</name>
-       <description>The two bits in GPIO_PADCTRL0 and GPIO_PADCTRL1 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>32</bitWidth>
-       <enumeratedValues>
-        <enumeratedValue>
-         <name>impedance</name>
-         <description>High Impedance.</description>
-         <value>0</value>
-        </enumeratedValue>
-        <enumeratedValue>
-         <name>pu</name>
-         <description>Weak pull-up mode.</description>
-         <value>1</value>
-        </enumeratedValue>
-        <enumeratedValue>
-         <name>pd</name>
-         <description>weak pull-down mode.</description>
-         <value>2</value>
-        </enumeratedValue>
-       </enumeratedValues>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>PADCTRL1</name>
-     <description>GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
-     <addressOffset>0x64</addressOffset>
      <fields>
       <field>
        <name>ALL</name>
@@ -8460,11 +8430,6 @@
          <description>TS2 is selected.</description>
          <value>0x4</value>
         </enumeratedValue>
-        <enumeratedValue>
-         <name>TS3</name>
-         <description>TS3 is selected.</description>
-         <value>0x8</value>
-        </enumeratedValue>
        </enumeratedValues>
       </field>
      </fields>
@@ -8682,7 +8647,7 @@
        <name>TSPOL</name>
        <description>Target Select Polarity, each Target Select can have unique polarity.</description>
        <bitOffset>16</bitOffset>
-       <bitWidth>4</bitWidth>
+       <bitWidth>3</bitWidth>
        <enumeratedValues>
         <enumeratedValue>
          <name>TS0_high</name>
@@ -8698,11 +8663,6 @@
          <name>TS2_high</name>
          <description>TS2 active high.</description>
          <value>0x4</value>
-        </enumeratedValue>
-        <enumeratedValue>
-         <name>TS3_high</name>
-         <description>TS3 active high.</description>
-         <value>0x8</value>
         </enumeratedValue>
        </enumeratedValues>
       </field>
@@ -10241,9 +10201,8 @@
    <registers>
     <register>
      <name>RTCX1</name>
-     <description>RTC X2 Capacitor Setting.</description>
+     <description>RTC X1 Capacitor Setting.</description>
      <addressOffset>0x3C</addressOffset>
-     <access>read-only</access>
      <fields>
       <field>
        <name>CAP</name>

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/spi_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/spi_regs.h
@@ -176,8 +176,6 @@ typedef struct {
 #define MXC_S_SPI_CTRL0_TS_ACTIVE_TS1                  (MXC_V_SPI_CTRL0_TS_ACTIVE_TS1 << MXC_F_SPI_CTRL0_TS_ACTIVE_POS) /**< CTRL0_TS_ACTIVE_TS1 Setting */
 #define MXC_V_SPI_CTRL0_TS_ACTIVE_TS2                  ((uint32_t)0x4UL) /**< CTRL0_TS_ACTIVE_TS2 Value */
 #define MXC_S_SPI_CTRL0_TS_ACTIVE_TS2                  (MXC_V_SPI_CTRL0_TS_ACTIVE_TS2 << MXC_F_SPI_CTRL0_TS_ACTIVE_POS) /**< CTRL0_TS_ACTIVE_TS2 Setting */
-#define MXC_V_SPI_CTRL0_TS_ACTIVE_TS3                  ((uint32_t)0x8UL) /**< CTRL0_TS_ACTIVE_TS3 Value */
-#define MXC_S_SPI_CTRL0_TS_ACTIVE_TS3                  (MXC_V_SPI_CTRL0_TS_ACTIVE_TS3 << MXC_F_SPI_CTRL0_TS_ACTIVE_POS) /**< CTRL0_TS_ACTIVE_TS3 Setting */
 
 /**@} end of group SPI_CTRL0_Register */
 
@@ -258,15 +256,13 @@ typedef struct {
 #define MXC_F_SPI_CTRL2_THREE_WIRE                     ((uint32_t)(0x1UL << MXC_F_SPI_CTRL2_THREE_WIRE_POS)) /**< CTRL2_THREE_WIRE Mask */
 
 #define MXC_F_SPI_CTRL2_TSPOL_POS                      16 /**< CTRL2_TSPOL Position */
-#define MXC_F_SPI_CTRL2_TSPOL                          ((uint32_t)(0xFUL << MXC_F_SPI_CTRL2_TSPOL_POS)) /**< CTRL2_TSPOL Mask */
+#define MXC_F_SPI_CTRL2_TSPOL                          ((uint32_t)(0x7UL << MXC_F_SPI_CTRL2_TSPOL_POS)) /**< CTRL2_TSPOL Mask */
 #define MXC_V_SPI_CTRL2_TSPOL_TS0_HIGH                 ((uint32_t)0x1UL) /**< CTRL2_TSPOL_TS0_HIGH Value */
 #define MXC_S_SPI_CTRL2_TSPOL_TS0_HIGH                 (MXC_V_SPI_CTRL2_TSPOL_TS0_HIGH << MXC_F_SPI_CTRL2_TSPOL_POS) /**< CTRL2_TSPOL_TS0_HIGH Setting */
 #define MXC_V_SPI_CTRL2_TSPOL_TS1_HIGH                 ((uint32_t)0x2UL) /**< CTRL2_TSPOL_TS1_HIGH Value */
 #define MXC_S_SPI_CTRL2_TSPOL_TS1_HIGH                 (MXC_V_SPI_CTRL2_TSPOL_TS1_HIGH << MXC_F_SPI_CTRL2_TSPOL_POS) /**< CTRL2_TSPOL_TS1_HIGH Setting */
 #define MXC_V_SPI_CTRL2_TSPOL_TS2_HIGH                 ((uint32_t)0x4UL) /**< CTRL2_TSPOL_TS2_HIGH Value */
 #define MXC_S_SPI_CTRL2_TSPOL_TS2_HIGH                 (MXC_V_SPI_CTRL2_TSPOL_TS2_HIGH << MXC_F_SPI_CTRL2_TSPOL_POS) /**< CTRL2_TSPOL_TS2_HIGH Setting */
-#define MXC_V_SPI_CTRL2_TSPOL_TS3_HIGH                 ((uint32_t)0x8UL) /**< CTRL2_TSPOL_TS3_HIGH Value */
-#define MXC_S_SPI_CTRL2_TSPOL_TS3_HIGH                 (MXC_V_SPI_CTRL2_TSPOL_TS3_HIGH << MXC_F_SPI_CTRL2_TSPOL_POS) /**< CTRL2_TSPOL_TS3_HIGH Setting */
 
 /**@} end of group SPI_CTRL2_Register */
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/trimsir_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/trimsir_regs.h
@@ -73,7 +73,7 @@ extern "C" {
  */
 typedef struct {
     __R  uint32_t rsv_0x0_0x3b[15];
-    __I  uint32_t rtcx1;                /**< <tt>\b 0x3C:</tt> TRIMSIR RTCX1 Register */
+    __IO uint32_t rtcx1;                /**< <tt>\b 0x3C:</tt> TRIMSIR RTCX1 Register */
     __R  uint32_t rsv_0x40;
     __IO uint32_t rtcx2;                /**< <tt>\b 0x44:</tt> TRIMSIR RTCX2 Register */
 } mxc_trimsir_regs_t;
@@ -92,7 +92,7 @@ typedef struct {
 /**
  * @ingroup  trimsir_registers
  * @defgroup TRIMSIR_RTCX1 TRIMSIR_RTCX1
- * @brief    RTC X2 Capacitor Setting.
+ * @brief    RTC X1 Capacitor Setting.
  * @{
  */
 #define MXC_F_TRIMSIR_RTCX1_CAP_POS                    0 /**< RTCX1_CAP Position */

--- a/Libraries/PeriphDrivers/Include/MAX32657/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/gpio.h
@@ -151,8 +151,6 @@ typedef enum {
  */
 typedef enum {
     MXC_GPIO_PAD_NONE, /**< No pull-up or pull-down */
-    MXC_GPIO_PAD_PULL_UP, /**< Set pad to strong pull-up */
-    MXC_GPIO_PAD_PULL_DOWN, /**< Set pad to strong pull-down */
     MXC_GPIO_PAD_WEAK_PULL_UP, /**< Set pad to weak pull-up */
     MXC_GPIO_PAD_WEAK_PULL_DOWN /**< Set pad to weak pull-down */
 } mxc_gpio_pad_t;

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me30.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me30.c
@@ -96,33 +96,16 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     // Configure the pad
     switch (cfg->pad) {
     case MXC_GPIO_PAD_NONE:
-        gpio->padctrl0 &= ~cfg->mask;
-        gpio->padctrl1 &= ~cfg->mask;
+        gpio->padctrl &= ~cfg->mask;
         break;
 
-    // Note: for "ps" field set 1 for weak and 0 for strong.
-    // As of 8-28-2024 most UG tables have this flipped the wrong way
     case MXC_GPIO_PAD_WEAK_PULL_UP:
-        gpio->padctrl0 |= cfg->mask;
-        gpio->padctrl1 &= ~cfg->mask;
+        gpio->padctrl |= cfg->mask;
         gpio->pssel |= cfg->mask;
-        break;
-
-    case MXC_GPIO_PAD_PULL_UP:
-        gpio->padctrl0 |= cfg->mask;
-        gpio->padctrl1 &= ~cfg->mask;
-        gpio->pssel &= ~cfg->mask;
         break;
 
     case MXC_GPIO_PAD_WEAK_PULL_DOWN:
-        gpio->padctrl0 &= ~cfg->mask;
-        gpio->padctrl1 |= cfg->mask;
-        gpio->pssel |= cfg->mask;
-        break;
-
-    case MXC_GPIO_PAD_PULL_DOWN:
-        gpio->padctrl0 &= ~cfg->mask;
-        gpio->padctrl1 |= cfg->mask;
+        gpio->padctrl |= cfg->mask;
         gpio->pssel &= ~cfg->mask;
         break;
 

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_reva_me30.svd
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_reva_me30.svd
@@ -443,39 +443,9 @@
         </fields>
       </register>
       <register>
-        <name>PADCTRL0</name>
-        <description>GPIO Input Mode Config 0. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+        <name>PADCTRL</name>
+        <description>GPIO Pad Control. Each bit in this register configures the pad for the associated GPIO pin in this port.</description>
         <addressOffset>0x60</addressOffset>
-        <fields>
-          <field>
-            <name>ALL</name>
-            <description>The two bits in GPIO_PADCTRL0 and GPIO_PADCTRL1 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
-            <bitOffset>0</bitOffset>
-            <bitWidth>32</bitWidth>
-            <enumeratedValues>
-              <enumeratedValue>
-                <name>impedance</name>
-                <description>High Impedance.</description>
-                <value>0</value>
-              </enumeratedValue>
-              <enumeratedValue>
-                <name>pu</name>
-                <description>Weak pull-up mode.</description>
-                <value>1</value>
-              </enumeratedValue>
-              <enumeratedValue>
-                <name>pd</name>
-                <description>weak pull-down mode.</description>
-                <value>2</value>
-              </enumeratedValue>
-            </enumeratedValues>
-          </field>
-        </fields>
-      </register>
-      <register>
-        <name>PADCTRL1</name>
-        <description>GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
-        <addressOffset>0x64</addressOffset>
         <fields>
           <field>
             <name>ALL</name>

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me30.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me30.c
@@ -151,13 +151,10 @@ int MXC_RTC_GetBusyFlag(void)
     return MXC_RTC_RevA_GetBusyFlag((mxc_rtc_reva_regs_t *)MXC_RTC);
 }
 
+// TODO(SW): TRIMSIR RTC X1/X2 register descriptions were updated due to design changes.
+//      CAP vs TRIM value differences unknown, and this function has not been tested.
 int MXC_RTC_TrimCrystal(void)
 {
-#if TARGET_NUM == 78000
-    /* MAX78000 does not have the ERFO clock which the Trim function requires */
-    return E_NOT_SUPPORTED;
-#endif
-
     unsigned int search_step, elapsed;
     unsigned int upper, lower, trim, oldtrim, bestTrim, bestElapsed, bestElapsedDiff;
     unsigned int freq = NOM_32K_FREQ;
@@ -209,10 +206,10 @@ int MXC_RTC_TrimCrystal(void)
         }
 
         /* Set the trim values */
-        MXC_SETFIELD(MXC_TRIMSIR->rtc, MXC_F_TRIMSIR_RTC_X1TRIM,
-                     (trim << MXC_F_TRIMSIR_RTC_X1TRIM_POS));
-        MXC_SETFIELD(MXC_TRIMSIR->rtc, MXC_F_TRIMSIR_RTC_X2TRIM,
-                     (trim << MXC_F_TRIMSIR_RTC_X2TRIM_POS));
+        MXC_SETFIELD(MXC_TRIMSIR->rtcx1, MXC_F_TRIMSIR_RTCX1_CAP,
+                     (trim << MXC_F_TRIMSIR_RTCX1_CAP_POS));
+        MXC_SETFIELD(MXC_TRIMSIR->rtcx2, MXC_F_TRIMSIR_RTCX2_CAP,
+                     (trim << MXC_F_TRIMSIR_RTCX2_CAP_POS));
 
         /* Sleep to settle new caps */
         MXC_Delay(MXC_DELAY_MSEC(10));
@@ -263,10 +260,10 @@ int MXC_RTC_TrimCrystal(void)
     }
 
     /* Apply the closest trim setting */
-    MXC_SETFIELD(MXC_TRIMSIR->rtc, MXC_F_TRIMSIR_RTC_X1TRIM,
-                 (bestTrim << MXC_F_TRIMSIR_RTC_X1TRIM_POS));
-    MXC_SETFIELD(MXC_TRIMSIR->rtc, MXC_F_TRIMSIR_RTC_X2TRIM,
-                 (bestTrim << MXC_F_TRIMSIR_RTC_X2TRIM_POS));
+    MXC_SETFIELD(MXC_TRIMSIR->rtcx1, MXC_F_TRIMSIR_RTCX1_CAP,
+                 (bestTrim << MXC_F_TRIMSIR_RTCX1_CAP_POS));
+    MXC_SETFIELD(MXC_TRIMSIR->rtcx2, MXC_F_TRIMSIR_RTCX2_CAP,
+                 (bestTrim << MXC_F_TRIMSIR_RTCX2_CAP_POS));
 
     /* Adjust 32K freq if we can't get close enough to 32768 Hz */
     if (bestElapsed >= SEARCH_TARGET) {

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva_me30.svd
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva_me30.svd
@@ -177,11 +177,6 @@
                 <description>TS2 is selected.</description>
                 <value>0x4</value>
               </enumeratedValue>
-              <enumeratedValue>
-                <name>TS3</name>
-                <description>TS3 is selected.</description>
-                <value>0x8</value>
-              </enumeratedValue>
             </enumeratedValues>
           </field>
         </fields>
@@ -399,7 +394,7 @@
             <name>TSPOL</name>
             <description>Target Select Polarity, each Target Select can have unique polarity.</description>
             <bitOffset>16</bitOffset>
-            <bitWidth>4</bitWidth>
+            <bitWidth>3</bitWidth>
             <enumeratedValues>
               <enumeratedValue>
                 <name>TS0_high</name>
@@ -415,11 +410,6 @@
                 <name>TS2_high</name>
                 <description>TS2 active high.</description>
                 <value>0x4</value>
-              </enumeratedValue>
-              <enumeratedValue>
-                <name>TS3_high</name>
-                <description>TS3 active high.</description>
-                <value>0x8</value>
               </enumeratedValue>
             </enumeratedValues>
           </field>

--- a/Libraries/PeriphDrivers/Source/SYS/SVD/trimsir_me30.svd
+++ b/Libraries/PeriphDrivers/Source/SYS/SVD/trimsir_me30.svd
@@ -12,9 +12,8 @@
     <registers>
       <register>
         <name>RTCX1</name>
-        <description>RTC X2 Capacitor Setting.</description>
+        <description>RTC X1 Capacitor Setting.</description>
         <addressOffset>0x3C</addressOffset>
-        <access>read-only</access>
         <fields>
           <field>
             <name>CAP</name>

--- a/Libraries/PeriphDrivers/Source/WUT/wut_me30.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_me30.c
@@ -168,13 +168,15 @@ static void MXC_WUT_GetWUTSync(mxc_wut_regs_t *wut, uint32_t *wutCnt, uint32_t *
 /* ************************************************************************** */
 static void MXC_WUT_SetTrim(uint32_t trimValue)
 {
-    MXC_SETFIELD(MXC_TRIMSIR->rtc, MXC_F_TRIMSIR_RTC_X1TRIM,
-                 (trimValue << MXC_F_TRIMSIR_RTC_X1TRIM_POS));
-    MXC_SETFIELD(MXC_TRIMSIR->rtc, MXC_F_TRIMSIR_RTC_X2TRIM,
-                 (trimValue << MXC_F_TRIMSIR_RTC_X2TRIM_POS));
+    MXC_SETFIELD(MXC_TRIMSIR->rtcx1, MXC_F_TRIMSIR_RTCX1_CAP,
+                 (trimValue << MXC_F_TRIMSIR_RTCX1_CAP_POS));
+    MXC_SETFIELD(MXC_TRIMSIR->rtcx2, MXC_F_TRIMSIR_RTCX2_CAP,
+                 (trimValue << MXC_F_TRIMSIR_RTCX2_CAP_POS));
 }
 
 /* ************************************************************************** */
+// TODO(SW): TRIMSIR RTC X1/X2 register descriptions were updated due to design changes.
+//      CAP vs TRIM value differences unknown, and this function has not been tested.
 static int MXC_WUT_StartTrim(mxc_wut_regs_t *wut)
 {
     uint32_t wutCnt0, wutCnt1;
@@ -194,7 +196,7 @@ static int MXC_WUT_StartTrim(mxc_wut_regs_t *wut)
     }
 
     /* Start with existing trim value */
-    trimValue = (MXC_TRIMSIR->rtc & MXC_F_TRIMSIR_RTC_X1TRIM) >> MXC_F_TRIMSIR_RTC_X1TRIM_POS;
+    trimValue = (MXC_TRIMSIR->rtcx1 & MXC_F_TRIMSIR_RTCX1_CAP) >> MXC_F_TRIMSIR_RTCX1_CAP_POS;
     MXC_WUT_SetTrim(trimValue);
 
     /* Initialize the variables */
@@ -236,7 +238,7 @@ int MXC_WUT_Handler(mxc_wut_regs_t *wut)
     calcTicks = ((uint64_t)wutTicks * (uint64_t)BB_CLK_RATE_HZ) / (uint64_t)32768;
 
     trimComplete = 0;
-    trimValue = (MXC_TRIMSIR->rtc & MXC_F_TRIMSIR_RTC_X1TRIM) >> MXC_F_TRIMSIR_RTC_X1TRIM_POS;
+    trimValue = (MXC_TRIMSIR->rtcx1 & MXC_F_TRIMSIR_RTCX1_CAP) >> MXC_F_TRIMSIR_RTCX1_CAP_POS;
 
     if (snapTicks > calcTicks) {
         /* See if we're closer to the calculated value */


### PR DESCRIPTION
### Description

- fix build errors
- remove TS3 from SPI registers. ME30 only supports 3 target select lines
- update GPIO pad controls to match ME12 design

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.