### PR TITLE
Fix(typo): there is a typo for max32660 include

### DIFF
--- a/Libraries/zephyr/MAX/Include/wrap_max32xxx.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32xxx.h
@@ -36,7 +36,7 @@ extern "C" {
 #elif defined(CONFIG_SOC_MAX32655)
 #include <max32655.h>
 #elif defined(CONFIG_SOC_MAX32660)
-#include <max326660.h>
+#include <max32660.h>
 #elif defined(CONFIG_SOC_MAX32662)
 #include <max32662.h>
 #elif defined(CONFIG_SOC_MAX32665)


### PR DESCRIPTION
max326660.h -> max32660.h

### Description

Fix typo in include directive

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

_______________________________________________________________________________

