### PR TITLE
feat(Build): Added CXX_STANDARD flag to override default when compiling for C++

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
@@ -405,10 +405,11 @@ CFLAGS=-mthumb                                                                 \
 
 # The flags passed to the C++ compiler.
 CXXFLAGS := $(CFLAGS)
+CXX_STANDARD?=17
 CXXFLAGS += \
 	-fno-rtti				\
 	-fno-exceptions				\
-	-std=c++11				\
+	-std=c++$(CXX_STANDARD)				
 
 # On GCC version > 4.8.0 use the -fno-isolate-erroneous-paths-dereference flag
 ifeq "$(GCCVERSIONGTEQ4)" "1"


### PR DESCRIPTION
### Description
Added CXX_STANDARD flag used in project.mk as ``CXX_STANDARD=14``.Which results in ``-std=c++14`` default value is 17 if not specified