### PR TITLE
fix(Examples): Link to the libphy.a directory in MAX32657 BLE5_ctr

### DIFF
--- a/Examples/MAX32657/Bluetooth/BLE5_ctr/project.mk
+++ b/Examples/MAX32657/Bluetooth/BLE5_ctr/project.mk
@@ -28,7 +28,7 @@
 LIB_CORDIO = 1
 
 CORDIO_DIR = $(LIBS_DIR)/Packetcraft-ADI
-RF_PHY_DIR = $(LIBS_DIR)/RF-PHY
+LIB_PHY_DIR = $(LIBS_DIR)/RF-PHY
 
 # Cordio library options
 BLE_HOST = 0

--- a/Examples/MAX32657/Bluetooth/BLE5_ctr/project.mk
+++ b/Examples/MAX32657/Bluetooth/BLE5_ctr/project.mk
@@ -28,7 +28,7 @@
 LIB_CORDIO = 1
 
 CORDIO_DIR = $(LIBS_DIR)/Packetcraft-ADI
-LIB_PHY_DIR = $(LIBS_DIR)/RF-PHY
+LIB_PHY_DIR ?= $(LIBS_DIR)/RF-PHY
 
 # Cordio library options
 BLE_HOST = 0


### PR DESCRIPTION
### Description

The BLE5_ctr example for the MAX32657 was failing to find the `libphy.a` file. The `project.mk` file was modified accordingly.
