### PR TITLE
fix(PeriphDrivers): Fix build warnings for MAX78002 ADC

### DIFF
--- a/Libraries/PeriphDrivers/Source/ADC/adc_ai87.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_ai87.c
@@ -37,9 +37,9 @@
  */
 
 #define MXC_F_MCR_ADCCFG2_CH 0x3
-#define TEMP_FACTOR 530.582f / 4096.0
-#define TEMP_FACTOR1V25 1.25 * TEMP_FACTOR
-#define TEMP_FACTOR2V048 2.048 * TEMP_FACTOR
+#define TEMP_FACTOR 530.582f / 4096.0f
+#define TEMP_FACTOR1V25 1.25f * TEMP_FACTOR
+#define TEMP_FACTOR2V048 2.048f * TEMP_FACTOR
 
 static void initGPIOForChannel(mxc_adc_chsel_t channel)
 {
@@ -397,7 +397,7 @@ int MXC_ConvertTemperature_ToF(uint16_t tempSensor_Readout, mxc_adc_refsel_t ref
                                float *temp)
 {
     if (MXC_ConvertTemperature_ToK(tempSensor_Readout, ref, ext_ref, temp) == E_NO_ERROR) {
-        *temp = ((*temp * 1.8) - 459.67f);
+        *temp = (*temp * 1.8f) - 459.67f;
         return E_NO_ERROR;
     } else {
         return E_BAD_PARAM;


### PR DESCRIPTION
### Description

Fixed build warnings of ADC driver for MAX78002 SoC.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
