### PR TITLE
fix(Examples,PeriphDrivers): Fix clock option value setting for UART-…

### DIFF
--- a/Examples/MAX78000/UART/main.c
+++ b/Examples/MAX78000/UART/main.c
@@ -102,8 +102,13 @@ int main(void)
         printf("-->Example Failed\n");
         return error;
     }
-
+#if defined(BOARD_EVKIT_V1)
     if ((error = MXC_UART_Init(WRITING_UART, UART_BAUD, MXC_UART_APB_CLK)) != E_NO_ERROR) {
+#elif defined(BOARD_FTHR_REVA)
+    // We define UART3(LPUART) as WRITING_UART for FTHR Board.
+    // LPUART can use IBRO and ERTCO clocks.
+    if ((error = MXC_UART_Init(WRITING_UART, UART_BAUD, MXC_UART_IBRO_CLK)) != E_NO_ERROR) {
+#endif
         printf("-->Error initializing UART: %d\n", error);
         printf("-->Example Failed\n");
         return error;

--- a/Libraries/PeriphDrivers/Source/UART/uart_ai85.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_ai85.c
@@ -273,14 +273,14 @@ int MXC_UART_SetClockSource(mxc_uart_regs_t *uart, mxc_uart_clock_t clock)
 #ifndef MSDK_NO_GPIO_CLK_INIT
             retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
 #endif // MSDK_NO_GPIO_CLK_INIT
-            clock_option = 2;
+            clock_option = 0;
             break;
 
         case MXC_UART_ERTCO_CLK:
 #ifndef MSDK_NO_GPIO_CLK_INIT
             retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
 #endif // MSDK_NO_GPIO_CLK_INIT
-            clock_option = 3;
+            clock_option = 1;
             break;
 
         default:
@@ -316,9 +316,9 @@ mxc_uart_clock_t MXC_UART_GetClockSource(mxc_uart_regs_t *uart)
         break;
     case 3:
         switch (clock_option) {
-        case 2:
+        case 0:
             return MXC_UART_IBRO_CLK;
-        case 3:
+        case 1:
             return MXC_UART_ERTCO_CLK;
         default:
             return E_BAD_STATE;


### PR DESCRIPTION
…IBRO and UART-ERTCO clocks in MAX78000.

### Description

-> UART3 is has low power capability and it works with IBRO and ERTCO clocks. We must set UART3_CTRL->bclksrc register bits to a value between 0-3. IBRO and ERTCO is defined as 2 and 3 in the MAX78000 user guide. However, the correct values seem to be 0 and 1 to set UART baudrate clock source to IBRO and ERTCO clocks respectively. 
![image](https://github.com/user-attachments/assets/37737124-8319-4bf8-9f2d-12464948aefc)



-> I updated the function definitions for the part to make the UART example work successfully. I tested the code for both clock options with MAX78000 FTHR.
![image](https://github.com/user-attachments/assets/d651cdbd-8fc1-410f-ab52-984bf455a7c6)

UART3 is initialized with IBRO clock by default in the example.
