### PR TITLE
fix(BLE): Zephyr: enable aes driver when BT selected.

### DIFF
--- a/Libraries/zephyr/MAX/Source/MAX32655/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32655/CMakeLists.txt
@@ -176,11 +176,15 @@ zephyr_library_sources(
 )
 endif()
 
-if (CONFIG_CRYPTO_MAX32)
+if (CONFIG_CRYPTO_MAX32 OR CONFIG_BT)
 zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/AES/aes_me17.c
     ${MSDK_PERIPH_SRC_DIR}/AES/aes_revb.c
+)
+endif()
 
+if (CONFIG_CRYPTO_MAX32)
+zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/CRC/crc_me17.c
     ${MSDK_PERIPH_SRC_DIR}/CRC/crc_reva.c
 )

--- a/Libraries/zephyr/MAX/Source/MAX32657/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32657/CMakeLists.txt
@@ -142,11 +142,15 @@ zephyr_library_sources(
 )
 endif()
 
-if (CONFIG_CRYPTO_MAX32)
+if (CONFIG_CRYPTO_MAX32 OR CONFIG_BT)
 zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/AES/aes_me30.c
     ${MSDK_PERIPH_SRC_DIR}/AES/aes_revb.c
+)
+endif()
 
+if (CONFIG_CRYPTO_MAX32)
+zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/CRC/crc_me30.c
     ${MSDK_PERIPH_SRC_DIR}/CRC/crc_reva.c
 )


### PR DESCRIPTION
### Description

When BT is selected during a zephyr build, need to also include msdk hal driver support for aes as we do not have any zephyr aes driver in zephyr layer.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.