### PR TITLE
fix(PeriphDrivers): Update the info block unlock sequence for the MAX32657

### DIFF
--- a/Libraries/PeriphDrivers/Source/FLC/flc_me30.c
+++ b/Libraries/PeriphDrivers/Source/FLC/flc_me30.c
@@ -196,12 +196,12 @@ int MXC_FLC_UnlockInfoBlock(uint32_t address)
 #endif
 
     /* Make sure the info block is locked */
-    flc->actrl = 0x1234;
+    MXC_FLC->actrl = 0x1234;
 
     /* Write the unlock sequence */
-    flc->actrl = 0x55bcbe69;
-    flc->actrl = 0x7688c189;
-    flc->actrl = 0x82306612;
+    MXC_FLC->actrl = 0x55bcbe69;
+    MXC_FLC->actrl = 0x7688c189;
+    MXC_FLC->actrl = 0x82306612;
 
     return E_NO_ERROR;
 }
@@ -219,7 +219,7 @@ int MXC_FLC_LockInfoBlock(uint32_t address)
     return E_NOT_SUPPORTED;
 #endif
 
-    flc->actrl = 0xDEADBEEF;
+    MXC_FLC->actrl = 0xDEADBEEF;
     return E_NO_ERROR;
 }
 

--- a/Libraries/PeriphDrivers/Source/FLC/flc_me30.c
+++ b/Libraries/PeriphDrivers/Source/FLC/flc_me30.c
@@ -185,13 +185,13 @@ int MXC_FLC_MassErase(void)
 //******************************************************************************
 int MXC_FLC_UnlockInfoBlock(uint32_t address)
 {
+    /* Flash Controller only accessible in secure world. */
 #if defined(CONFIG_TRUSTED_EXECUTION_SECURE) || (CONFIG_TRUSTED_EXECUTION_SECURE != 0)
     if ((address < MXC_INFO_MEM_BASE) ||
         (address >= (MXC_INFO_MEM_BASE + (MXC_INFO_MEM_SIZE * 2)))) {
         return E_BAD_PARAM;
     }
 #else
-    /* Flash Controller only accessible in secure world. */
     return E_NOT_SUPPORTED;
 #endif
 

--- a/Libraries/PeriphDrivers/Source/FLC/flc_me30.c
+++ b/Libraries/PeriphDrivers/Source/FLC/flc_me30.c
@@ -183,15 +183,44 @@ int MXC_FLC_MassErase(void)
 }
 
 //******************************************************************************
-__weak int MXC_FLC_UnlockInfoBlock(uint32_t address)
+int MXC_FLC_UnlockInfoBlock(uint32_t address)
 {
+#if defined(CONFIG_TRUSTED_EXECUTION_SECURE) || (CONFIG_TRUSTED_EXECUTION_SECURE != 0)
+    if ((address < MXC_INFO_MEM_BASE) ||
+        (address >= (MXC_INFO_MEM_BASE + (MXC_INFO_MEM_SIZE * 2)))) {
+        return E_BAD_PARAM;
+    }
+#else
+    /* Flash Controller only accessible in secure world. */
     return E_NOT_SUPPORTED;
+#endif
+
+    /* Make sure the info block is locked */
+    flc->actrl = 0x1234;
+
+    /* Write the unlock sequence */
+    flc->actrl = 0x55bcbe69;
+    flc->actrl = 0x7688c189;
+    flc->actrl = 0x82306612;
+
+    return E_NO_ERROR;
 }
 
 //******************************************************************************
 int MXC_FLC_LockInfoBlock(uint32_t address)
 {
-    return MXC_FLC_RevA_LockInfoBlock((mxc_flc_reva_regs_t *)MXC_FLC, address);
+    /* Flash Controller only accessible in secure world. */
+#if defined(CONFIG_TRUSTED_EXECUTION_SECURE) || (CONFIG_TRUSTED_EXECUTION_SECURE != 0)
+    if ((address < MXC_INFO_MEM_BASE) ||
+        (address >= (MXC_INFO_MEM_BASE + (MXC_INFO_MEM_SIZE * 2)))) {
+        return E_BAD_PARAM;
+    }
+#else
+    return E_NOT_SUPPORTED;
+#endif
+
+    flc->actrl = 0xDEADBEEF;
+    return E_NO_ERROR;
 }
 
 //******************************************************************************


### PR DESCRIPTION
### Description

This PR updates the Unlock/Lock Info Block functions using the correct unlock sequence.

It has a different sequence from the FLC RevA drivers.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.