### PR TITLE
style(Other): Update conditional compilation directives for `CONFIG_SOC_*` definitions in Zephyr wrapper

### DIFF
--- a/Libraries/zephyr/MAX/Include/wrap_max32_adc.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_adc.h
@@ -53,8 +53,8 @@ typedef enum {
 /*
  *  MAX32655, MAX32665, MAX32666 related mapping
  */
-#if defined(CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666) || \
-    (CONFIG_SOC_MAX32680)
+#if defined(CONFIG_SOC_MAX32655) || defined(CONFIG_SOC_MAX32665) || \
+    defined(CONFIG_SOC_MAX32666) || defined(CONFIG_SOC_MAX32680)
 
 #define WRAP_MXC_F_ADC_CONV_DONE_IE MXC_F_ADC_INTR_DONE_IE
 #define WRAP_MXC_F_ADC_CONV_DONE_IF MXC_F_ADC_INTR_DONE_IF
@@ -153,8 +153,8 @@ static inline void Wrap_MXC_ADC_GetData(uint16_t **outdata)
 /*
  *  MAX32690,  related mapping
  */
-#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || \
-    (CONFIG_SOC_MAX78002)
+#elif defined(CONFIG_SOC_MAX32690) || defined(CONFIG_SOC_MAX32672) || \
+    defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX78002)
 
 #define WRAP_MXC_F_ADC_CONV_DONE_IE MXC_F_ADC_INTEN_SEQ_DONE
 #define WRAP_MXC_F_ADC_CONV_DONE_IF MXC_F_ADC_INTFL_SEQ_DONE

--- a/Libraries/zephyr/MAX/Include/wrap_max32_dma.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_dma.h
@@ -26,7 +26,7 @@
 extern "C" {
 #endif
 
-#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
 #define ADI_MAX32_DMA_CTRL_DIS_IE MXC_F_DMA_CFG_CHDIEN
 #define ADI_MAX32_DMA_CTRL_CTZIEN MXC_F_DMA_CFG_CTZIEN
 
@@ -50,7 +50,7 @@ extern "C" {
 
 static inline int MXC_DMA_GetIntFlags(mxc_dma_regs_t *dma)
 {
-#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
     return dma->intr;
 #else
     return dma->intfl;
@@ -59,7 +59,7 @@ static inline int MXC_DMA_GetIntFlags(mxc_dma_regs_t *dma)
 
 static inline int Wrap_MXC_DMA_Init(mxc_dma_regs_t *dma)
 {
-#if defined(CONFIG_SOC_MAX32657) || (CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
     return MXC_DMA_Init(dma);
 #else
     (void)dma;
@@ -69,7 +69,7 @@ static inline int Wrap_MXC_DMA_Init(mxc_dma_regs_t *dma)
 
 static inline void Wrap_MXC_DMA_DeInit(mxc_dma_regs_t *dma)
 {
-#if defined(CONFIG_SOC_MAX32657) || (CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
     MXC_DMA_DeInit(dma);
 #else
     (void)dma;
@@ -79,7 +79,7 @@ static inline void Wrap_MXC_DMA_DeInit(mxc_dma_regs_t *dma)
 
 static inline int Wrap_MXC_DMA_AcquireChannel(mxc_dma_regs_t *dma)
 {
-#if defined(CONFIG_SOC_MAX32657) || (CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
     return MXC_DMA_AcquireChannel(dma);
 #else
     (void)dma;
@@ -89,7 +89,7 @@ static inline int Wrap_MXC_DMA_AcquireChannel(mxc_dma_regs_t *dma)
 
 static inline void Wrap_MXC_DMA_Handler(mxc_dma_regs_t *dma)
 {
-#if defined(CONFIG_SOC_MAX32657) || (CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
     MXC_DMA_Handler(dma);
 #else
     (void)dma;
@@ -100,7 +100,7 @@ static inline void Wrap_MXC_DMA_Handler(mxc_dma_regs_t *dma)
 static inline int Wrap_MXC_DMA_MemCpy(mxc_dma_regs_t *dma, void *dest, void *src, int len,
                                       mxc_dma_complete_cb_t callback)
 {
-#if defined(CONFIG_SOC_MAX32657) || (CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
     return MXC_DMA_MemCpy(dma, dest, src, len, callback);
 #else
     (void)dma;
@@ -112,7 +112,7 @@ static inline int Wrap_MXC_DMA_DoTransfer(mxc_dma_regs_t *dma, mxc_dma_config_t 
                                           mxc_dma_srcdst_t firstSrcDst,
                                           mxc_dma_trans_chain_t callback)
 {
-#if defined(CONFIG_SOC_MAX32657) || (CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
     return MXC_DMA_DoTransfer(dma, config, firstSrcDst, callback);
 #else
     (void)dma;

--- a/Libraries/zephyr/MAX/Include/wrap_max32_i2c.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_i2c.h
@@ -29,7 +29,7 @@ extern "C" {
 /*
  *  MAX32665, MAX32666 related mapping
  */
-#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
 
 /*
  *  Control register bits
@@ -128,9 +128,10 @@ static inline void Wrap_MXC_I2C_Stop(mxc_i2c_regs_t *i2c)
 /*
  *  MAX32690, MAX32655 related mapping
  */
-#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32670) || \
-    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675) ||          \
-    (CONFIG_SOC_MAX32680) || (CONFIG_SOC_MAX32657) || (CONFIG_SOC_MAX78002)
+#elif defined(CONFIG_SOC_MAX32690) || defined(CONFIG_SOC_MAX32655) || \
+    defined(CONFIG_SOC_MAX32670) || defined(CONFIG_SOC_MAX32672) ||   \
+    defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32675) ||   \
+    defined(CONFIG_SOC_MAX32680) || defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX78002)
 /*
  *  Control register bits
  */

--- a/Libraries/zephyr/MAX/Include/wrap_max32_lp.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_lp.h
@@ -29,8 +29,9 @@ extern "C" {
 /*
  *  MAX32665, MAX32666 related mapping
  */
-#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666) || (CONFIG_SOC_MAX32670) || \
-    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666) || \
+    defined(CONFIG_SOC_MAX32670) || defined(CONFIG_SOC_MAX32672) || \
+    defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32675)
 
 static inline void Wrap_MXC_LP_EnterLowPowerMode(void)
 {
@@ -55,8 +56,8 @@ static inline void Wrap_MXC_LP_EnterPowerDownMode(void)
 /*
  *  MAX32690, MAX32655 related mapping
  */
-#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32680) || \
-    (CONFIG_SOC_MAX32657) || (CONFIG_SOC_MAX78002)
+#elif defined(CONFIG_SOC_MAX32690) || defined(CONFIG_SOC_MAX32655) || \
+    defined(CONFIG_SOC_MAX32680) || defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX78002)
 
 static inline void Wrap_MXC_LP_EnterLowPowerMode(void)
 {

--- a/Libraries/zephyr/MAX/Include/wrap_max32_owm.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_owm.h
@@ -29,7 +29,7 @@ extern "C" {
 /*
  *  MAX32665, MAX32666 related mapping
  */
-#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
 
 static inline int Wrap_MXC_OWM_Init(const mxc_owm_cfg_t *cfg)
 {
@@ -40,8 +40,8 @@ static inline int Wrap_MXC_OWM_Init(const mxc_owm_cfg_t *cfg)
 /*
  *  MAX32690, MAX32655 related mapping
  */
-#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32680) || \
-    (CONFIG_SOC_MAX78002)
+#elif defined(CONFIG_SOC_MAX32690) || defined(CONFIG_SOC_MAX32655) || \
+    defined(CONFIG_SOC_MAX32680) || defined(CONFIG_SOC_MAX78002)
 
 static inline int Wrap_MXC_OWM_Init(const mxc_owm_cfg_t *cfg)
 {

--- a/Libraries/zephyr/MAX/Include/wrap_max32_spi.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_spi.h
@@ -29,7 +29,7 @@ extern "C" {
 /*
  *  MAX32665, MAX32666 related mapping
  */
-#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
 
 #define ADI_MAX32_SPI_CTRL_MASTER_MODE MXC_F_SPI_CTRL0_MASTER
 
@@ -73,9 +73,10 @@ static inline int Wrap_MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int qua
 /*
  *  MAX32690, MAX32655 related mapping
  */
-#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32670) || \
-    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675) ||          \
-    (CONFIG_SOC_MAX32680) || (CONFIG_SOC_MAX32657) || (CONFIG_SOC_MAX78002)
+#elif defined(CONFIG_SOC_MAX32690) || defined(CONFIG_SOC_MAX32655) || \
+    defined(CONFIG_SOC_MAX32670) || defined(CONFIG_SOC_MAX32672) ||   \
+    defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32675) ||   \
+    defined(CONFIG_SOC_MAX32680) || defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX78002)
 #if defined(CONFIG_SOC_MAX32657)
 #define ADI_MAX32_SPI_CTRL_MASTER_MODE MXC_F_SPI_CTRL0_CONT_MODE
 #else
@@ -128,7 +129,7 @@ static inline int Wrap_MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int qua
 static inline int Wrap_MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed,
                                     int numSlaves, unsigned ssPolarity, unsigned int hz)
 {
-#if defined(CONFIG_SOC_MAX32670) || (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32675)
+#if defined(CONFIG_SOC_MAX32670) || defined(CONFIG_SOC_MAX32672) || defined(CONFIG_SOC_MAX32675)
     return MXC_SPI_Init(spi, masterMode, quadModeUsed, numSlaves, ssPolarity, hz);
 #else
     mxc_spi_pins_t tmp; // not used

--- a/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
@@ -34,7 +34,7 @@ void max32xx_system_init(void);
 /*
  *  MAX32665, MAX32666 related mapping
  */
-#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
 
 #define ADI_MAX32_CLK_IPO MXC_SYS_CLOCK_HIRC96
 #define ADI_MAX32_CLK_ERFO MXC_SYS_CLOCK_XTAL32M
@@ -54,9 +54,10 @@ static inline void Wrap_MXC_SYS_SetClockDiv(int div)
 /*
  *  MAX32690, MAX32655 related mapping
  */
-#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32670) || \
-    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675) ||          \
-    (CONFIG_SOC_MAX32680) || (CONFIG_SOC_MAX32657) || (CONFIG_SOC_MAX78002)
+#elif defined(CONFIG_SOC_MAX32690) || defined(CONFIG_SOC_MAX32655) || \
+    defined(CONFIG_SOC_MAX32670) || defined(CONFIG_SOC_MAX32672) ||   \
+    defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32675) ||   \
+    defined(CONFIG_SOC_MAX32680) || defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX78002)
 
 #define ADI_MAX32_CLK_IPO MXC_SYS_CLOCK_IPO
 #if defined(CONFIG_SOC_MAX78002)
@@ -69,8 +70,8 @@ static inline void Wrap_MXC_SYS_SetClockDiv(int div)
 #define ADI_MAX32_CLK_INRO MXC_SYS_CLOCK_INRO
 #define ADI_MAX32_CLK_ERTCO MXC_SYS_CLOCK_ERTCO
 #define ADI_MAX32_CLK_EXTCLK MXC_SYS_CLOCK_EXTCLK
-#if !(defined(CONFIG_SOC_MAX32670) || (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || \
-      (CONFIG_SOC_MAX32675))
+#if !(defined(CONFIG_SOC_MAX32670) || defined(CONFIG_SOC_MAX32672) || \
+      defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32675))
 #define ADI_MAX32_CLK_ISO MXC_SYS_CLOCK_ISO
 #endif
 

--- a/Libraries/zephyr/MAX/Include/wrap_max32_tmr.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_tmr.h
@@ -39,7 +39,7 @@ typedef struct {
 /*
  *  MAX32665, MAX32666 related mapping
  */
-#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
 
 /* All timers are 32bits */
 #define WRAP_MXC_IS_32B_TIMER(idx) (1)
@@ -101,12 +101,13 @@ int Wrap_MXC_TMR_GetPendingInt(mxc_tmr_regs_t *tmr)
 /*
  *  MAX32690, MAX32655 related mapping
  */
-#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32670) || \
-    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675) ||          \
-    (CONFIG_SOC_MAX32680) || (CONFIG_SOC_MAX32657) || (CONFIG_SOC_MAX78002)
+#elif defined(CONFIG_SOC_MAX32690) || defined(CONFIG_SOC_MAX32655) || \
+    defined(CONFIG_SOC_MAX32670) || defined(CONFIG_SOC_MAX32672) ||   \
+    defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32675) ||   \
+    defined(CONFIG_SOC_MAX32680) || defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX78002)
 
-#if defined(CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32675) || (CONFIG_SOC_MAX32657) || \
-    (CONFIG_SOC_MAX32670)
+#if defined(CONFIG_SOC_MAX32672) || defined(CONFIG_SOC_MAX32675) || \
+    defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX32670)
 /* All timers are 32bits */
 #define WRAP_MXC_IS_32B_TIMER(idx) (1)
 #elif defined(CONFIG_SOC_MAX32662)
@@ -151,8 +152,8 @@ static inline int Wrap_MXC_TMR_GetClockIndex(int z_clock)
         return MXC_TMR_32K_CLK;
     case 5: //ADI_MAX32_PRPH_CLK_SRC_INRO
         return MXC_TMR_INRO_CLK;
-#if defined(CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32680) || (CONFIG_SOC_MAX32690) || \
-    (CONFIG_SOC_MAX78002)
+#if defined(CONFIG_SOC_MAX32655) || defined(CONFIG_SOC_MAX32680) || \
+    defined(CONFIG_SOC_MAX32690) || defined(CONFIG_SOC_MAX78002)
     case 6: //ADI_MAX32_PRPH_CLK_SRC_ISO
         return MXC_TMR_ISO_CLK;
 #endif

--- a/Libraries/zephyr/MAX/Include/wrap_max32_trng.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_trng.h
@@ -29,7 +29,7 @@ extern "C" {
 /*
  *  MAX32665, MAX32666 related mapping
  */
-#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
 
 static inline int Wrap_MXC_TRNG_RandomInt_NonBlocking(uint32_t *data)
 {
@@ -44,9 +44,10 @@ static inline int Wrap_MXC_TRNG_RandomInt_NonBlocking(uint32_t *data)
 /*
  *  MAX32690, MAX32655 related mapping
  */
-#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32670) || \
-    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675) ||          \
-    (CONFIG_SOC_MAX32680) || (CONFIG_SOC_MAX32657) || (CONFIG_SOC_MAX78002)
+#elif defined(CONFIG_SOC_MAX32690) || defined(CONFIG_SOC_MAX32655) || \
+    defined(CONFIG_SOC_MAX32670) || defined(CONFIG_SOC_MAX32672) ||   \
+    defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32675) ||   \
+    defined(CONFIG_SOC_MAX32680) || defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX78002)
 
 static inline int Wrap_MXC_TRNG_RandomInt_NonBlocking(uint32_t *data)
 {

--- a/Libraries/zephyr/MAX/Include/wrap_max32_uart.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_uart.h
@@ -26,7 +26,7 @@
 extern "C" {
 #endif
 
-#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
 // status flags
 #define ADI_MAX32_UART_RX_EMPTY MXC_F_UART_STATUS_RX_EMPTY
 #define ADI_MAX32_UART_TX_EMPTY MXC_F_UART_STATUS_TX_EMPTY
@@ -117,14 +117,15 @@ static inline void Wrap_MXC_UART_DisableRxDMA(mxc_uart_regs_t *uart)
 /*
  *  MAX32690, MAX32655 related mapping
  */
-#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32670) || \
-    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675) ||          \
-    (CONFIG_SOC_MAX32680) || (CONFIG_SOC_MAX32657) || (CONFIG_SOC_MAX78002)
+#elif defined(CONFIG_SOC_MAX32690) || defined(CONFIG_SOC_MAX32655) || \
+    defined(CONFIG_SOC_MAX32670) || defined(CONFIG_SOC_MAX32672) ||   \
+    defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32675) ||   \
+    defined(CONFIG_SOC_MAX32680) || defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX78002)
 // status flags
 #define ADI_MAX32_UART_RX_EMPTY MXC_F_UART_STATUS_RX_EM
 #define ADI_MAX32_UART_TX_EMPTY MXC_F_UART_STATUS_TX_EM
 
-#if defined(CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32657)
+#if defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32657)
 // error flags
 #define ADI_MAX32_UART_ERROR_OVERRUN MXC_F_UART_INTFL_RX_OV
 #define ADI_MAX32_UART_ERROR_PARITY MXC_F_UART_INTFL_RX_PAR
@@ -215,11 +216,11 @@ static inline void Wrap_MXC_UART_DisableRxDMA(mxc_uart_regs_t *uart)
     uart->dma &= ~MXC_F_UART_DMA_RX_EN;
 }
 
-#endif // defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655)
+#endif // defined(CONFIG_SOC_MAX32690) || defined(CONFIG_SOC_MAX32655)
 
 static inline unsigned int Wrap_MXC_UART_GetRegINTEN(mxc_uart_regs_t *uart)
 {
-#if defined(CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32657)
+#if defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32657)
     return uart->inten;
 #else
     return uart->int_en;

--- a/Libraries/zephyr/MAX/Include/wrap_max32_wdt.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_wdt.h
@@ -37,7 +37,7 @@ typedef struct {
 /*
  *  MAX32665, MAX32666 related mapping
  */
-#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
 
 #define WRAP_MXC_F_WDT_CTRL_EN MXC_F_WDT_CTRL_WDT_EN
 
@@ -83,9 +83,10 @@ static inline int Wrap_MXC_WDT_SelectClockSource(mxc_wdt_regs_t *wdt, uint32_t c
 /*
  *  MAX32690, MAX32655 related mapping
  */
-#elif defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655) || (CONFIG_SOC_MAX32670) || \
-    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675) ||          \
-    (CONFIG_SOC_MAX32680) || (CONFIG_SOC_MAX32657) || (CONFIG_SOC_MAX78002)
+#elif defined(CONFIG_SOC_MAX32690) || defined(CONFIG_SOC_MAX32655) || \
+    defined(CONFIG_SOC_MAX32670) || defined(CONFIG_SOC_MAX32672) ||   \
+    defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32675) ||   \
+    defined(CONFIG_SOC_MAX32680) || defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX78002)
 
 #define WRAP_MXC_F_WDT_CTRL_EN MXC_F_WDT_CTRL_EN
 
@@ -138,7 +139,7 @@ static inline int Wrap_MXC_WDT_SelectClockSource(mxc_wdt_regs_t *wdt, uint32_t c
         clk_src = MXC_WDT_INRO_CLK;
 #endif
         break;
-#if !(defined(CONFIG_SOC_MAX32675) || (CONFIG_SOC_MAX32680))
+#if !(defined(CONFIG_SOC_MAX32675) || defined(CONFIG_SOC_MAX32680))
     case 4: // ADI_MAX32_PRPH_CLK_SRC_ERTCO
         clk_src = MXC_WDT_ERTCO_CLK;
         break;


### PR DESCRIPTION
The 'if defined(FOO) || BAR' lines are not clear

$ sed 's, (CONFIG_SOC, defined(CONFIG_SOC,g' -i $(git grep --name-only  if.defined\(.*\|\|.\() $ sed 's,||\s*\\$,\|\| \\,g' -i $(git grep --name-only '||.*\\$')

### Description

Not much to add other than the subject of the single git commit above.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.