### PR TITLE
fix(PeriphDrivers): I2C REVA Inifnite Loop

### DIFF
--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
@@ -994,7 +994,7 @@ int MXC_I2C_RevA_MasterTransaction(mxc_i2c_reva_req_t *req)
     } else {
         i2c->mstctrl |= MXC_F_I2C_REVA_MSTCTRL_STOP;
 
-        while (!(i2c->mstctrl & MXC_F_I2C_REVA_MSTCTRL_STOP)) {}
+        while (!(i2c->intfl0 & MXC_F_I2C_REVA_INTFL0_STOP)) {}
         // Wait for Transaction to finish
     }
 

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
@@ -994,7 +994,7 @@ int MXC_I2C_RevA_MasterTransaction(mxc_i2c_reva_req_t *req)
     } else {
         i2c->mstctrl |= MXC_F_I2C_REVA_MSTCTRL_STOP;
 
-        while (!(i2c->intfl0 & MXC_F_I2C_REVA_INTFL0_STOP)) {}
+        while ((i2c->mstctrl & MXC_F_I2C_REVA_MSTCTRL_STOP)) {}
         // Wait for Transaction to finish
     }
 


### PR DESCRIPTION
### Description
Fixed issues in ``MXC_I2C_RevA_MasterTransaction`` where after stop condition sent, the code spun on the stop condition send bit being cleared. The ``MSTRCTRL`` stop bit is cleared when the stop condition has started, we spin while that bit is 0, therefore we always spin since it clears instantly, or at least faster than the processor can read it.  

The original interrupt flag check is wrong too, since it detects when a stop condition occurs. The correct logic is to wait on the send bit until hardware clears it for us. This most likely previously worked because of this line 
``i2c->intfl0 = MXC_F_I2C_REVA_INTFL0_DONE;``. Meaning although "safer" we probably don't need to wait for the stop condition to be sent.

Address #1261