### PR TITLE
fix(PeriphDrivers): Fix bad logic on ME16 UART IDX checking in MXC_UART_SetClockSource.

### DIFF
--- a/Libraries/PeriphDrivers/Source/UART/uart_me16.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me16.c
@@ -236,7 +236,7 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 {
     uint8_t retval = E_NO_ERROR;
 
-    if (MXC_UART_GET_IDX(uart) != 0 || MXC_UART_GET_IDX(uart) != 2) {
+    if (MXC_UART_GET_IDX(uart) != 0 && MXC_UART_GET_IDX(uart) != 2) {
         return E_BAD_PARAM;
     }
 


### PR DESCRIPTION
### Description

ME16 (MAX32675) will currently always fail to initialize its UART. This is because the logic inside the SetClockSource function uses an || instead of an && for checking mutually exclusive conditions:

```C
// FIXME: CHANGE FROM || TO &&
    if (MXC_UART_GET_IDX(uart) != 0 || MXC_UART_GET_IDX(uart) != 2) { 
        return E_BAD_PARAM;
    }
```

Because the UART is for sure _either_ 0 or 2, this check will always fail. The correct operation is to use && for this sort of check. That's the only change in this PR. 