### PR TITLE
fix(workflow): Update clang-format-run-pr.yml to Node20.js and update permissions

### DIFF
--- a/.github/workflows/clang-format-run-pr.yml
+++ b/.github/workflows/clang-format-run-pr.yml
@@ -27,14 +27,20 @@ on:
 
 permissions:
   actions: write
+  contents: write
 
 env:
   CLANG_VERSION: 14
 
 jobs:
 
-  run-on-pr: 
-    # Run on branchs, not forked PR branches
+  run-on-pr:
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: write
+
+    # Run on branches, not forked PR branches
     if: |
       contains(github.event.comment.body, '/clang-format-run')
 

--- a/.github/workflows/clang-format-run-pr.yml
+++ b/.github/workflows/clang-format-run-pr.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         sudo apt-get install clang-format-${CLANG_VERSION}
 
-    - uses: actions/github-script@v6
+    - uses: actions/github-script@v7
       id: get-pr
       with:
         script: |


### PR DESCRIPTION
### Description

Clang-format workflow not working. Not sure if it's because of the deprecated Node16.js that the workflow was using or if it's a permission issue with this repo.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.