### PR TITLE
fix(BLE): Setting dtmRxSyncMs to 10.

### DIFF
--- a/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_cfg.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_cfg.c
@@ -172,7 +172,7 @@ void palCfgLoadLlParams(uint8_t *pConfig)
   pCfg->cisSubEvtSpaceDelay   = 0;
   pCfg->maxBig                = 0;
   pCfg->maxBis                = 0;
-  pCfg->dtmRxSyncMs           = 1; /* effect PER */
+  pCfg->dtmRxSyncMs           = 10; /* effect PER */
 #endif
 }
 

--- a/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_cfg.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_cfg.c
@@ -172,7 +172,7 @@ void palCfgLoadLlParams(uint8_t *pConfig)
   pCfg->cisSubEvtSpaceDelay   = 0;
   pCfg->maxBig                = 0;
   pCfg->maxBis                = 0;
-  pCfg->dtmRxSyncMs           = 1; /* effect PER */
+  pCfg->dtmRxSyncMs           = 10; /* effect PER */
 #endif
 }
 

--- a/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_cfg.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_cfg.c
@@ -172,7 +172,7 @@ void palCfgLoadLlParams(uint8_t *pConfig)
   pCfg->cisSubEvtSpaceDelay   = 0;
   pCfg->maxBig                = 0;
   pCfg->maxBis                = 0;
-  pCfg->dtmRxSyncMs           = 1; /* effect PER */
+  pCfg->dtmRxSyncMs           = 10; /* effect PER */
 #endif
 }
 


### PR DESCRIPTION
### Description

This solves a Bluetooth test mode problem when receiving long packets. Increasing the sync time to 10 ms prevents the receiver from timing out while receiving packets from the tester. 

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
