### PR TITLE
fix(BLE): Resolve double increment of memory management in LlInitSetRtCfg

### DIFF
--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -595,8 +595,8 @@ jobs:
           boards: |
             max32655_board1
             max32655_board2
-            max32665_board1
-            max32690_board_w1
+            # max32665_board1
+            # max32690_board_w1
           lock: true
           timeout: 3600 # Attempt to lock for an hour
 
@@ -615,23 +615,23 @@ jobs:
           # sed -i "s/'S'/'!'/g" Examples/MAX32690/Bluetooth/BLE_otac/datc_main.c
 
       - name: Erase Boards DATS
-        if: ${{env.MAX32655_DATS_CONNECTED_TEST == 'true' || env.MAX32665_DATS_CONNECTED_TEST == 'true' || env.MAX32690_DATS_CONNECTED_TEST == 'true'}}
+        if: ${{env.MAX32655_DATS_CONNECTED_TEST == 'true' || env.MAX32655_RUN_ALL_TEST == 'true'}}
         uses: Analog-Devices-MSDK/btm-ci-scripts/actions/ocderase@v1.1
         with:
           board: |
             max32655_board1
             max32655_board2
-            max32665_board1
-            max32690_board_w1
+            # max32665_board1
+            # max32690_board_w1
 
           has_two_flash_banks: |
             true
             true
-            true
-            true
+            # true
+            # true
 
       - name: Flash DATS 655
-        if: ${{env.MAX32655_DATS_CONNECTED_TEST == 'true'}}
+        if: ${{env.MAX32655_DATS_CONNECTED_TEST == 'true' || env.MAX32655_RUN_ALL_TEST == 'true'}}
         uses: Analog-Devices-MSDK/btm-ci-scripts/actions/ocdflash@v1.1
         with:
           board: |
@@ -652,7 +652,7 @@ jobs:
           distclean: true
 
       - name: DATS 655
-        if: ${{env.MAX32655_DATS_CONNECTED_TEST == 'true'}}
+        if: ${{env.MAX32655_DATS_CONNECTED_TEST == 'true' || env.MAX32655_RUN_ALL_TEST == 'true'}}
         run: | 
           DATS_TEST_DIR=$TEST_DIR/dats     
           DATS_BOARD_655=max32655_board1
@@ -662,17 +662,17 @@ jobs:
 
 
       - name: Erase Boards OTAS
-        if: ${{env.MAX32655_DATS_CONNECTED_TEST == 'true' || env.MAX32665_DATS_CONNECTED_TEST == 'true' || env.MAX32690_DATS_CONNECTED_TEST == 'true'}}
+        if: ${{env.MAX32655_DATS_CONNECTED_TEST == 'true' || env.MAX32655_RUN_ALL_TEST == 'true'}}
         uses: Analog-Devices-MSDK/btm-ci-scripts/actions/ocderase@v1.1
         with:
           board: |
             max32655_board1
             max32655_board2
-            max32665_board1
-            max32690_board_w1
+            # max32665_board1
+            # max32690_board_w1
       
       - name: Flash OTAS
-        if: ${{env.MAX32655_DATS_CONNECTED_TEST == 'true' || env.MAX32665_DATS_CONNECTED_TEST == 'true' || env.MAX32690_DATS_CONNECTED_TEST == 'true'}}
+        if: ${{env.MAX32655_DATS_CONNECTED_TEST == 'true' || env.MAX32655_RUN_ALL_TEST == 'true'}}
         uses: Analog-Devices-MSDK/btm-ci-scripts/actions/ocdflash@v1.1
         with:
           board: |
@@ -695,13 +695,13 @@ jobs:
           distclean: true
 
       - name: OTAS
-        if: ${{env.MAX32655_DATS_CONNECTED_TEST == 'true' || env.MAX32665_DATS_CONNECTED_TEST == 'true' || env.MAX32690_DATS_CONNECTED_TEST == 'true'}}
+        if: ${{env.MAX32655_DATS_CONNECTED_TEST == 'true' || env.MAX32655_RUN_ALL_TEST == 'true'}}
         run: | 
           OTAS_TEST_DIR=$TEST_DIR/otas
           OTAS_BOARD_655=max32655_board1
           OTAC_BOARD_655=max32655_board2
-          OTAC_BOARD_665=max32665_board1
-          OTAC_BOARD_690=max32690_board_w1
+          # OTAC_BOARD_665=max32665_board1
+          # OTAC_BOARD_690=max32690_board_w1
 
 
           if [[ $MAX32655_OTAS_CONNECTED_TEST == 'true' ]]; then

--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -595,8 +595,6 @@ jobs:
           boards: |
             max32655_board1
             max32655_board2
-            # max32665_board1
-            # max32690_board_w1
           lock: true
           timeout: 3600 # Attempt to lock for an hour
 
@@ -621,8 +619,6 @@ jobs:
           board: |
             max32655_board1
             max32655_board2
-            # max32665_board1
-            # max32690_board_w1
 
           has_two_flash_banks: |
             true
@@ -668,8 +664,6 @@ jobs:
           board: |
             max32655_board1
             max32655_board2
-            # max32665_board1
-            # max32690_board_w1
       
       - name: Flash OTAS
         if: ${{env.MAX32655_DATS_CONNECTED_TEST == 'true' || env.MAX32655_RUN_ALL_TEST == 'true'}}

--- a/Libraries/Cordio/controller/sources/ble/init/init.c
+++ b/Libraries/Cordio/controller/sources/ble/init/init.c
@@ -319,16 +319,22 @@ uint32_t LlInitSetLlRtCfg(const LlRtCfg_t *pLlRtCfg, uint8_t *pFreeMem, uint32_t
 /*************************************************************************************************/
 uint32_t LlInitSetRtCfg(LlInitRtCfg_t *pCfg)
 {
-  uint32_t memUsed = LlInitSetBbRtCfg(pCfg->pBbRtCfg, pCfg->wlSizeCfg, pCfg->rlSizeCfg, pCfg->plSizeCfg,
+  uint32_t totalMemUsed = 0;
+  uint32_t memUsed;
+
+  memUsed = LlInitSetBbRtCfg(pCfg->pBbRtCfg, pCfg->wlSizeCfg, pCfg->rlSizeCfg, pCfg->plSizeCfg,
                                  pCfg->pFreeMem, pCfg->freeMemAvail);
+
   pCfg->pFreeMem += memUsed;
   pCfg->freeMemAvail -= memUsed;
+  totalMemUsed += memUsed;
 
-  memUsed += LlInitSetLlRtCfg(pCfg->pLlRtCfg, pCfg->pFreeMem, pCfg->freeMemAvail);
+  memUsed = LlInitSetLlRtCfg(pCfg->pLlRtCfg, pCfg->pFreeMem, pCfg->freeMemAvail);
   pCfg->pFreeMem += memUsed;
   pCfg->freeMemAvail -= memUsed;
+  totalMemUsed += memUsed;
 
-  return memUsed;
+  return totalMemUsed;
 }
 
 /*************************************************************************************************/


### PR DESCRIPTION
### Description

#### Problem

- `LlInitSetRtCfg()` was first implemented in the [mallinfo PR](https://github.com/analogdevicesinc/msdk/pull/1179/files#diff-7d918cdc331800eea5a880227f42b3b870c5b4529dc90a38978c1f218cd6c08a)
- `totalMemUsed` was not utilized.  `memUsed` was incremented -- instead of overwritten -- when calling `LlInitSetLlRtCfg()` in addition to the preceding `LlInitSetBbRtCfg()`, whose memory usage was already accounted for. This is not accurate.

#### Fix

- Leverage `totalMemUsed`
- Overwrite `memUsed` when calling either `LlInitSetLlRtCfg()` or `LlInitSetBbRtCfg()`


