### PR TITLE
fix(PeriphDrivers): Fix GPIO Structure Collision for HART UART

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32675/mxc_pins.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/mxc_pins.h
@@ -44,7 +44,9 @@ extern const mxc_gpio_cfg_t gpio_cfg_uart0_flow;
 extern const mxc_gpio_cfg_t gpio_cfg_uart0_flow_disable;
 extern const mxc_gpio_cfg_t gpio_cfg_uart1;
 extern const mxc_gpio_cfg_t gpio_cfg_uart1_flow;
-extern const mxc_gpio_cfg_t hart_gpio_cfg_uart2;
+
+extern const mxc_gpio_cfg_t gpio_cfg_hart;
+
 extern const mxc_gpio_cfg_t gpio_cfg_uart2;
 extern const mxc_gpio_cfg_t gpio_cfg_uart2_flow;
 extern const mxc_gpio_cfg_t gpio_cfg_uart2_flow_disable;

--- a/Libraries/PeriphDrivers/Include/MAX32675/mxc_pins.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/mxc_pins.h
@@ -44,6 +44,7 @@ extern const mxc_gpio_cfg_t gpio_cfg_uart0_flow;
 extern const mxc_gpio_cfg_t gpio_cfg_uart0_flow_disable;
 extern const mxc_gpio_cfg_t gpio_cfg_uart1;
 extern const mxc_gpio_cfg_t gpio_cfg_uart1_flow;
+extern const mxc_gpio_cfg_t hart_gpio_cfg_uart2;
 extern const mxc_gpio_cfg_t gpio_cfg_uart2;
 extern const mxc_gpio_cfg_t gpio_cfg_uart2_flow;
 extern const mxc_gpio_cfg_t gpio_cfg_uart2_flow_disable;

--- a/Libraries/PeriphDrivers/Include/MAX32680/mxc_pins.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/mxc_pins.h
@@ -41,6 +41,8 @@ extern const mxc_gpio_cfg_t gpio_cfg_i2c2;
 extern const mxc_gpio_cfg_t gpio_cfg_i2c2b;
 extern const mxc_gpio_cfg_t gpio_cfg_i2c2c;
 
+extern const mxc_gpio_cfg_t gpio_cfg_hart;
+
 extern const mxc_gpio_cfg_t gpio_cfg_uart0;
 extern const mxc_gpio_cfg_t gpio_cfg_uart0_flow;
 extern const mxc_gpio_cfg_t gpio_cfg_uart0_flow_disable;

--- a/Libraries/PeriphDrivers/Source/AFE/hart_uart.c
+++ b/Libraries/PeriphDrivers/Source/AFE/hart_uart.c
@@ -198,7 +198,7 @@ static int hart_uart_init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
         break;
 
     case 2:
-        MXC_AFE_GPIO_Config(&gpio_cfg_uart2);
+        MXC_AFE_GPIO_Config(&hart_gpio_cfg_uart2);
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_UART2);
         break;
 

--- a/Libraries/PeriphDrivers/Source/AFE/hart_uart.c
+++ b/Libraries/PeriphDrivers/Source/AFE/hart_uart.c
@@ -193,12 +193,12 @@ static int hart_uart_init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
 
     switch (MXC_UART_GET_IDX(uart)) {
     case 0:
-        MXC_AFE_GPIO_Config(&gpio_cfg_uart0);
+        MXC_AFE_GPIO_Config(&gpio_cfg_hart);
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_UART0);
         break;
 
     case 2:
-        MXC_AFE_GPIO_Config(&hart_gpio_cfg_uart2);
+        MXC_AFE_GPIO_Config(&gpio_cfg_hart);
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_UART2);
         break;
 

--- a/Libraries/PeriphDrivers/Source/SYS/pins_me16.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_me16.c
@@ -56,8 +56,8 @@ const mxc_gpio_cfg_t gpio_cfg_uart1_flow_disable = { MXC_GPIO0, (MXC_GPIO_PIN_30
                                                      MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
 // NOTE: UART2 mapping B is tied to HART modem in the AFE and cannot be moved.
-const mxc_gpio_cfg_t hart_gpio_cfg_uart2 = { MXC_GPIO0, (MXC_GPIO_PIN_14 | MXC_GPIO_PIN_15), MXC_GPIO_FUNC_ALT2,
-                                                MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_hart = { MXC_GPIO0, (MXC_GPIO_PIN_14 | MXC_GPIO_PIN_15), MXC_GPIO_FUNC_ALT2,
+                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
 const mxc_gpio_cfg_t gpio_cfg_uart2 = { MXC_GPIO1, (MXC_GPIO_PIN_8 | MXC_GPIO_PIN_9), MXC_GPIO_FUNC_ALT1,
                                         MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };

--- a/Libraries/PeriphDrivers/Source/SYS/pins_me16.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_me16.c
@@ -55,6 +55,10 @@ const mxc_gpio_cfg_t gpio_cfg_uart1_flow = { MXC_GPIO0, (MXC_GPIO_PIN_30 | MXC_G
 const mxc_gpio_cfg_t gpio_cfg_uart1_flow_disable = { MXC_GPIO0, (MXC_GPIO_PIN_30 | MXC_GPIO_PIN_31), MXC_GPIO_FUNC_IN,
                                                      MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
+// NOTE: UART2 mapping B is tied to HART modem in the AFE and cannot be moved.
+const mxc_gpio_cfg_t hart_gpio_cfg_uart2 = { MXC_GPIO0, (MXC_GPIO_PIN_14 | MXC_GPIO_PIN_15), MXC_GPIO_FUNC_ALT2,
+                                                MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+
 const mxc_gpio_cfg_t gpio_cfg_uart2 = { MXC_GPIO1, (MXC_GPIO_PIN_8 | MXC_GPIO_PIN_9), MXC_GPIO_FUNC_ALT1,
                                         MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart2_flow = { MXC_GPIO1, (MXC_GPIO_PIN_10 | MXC_GPIO_PIN_11), MXC_GPIO_FUNC_ALT1,

--- a/Libraries/PeriphDrivers/Source/SYS/pins_me20.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_me20.c
@@ -41,6 +41,10 @@ const mxc_gpio_cfg_t gpio_cfg_i2c1 = { MXC_GPIO0, (MXC_GPIO_PIN_16 | MXC_GPIO_PI
 const mxc_gpio_cfg_t gpio_cfg_i2c2 = { MXC_GPIO0, (MXC_GPIO_PIN_30 | MXC_GPIO_PIN_31), MXC_GPIO_FUNC_ALT1,
                                        MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
+// NOTE: UART0 is tied to HART modem in the AFE and cannot be moved.
+const mxc_gpio_cfg_t gpio_cfg_hart = { MXC_GPIO0, (MXC_GPIO_PIN_0 | MXC_GPIO_PIN_1), MXC_GPIO_FUNC_ALT1,
+                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+
 const mxc_gpio_cfg_t gpio_cfg_uart0 = { MXC_GPIO0, (MXC_GPIO_PIN_0 | MXC_GPIO_PIN_1), MXC_GPIO_FUNC_ALT1,
                                         MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart0_flow = { MXC_GPIO0, (MXC_GPIO_PIN_2 | MXC_GPIO_PIN_3), MXC_GPIO_FUNC_ALT2,


### PR DESCRIPTION
Use dedicated gpio structure for HART UART to avoid collision issues with multiple mappings.

### Description

Please include a summary of the changes and related issues. Please also include relevant motivation and context.

### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [X] Description of changes and all other relevant information.
- [X] Validated working example with 260 byte long HART message echo.