### PR TITLE
fix(CMSIS): Checking for definition of MXC_DMA1.

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.h
@@ -705,7 +705,7 @@ We may want to handle GET_IRQ better...
 #define MXC_BASE_DMA0 MXC_BASE_DMA0_NS
 #define MXC_DMA0 MXC_DMA0_NS
 /* MXC_DMA1 is not defined because Non-Secure Code can only access DMA0. */
-#if MXC_DMA1
+#ifdef MXC_DMA1
 #warning "Secure DMA (DMA1) is not accessible from Non-Secure world."
 #endif
 


### PR DESCRIPTION
### Description

Solves a build error when building without secure execution.

```bash
+++ Compiling: ../../../MAX32657/source/pal_bb_drv.c
In file included from ../../../../../Libraries/PeriphDrivers/Include/MAX32657/mxc_device.h:22,
                 from ../../../MAX32657/include/dbb_registers.h:47,
                 from ../../../MAX32657/source/pal_bb_drv.c:54:
../../../../../Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.h:708:5: error: "MXC_DMA1" is not defined, evaluates to 0 [-Werror=undef]
  708 | #if MXC_DMA1
```

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
