### PR TITLE
fix(Examples): Fixed PHY selection bug in RF Test

### DIFF
--- a/Examples/MAX32655/Bluetooth/RF_Test/main.c
+++ b/Examples/MAX32655/Bluetooth/RF_Test/main.c
@@ -706,8 +706,11 @@ void txTestTask(void *pvParameters)
         if (testConfig.testType == BLE_TX_TEST) {
             res = LlEnhancedTxTest(testConfig.channel, packetLen, packetType, phy, 0);
         } else {
-            // Transmitters decision if it is S2 or S8.
-            res = LlEnhancedRxTest(testConfig.channel, LL_PHY_LE_CODED, 0, 0);
+            // Transmitters decision if it is S2 or S8. 
+            if(phy == LL_PHY_LE_CODED_S8 || phy == LL_PHY_LE_CODED_S2 ) {
+                phy = LL_PHY_LE_CODED;
+            }
+            res = LlEnhancedRxTest(testConfig.channel, phy, 0, 0);
         }
         xTaskResumeAll(); //Restore scheduler
 

--- a/Examples/MAX32655/Bluetooth/RF_Test/main.c
+++ b/Examples/MAX32655/Bluetooth/RF_Test/main.c
@@ -706,7 +706,8 @@ void txTestTask(void *pvParameters)
         if (testConfig.testType == BLE_TX_TEST) {
             res = LlEnhancedTxTest(testConfig.channel, packetLen, packetType, phy, 0);
         } else {
-            res = LlEnhancedRxTest(testConfig.channel, phy, 0, 0);
+            // Transmitters decision if it is S2 or S8. 
+            res = LlEnhancedRxTest(testConfig.channel, LL_PHY_LE_CODED, 0, 0);
         }
         xTaskResumeAll(); //Restore scheduler
 

--- a/Examples/MAX32655/Bluetooth/RF_Test/main.c
+++ b/Examples/MAX32655/Bluetooth/RF_Test/main.c
@@ -706,7 +706,7 @@ void txTestTask(void *pvParameters)
         if (testConfig.testType == BLE_TX_TEST) {
             res = LlEnhancedTxTest(testConfig.channel, packetLen, packetType, phy, 0);
         } else {
-            // Transmitters decision if it is S2 or S8. 
+            // Transmitters decision if it is S2 or S8.
             res = LlEnhancedRxTest(testConfig.channel, LL_PHY_LE_CODED, 0, 0);
         }
         xTaskResumeAll(); //Restore scheduler

--- a/Examples/MAX32655/Bluetooth/RF_Test/main.c
+++ b/Examples/MAX32655/Bluetooth/RF_Test/main.c
@@ -706,8 +706,8 @@ void txTestTask(void *pvParameters)
         if (testConfig.testType == BLE_TX_TEST) {
             res = LlEnhancedTxTest(testConfig.channel, packetLen, packetType, phy, 0);
         } else {
-            // Transmitters decision if it is S2 or S8. 
-            if(phy == LL_PHY_LE_CODED_S8 || phy == LL_PHY_LE_CODED_S2 ) {
+            // Transmitters decision if it is S2 or S8.
+            if (phy == LL_PHY_LE_CODED_S8 || phy == LL_PHY_LE_CODED_S2) {
                 phy = LL_PHY_LE_CODED;
             }
             res = LlEnhancedRxTest(testConfig.channel, phy, 0, 0);

--- a/Examples/MAX32665/Bluetooth/RF_Test/main.c
+++ b/Examples/MAX32665/Bluetooth/RF_Test/main.c
@@ -709,8 +709,8 @@ void txTestTask(void *pvParameters)
         if (testConfig.testType == BLE_TX_TEST) {
             res = LlEnhancedTxTest(testConfig.channel, packetLen, packetType, phy, 0);
         } else {
-            // Transmitters decision if it is S2 or S8. 
-            if(phy == LL_PHY_LE_CODED_S8 || phy == LL_PHY_LE_CODED_S2 ) {
+            // Transmitters decision if it is S2 or S8.
+            if (phy == LL_PHY_LE_CODED_S8 || phy == LL_PHY_LE_CODED_S2) {
                 phy = LL_PHY_LE_CODED;
             }
             res = LlEnhancedRxTest(testConfig.channel, phy, 0, 0);

--- a/Examples/MAX32665/Bluetooth/RF_Test/main.c
+++ b/Examples/MAX32665/Bluetooth/RF_Test/main.c
@@ -709,8 +709,11 @@ void txTestTask(void *pvParameters)
         if (testConfig.testType == BLE_TX_TEST) {
             res = LlEnhancedTxTest(testConfig.channel, packetLen, packetType, phy, 0);
         } else {
-            // Transmitters decision if S2 or S8
-            res = LlEnhancedRxTest(testConfig.channel, LL_PHY_LE_CODED, 0, 0);
+            // Transmitters decision if it is S2 or S8. 
+            if(phy == LL_PHY_LE_CODED_S8 || phy == LL_PHY_LE_CODED_S2 ) {
+                phy = LL_PHY_LE_CODED;
+            }
+            res = LlEnhancedRxTest(testConfig.channel, phy, 0, 0);
         }
         xTaskResumeAll(); //Restore scheduler
 

--- a/Examples/MAX32665/Bluetooth/RF_Test/main.c
+++ b/Examples/MAX32665/Bluetooth/RF_Test/main.c
@@ -709,7 +709,8 @@ void txTestTask(void *pvParameters)
         if (testConfig.testType == BLE_TX_TEST) {
             res = LlEnhancedTxTest(testConfig.channel, packetLen, packetType, phy, 0);
         } else {
-            res = LlEnhancedRxTest(testConfig.channel, phy, 0, 0);
+            // Transmitters decision if S2 or S8
+            res = LlEnhancedRxTest(testConfig.channel, LL_PHY_LE_CODED, 0, 0);
         }
         xTaskResumeAll(); //Restore scheduler
 

--- a/Examples/MAX32690/Bluetooth/RF_Test/main.c
+++ b/Examples/MAX32690/Bluetooth/RF_Test/main.c
@@ -710,8 +710,8 @@ void txTestTask(void *pvParameters)
         if (testConfig.testType == BLE_TX_TEST) {
             res = LlEnhancedTxTest(testConfig.channel, packetLen, packetType, phy, 0);
         } else {
-            // Transmitters decision if it is S2 or S8. 
-            if(phy == LL_PHY_LE_CODED_S8 || phy == LL_PHY_LE_CODED_S2 ) {
+            // Transmitters decision if it is S2 or S8.
+            if (phy == LL_PHY_LE_CODED_S8 || phy == LL_PHY_LE_CODED_S2) {
                 phy = LL_PHY_LE_CODED;
             }
             res = LlEnhancedRxTest(testConfig.channel, phy, 0, 0);

--- a/Examples/MAX32690/Bluetooth/RF_Test/main.c
+++ b/Examples/MAX32690/Bluetooth/RF_Test/main.c
@@ -710,7 +710,8 @@ void txTestTask(void *pvParameters)
         if (testConfig.testType == BLE_TX_TEST) {
             res = LlEnhancedTxTest(testConfig.channel, packetLen, packetType, phy, 0);
         } else {
-            res = LlEnhancedRxTest(testConfig.channel, phy, 0, 0);
+            // Transmitters decision if S2 or S8
+            res = LlEnhancedRxTest(testConfig.channel, LL_PHY_LE_CODED, 0, 0);
         }
         xTaskResumeAll(); //Restore scheduler
 

--- a/Examples/MAX32690/Bluetooth/RF_Test/main.c
+++ b/Examples/MAX32690/Bluetooth/RF_Test/main.c
@@ -710,8 +710,11 @@ void txTestTask(void *pvParameters)
         if (testConfig.testType == BLE_TX_TEST) {
             res = LlEnhancedTxTest(testConfig.channel, packetLen, packetType, phy, 0);
         } else {
-            // Transmitters decision if S2 or S8
-            res = LlEnhancedRxTest(testConfig.channel, LL_PHY_LE_CODED, 0, 0);
+            // Transmitters decision if it is S2 or S8. 
+            if(phy == LL_PHY_LE_CODED_S8 || phy == LL_PHY_LE_CODED_S2 ) {
+                phy = LL_PHY_LE_CODED;
+            }
+            res = LlEnhancedRxTest(testConfig.channel, phy, 0, 0);
         }
         xTaskResumeAll(); //Restore scheduler
 


### PR DESCRIPTION
### Description

Updated example to pass the coded mode option instead of the S2 or S8 option.

Addresses #1249 