### PR TITLE
fix(BLE): Update PAL UART to derive clock via IBRO

### DIFF
--- a/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_uart.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_uart.c
@@ -296,13 +296,8 @@ void PalUartInit(PalUartId_t id, const PalUartConfig_t *pCfg)
   palUartCb[uartNum].wrCback = pCfg->wrCback;
 
   /* Initialize the UART */
-  if(uartNum == 3) {
-    /* Use the IBRO clock for UART3 */
-    result = MXC_UART_Init(MXC_UART_GET_UART(uartNum), pCfg->baud, MXC_UART_IBRO_CLK);
-  } else {
-    /* Use the APB clock for rest of the UARTs */
-    result = MXC_UART_Init(MXC_UART_GET_UART(uartNum), pCfg->baud, MXC_UART_APB_CLK);
-  }
+  result = MXC_UART_Init(MXC_UART_GET_UART(uartNum), pCfg->baud, MXC_UART_IBRO_CLK);
+  
 
   (void)result;
   PAL_SYS_ASSERT(result == 0);

--- a/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_uart.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_uart.c
@@ -295,7 +295,6 @@ void PalUartInit(PalUartId_t id, const PalUartConfig_t *pCfg)
   palUartCb[uartNum].rdCback = pCfg->rdCback;
   palUartCb[uartNum].wrCback = pCfg->wrCback;
 
-  /* Initialize the UART */
   result = MXC_UART_Init(MXC_UART_GET_UART(uartNum), pCfg->baud, MXC_UART_IBRO_CLK);
   
 

--- a/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_uart.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_uart.c
@@ -302,13 +302,7 @@ void PalUartInit(PalUartId_t id, const PalUartConfig_t *pCfg)
   palUartCb[uartNum].wrCback = pCfg->wrCback;
 
   /* Initialize the UART */
-  if(uartNum == 3) {
-    /* Use the IBRO clock for UART3 */
-    result = MXC_UART_Init(MXC_UART_GET_UART(uartNum), pCfg->baud, MXC_UART_IBRO_CLK);
-  } else {
-    /* Use the APB clock for rest of the UARTs */
-    result = MXC_UART_Init(MXC_UART_GET_UART(uartNum), pCfg->baud, MXC_UART_APB_CLK);
-  }
+  result = MXC_UART_Init(MXC_UART_GET_UART(uartNum), pCfg->baud, MXC_UART_IBRO_CLK);
 
   (void)result;
   PAL_SYS_ASSERT(result == 0);

--- a/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_uart.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_uart.c
@@ -301,7 +301,6 @@ void PalUartInit(PalUartId_t id, const PalUartConfig_t *pCfg)
   palUartCb[uartNum].rdCback = pCfg->rdCback;
   palUartCb[uartNum].wrCback = pCfg->wrCback;
 
-  /* Initialize the UART */
   result = MXC_UART_Init(MXC_UART_GET_UART(uartNum), pCfg->baud, MXC_UART_IBRO_CLK);
 
   (void)result;


### PR DESCRIPTION
## Pull Request Template

### Description

Previously, the UART clock was fed off of the ``APB`` clock, which is derived from the ``IPO``. Nonproduction parts commonly have inaccurate trims for the ``IPO``. This makes the UART not work as the baud rate is off. ``IBRO`` is a slower more accurate clock, which does not have this issue. 


Changes:
- Initialize all UART using ``pal_uart`` to be on ``IBRO``