### PR TITLE
refactor(PeriphDrivers)!: Update WUT API naming schemes for MAX32655, MAX32657, MAX32665, MAX32690, MAX78000, and MAX78002. Offer WUT selection on MAX32690

### DIFF
--- a/Examples/MAX32655/Bluetooth/BLE_FreeRTOS/freertos_tickless.c
+++ b/Examples/MAX32655/Bluetooth/BLE_FreeRTOS/freertos_tickless.c
@@ -160,7 +160,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     /* Determine if we need to snapshot the PalBb clock */
     if (schTimerActive) {
         /* Snapshot the current WUT value with the PalBb clock */
-        MXC_WUT_Store(MXC_WUT0);
+        MXC_WUT_StoreCount(MXC_WUT0);
         preCapture = MXC_WUT_GetCount(MXC_WUT0);
         schUsec = PalTimerGetExpTime();
 
@@ -176,7 +176,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
         }
     } else {
         /* Snapshot the current WUT value */
-        MXC_WUT_Edge(MXC_WUT0);
+        MXC_WUT_WaitForEdge(MXC_WUT0);
         preCapture = MXC_WUT_GetCount(MXC_WUT0);
         bleSleepTicks = 0;
         schUsec = 0;
@@ -239,7 +239,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     }
 
     /* Recalculate dsWutTicks for the FreeRTOS tick counter update */
-    MXC_WUT_Edge(MXC_WUT0);
+    MXC_WUT_WaitForEdge(MXC_WUT0);
     postCapture = MXC_WUT_GetCount(MXC_WUT0);
     dsWutTicks = postCapture - preCapture;
 

--- a/Examples/MAX32655/Bluetooth/BLE_fit_FreeRTOS/freertos_tickless.c
+++ b/Examples/MAX32655/Bluetooth/BLE_fit_FreeRTOS/freertos_tickless.c
@@ -160,7 +160,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     /* Determine if we need to snapshot the PalBb clock */
     if (schTimerActive) {
         /* Snapshot the current WUT value with the PalBb clock */
-        MXC_WUT_Store(MXC_WUT0);
+        MXC_WUT_StoreCount(MXC_WUT0);
         preCapture = MXC_WUT_GetCount(MXC_WUT0);
         schUsec = PalTimerGetExpTime();
 
@@ -176,7 +176,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
         }
     } else {
         /* Snapshot the current WUT value */
-        MXC_WUT_Edge(MXC_WUT0);
+        MXC_WUT_WaitForEdge(MXC_WUT0);
         preCapture = MXC_WUT_GetCount(MXC_WUT0);
         bleSleepTicks = 0;
         schUsec = 0;
@@ -238,7 +238,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     }
 
     /* Recalculate dsWutTicks for the FreeRTOS tick counter update */
-    MXC_WUT_Edge(MXC_WUT0);
+    MXC_WUT_WaitForEdge(MXC_WUT0);
     postCapture = MXC_WUT_GetCount(MXC_WUT0);
     dsWutTicks = postCapture - preCapture;
 

--- a/Examples/MAX32655/Bluetooth/RF_Test/freertos_tickless.c
+++ b/Examples/MAX32655/Bluetooth/RF_Test/freertos_tickless.c
@@ -135,10 +135,10 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     MXC_GPIO_OutSet(uart_rts.port, uart_rts.mask);
 
     /* Snapshot the current WUT value */
-    MXC_WUT_Edge(MXC_WUT0);
+    MXC_WUT_WaitForEdge(MXC_WUT0);
     pre_capture = MXC_WUT_GetCount(MXC_WUT0);
     MXC_WUT_SetCompare(MXC_WUT0, pre_capture + wut_ticks);
-    MXC_WUT_Edge(MXC_WUT0);
+    MXC_WUT_WaitForEdge(MXC_WUT0);
 
     LED_Off(1);
 

--- a/Examples/MAX32655/FreeRTOSDemo/freertos_tickless.c
+++ b/Examples/MAX32655/FreeRTOSDemo/freertos_tickless.c
@@ -135,10 +135,10 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     MXC_GPIO_OutSet(uart_rts.port, uart_rts.mask);
 
     /* Snapshot the current WUT value */
-    MXC_WUT_Edge(MXC_WUT0);
+    MXC_WUT_WaitForEdge(MXC_WUT0);
     pre_capture = MXC_WUT_GetCount(MXC_WUT0);
     MXC_WUT_SetCompare(MXC_WUT0, pre_capture + wut_ticks);
-    MXC_WUT_Edge(MXC_WUT0);
+    MXC_WUT_WaitForEdge(MXC_WUT0);
 
     LED_Off(1);
 

--- a/Examples/MAX32655/FreeRTOSDemo/main.c
+++ b/Examples/MAX32655/FreeRTOSDemo/main.c
@@ -352,7 +352,7 @@ int freertos_permit_tickless(void)
  */
 void WUT_IRQHandler(void)
 {
-    MXC_WUT_IntClear(MXC_WUT0);
+    MXC_WUT_ClearFlags(MXC_WUT0);
     NVIC_ClearPendingIRQ(WUT_IRQn);
 }
 

--- a/Examples/MAX32655/WUT/main.c
+++ b/Examples/MAX32655/WUT/main.c
@@ -38,7 +38,7 @@
 
 void WUT_IRQHandler(void)
 {
-    MXC_WUT_IntClear(MXC_WUT0);
+    MXC_WUT_ClearFlags(MXC_WUT0);
 }
 
 // *****************************************************************************

--- a/Examples/MAX32665/Bluetooth/BLE_FreeRTOS/freertos_tickless.c
+++ b/Examples/MAX32665/Bluetooth/BLE_FreeRTOS/freertos_tickless.c
@@ -250,7 +250,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     /* Determine if we need to snapshot the PalBb clock */
     if (schTimerActive) {
         /* Snapshot the current WUT value with the PalBb clock */
-        MXC_WUT_Store();
+        MXC_WUT_StoreCount();
         preCapture = MXC_WUT_GetCount();
         schUsec = PalTimerGetExpTime();
 
@@ -266,7 +266,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
         }
     } else {
         /* Snapshot the current WUT value */
-        MXC_WUT_Edge();
+        MXC_WUT_WaitForEdge();
         preCapture = MXC_WUT_GetCount();
         bleSleepTicks = 0;
         schUsec = 0;
@@ -327,7 +327,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     }
 
     /* Recalculate dsWutTicks for the FreeRTOS tick counter update */
-    MXC_WUT_Edge();
+    MXC_WUT_WaitForEdge();
     postCapture = MXC_WUT_GetCount();
     dsWutTicks = postCapture - preCapture;
 

--- a/Examples/MAX32665/Bluetooth/BLE_FreeRTOS/stack_dats.c
+++ b/Examples/MAX32665/Bluetooth/BLE_FreeRTOS/stack_dats.c
@@ -202,7 +202,7 @@ static void mainWsfInit(void)
 /*************************************************************************************************/
 void WUT_IRQHandler(void)
 {
-    MXC_WUT_IntClear();
+    MXC_WUT_ClearFlags();
     NVIC_ClearPendingIRQ(WUT_IRQn);
     MXC_WUT_Handler();
     PalTimerIRQCallBack();

--- a/Examples/MAX32665/Bluetooth/RF_Test/freertos_tickless.c
+++ b/Examples/MAX32665/Bluetooth/RF_Test/freertos_tickless.c
@@ -248,7 +248,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     /* Determine if we need to snapshot the PalBb clock */
     if (schTimerActive) {
         /* Snapshot the current WUT value with the PalBb clock */
-        MXC_WUT_Store();
+        MXC_WUT_StoreCount();
         preCapture = MXC_WUT_GetCount();
         schUsec = PalTimerGetExpTime();
 
@@ -264,7 +264,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
         }
     } else {
         /* Snapshot the current WUT value */
-        MXC_WUT_Edge();
+        MXC_WUT_WaitForEdge();
         preCapture = MXC_WUT_GetCount();
         bleSleepTicks = 0;
         schUsec = 0;
@@ -326,7 +326,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     }
 
     /* Recalculate dsWutTicks for the FreeRTOS tick counter update */
-    MXC_WUT_Edge();
+    MXC_WUT_WaitForEdge();
     postCapture = MXC_WUT_GetCount();
     dsWutTicks = postCapture - preCapture;
 

--- a/Examples/MAX32665/FreeRTOSDemo/freertos_tickless.c
+++ b/Examples/MAX32665/FreeRTOSDemo/freertos_tickless.c
@@ -235,10 +235,10 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     MXC_GPIO_OutSet(uart_rts.port, uart_rts.mask);
 
     /* Snapshot the current WUT value */
-    MXC_WUT_Edge();
+    MXC_WUT_WaitForEdge();
     pre_capture = MXC_WUT_GetCount();
     MXC_WUT_SetCompare(pre_capture + wut_ticks);
-    MXC_WUT_Edge();
+    MXC_WUT_WaitForEdge();
 
     LED_Off(SLEEP_LED);
 

--- a/Examples/MAX32665/FreeRTOSDemo/main.c
+++ b/Examples/MAX32665/FreeRTOSDemo/main.c
@@ -397,7 +397,7 @@ void turnOffUnused(void)
  */
 void WUT_IRQHandler(void)
 {
-    MXC_WUT_IntClear();
+    MXC_WUT_ClearFlags();
     NVIC_ClearPendingIRQ(WUT_IRQn);
 }
 

--- a/Examples/MAX32665/WUT/main.c
+++ b/Examples/MAX32665/WUT/main.c
@@ -46,7 +46,7 @@
 /***** Functions *****/
 void WUT_IRQHandler(void)
 {
-    MXC_WUT_IntClear();
+    MXC_WUT_ClearFlags();
 }
 
 // *****************************************************************************

--- a/Examples/MAX32680/FreeRTOSDemo/freertos_tickless.c
+++ b/Examples/MAX32680/FreeRTOSDemo/freertos_tickless.c
@@ -135,10 +135,10 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     MXC_GPIO_OutSet(uart_rts.port, uart_rts.mask);
 
     /* Snapshot the current WUT value */
-    MXC_WUT_Edge(MXC_WUT);
+    MXC_WUT_WaitForEdge(MXC_WUT);
     pre_capture = MXC_WUT_GetCount(MXC_WUT);
     MXC_WUT_SetCompare(MXC_WUT, pre_capture + wut_ticks);
-    MXC_WUT_Edge(MXC_WUT);
+    MXC_WUT_WaitForEdge(MXC_WUT);
 
     LED_Off(1);
 

--- a/Examples/MAX32680/FreeRTOSDemo/main.c
+++ b/Examples/MAX32680/FreeRTOSDemo/main.c
@@ -349,7 +349,7 @@ int freertos_permit_tickless(void)
  */
 void WUT_IRQHandler(void)
 {
-    MXC_WUT_IntClear(MXC_WUT);
+    MXC_WUT_ClearFlags(MXC_WUT);
     NVIC_ClearPendingIRQ(WUT_IRQn);
 }
 

--- a/Examples/MAX32680/WUT/main.c
+++ b/Examples/MAX32680/WUT/main.c
@@ -65,7 +65,7 @@ void setTrigger(int waitForTrigger)
 
 void WUT_IRQHandler(void)
 {
-    MXC_WUT_IntClear(MXC_WUT);
+    MXC_WUT_ClearFlags(MXC_WUT);
 }
 
 // *****************************************************************************

--- a/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/dats_main.c
+++ b/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/dats_main.c
@@ -342,7 +342,7 @@ static void trimStart(void)
     extern void wutTrimCb(int err);
 
     /* Start the 32 kHz crystal trim procedure */
-    err = MXC_WUT_TrimCrystalAsync(wutTrimCb);
+    err = MXC_WUT_TrimCrystalAsync(MXC_WUT0, wutTrimCb);
     if (err != E_NO_ERROR) {
         APP_TRACE_INFO1("Error starting 32kHz crystal trim %d", err);
     }

--- a/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/freertos_tickless.c
+++ b/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/freertos_tickless.c
@@ -60,7 +60,7 @@
 int freertos_permit_tickless(void)
 {
     /* Can not disable BLE DBB and 32 MHz clock while trim procedure is ongoing */
-    if (MXC_WUT_TrimPending() != E_NO_ERROR) {
+    if (MXC_WUT_TrimPending(MXC_WUT0) != E_NO_ERROR) {
         return E_BUSY;
     }
 
@@ -160,8 +160,8 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     /* Determine if we need to snapshot the PalBb clock */
     if (schTimerActive) {
         /* Snapshot the current WUT value with the PalBb clock */
-        MXC_WUT_Store();
-        preCapture = MXC_WUT_GetCount();
+        MXC_WUT_Store(MXC_WUT0);
+        preCapture = MXC_WUT_GetCount(MXC_WUT0);
         schUsec = PalTimerGetExpTime();
 
         /* Adjust idleTicks for the time it takes to restart the BLE hardware */
@@ -176,8 +176,8 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
         }
     } else {
         /* Snapshot the current WUT value */
-        MXC_WUT_Edge();
-        preCapture = MXC_WUT_GetCount();
+        MXC_WUT_Edge(MXC_WUT0);
+        preCapture = MXC_WUT_GetCount(MXC_WUT0);
         bleSleepTicks = 0;
         schUsec = 0;
     }
@@ -221,7 +221,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
 
         if (schTimerActive) {
             /* Restore the BB counter */
-            MXC_WUT_RestoreBBClock(BB_CLK_RATE_HZ);
+            MXC_WUT_RestoreBBClock(MXC_WUT0, BB_CLK_RATE_HZ);
 
             /* Restart the BLE scheduler timer */
             dsWutTicks = MXC_WUT->cnt - preCapture;
@@ -237,8 +237,8 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     }
 
     /* Recalculate dsWutTicks for the FreeRTOS tick counter update */
-    MXC_WUT_Edge();
-    postCapture = MXC_WUT_GetCount();
+    MXC_WUT_Edge(MXC_WUT0);
+    postCapture = MXC_WUT_GetCount(MXC_WUT0);
     dsWutTicks = postCapture - preCapture;
 
     /*

--- a/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/freertos_tickless.c
+++ b/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/freertos_tickless.c
@@ -160,7 +160,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     /* Determine if we need to snapshot the PalBb clock */
     if (schTimerActive) {
         /* Snapshot the current WUT value with the PalBb clock */
-        MXC_WUT_Store(MXC_WUT0);
+        MXC_WUT_StoreCount(MXC_WUT0);
         preCapture = MXC_WUT_GetCount(MXC_WUT0);
         schUsec = PalTimerGetExpTime();
 
@@ -176,7 +176,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
         }
     } else {
         /* Snapshot the current WUT value */
-        MXC_WUT_Edge(MXC_WUT0);
+        MXC_WUT_WaitForEdge(MXC_WUT0);
         preCapture = MXC_WUT_GetCount(MXC_WUT0);
         bleSleepTicks = 0;
         schUsec = 0;
@@ -237,7 +237,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     }
 
     /* Recalculate dsWutTicks for the FreeRTOS tick counter update */
-    MXC_WUT_Edge(MXC_WUT0);
+    MXC_WUT_WaitForEdge(MXC_WUT0);
     postCapture = MXC_WUT_GetCount(MXC_WUT0);
     dsWutTicks = postCapture - preCapture;
 

--- a/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/stack_dats.c
+++ b/Examples/MAX32690/Bluetooth/BLE_FreeRTOS/stack_dats.c
@@ -279,7 +279,7 @@ void trim32k(void)
 
     /* Execute the trim procedure */
     wutTrimComplete = 0;
-    if (MXC_WUT_TrimCrystalAsync(wutTrimCb) != E_NO_ERROR) {
+    if (MXC_WUT_TrimCrystalAsync(MXC_WUT0, wutTrimCb) != E_NO_ERROR) {
         APP_TRACE_INFO0("Error with 32k trim");
     } else {
         while (!wutTrimComplete) {}

--- a/Examples/MAX32690/Bluetooth/BLE_datc/main.c
+++ b/Examples/MAX32690/Bluetooth/BLE_datc/main.c
@@ -277,7 +277,7 @@ int main(void)
 
     /* Execute the trim procedure */
     wutTrimComplete = 0;
-    MXC_WUT_TrimCrystalAsync(wutTrimCb);
+    MXC_WUT_TrimCrystalAsync(MXC_WUT0, wutTrimCb);
     while (!wutTrimComplete) {}
 
     /* Shutdown the 32 MHz crystal and the BLE DBB */

--- a/Examples/MAX32690/Bluetooth/BLE_dats/dats_main.c
+++ b/Examples/MAX32690/Bluetooth/BLE_dats/dats_main.c
@@ -403,7 +403,7 @@ static void trimStart(void)
     extern void wutTrimCb(int err);
 
     /* Start the 32 kHz crystal trim procedure */
-    err = MXC_WUT_TrimCrystalAsync(wutTrimCb);
+    err = MXC_WUT_TrimCrystalAsync(MXC_WUT0, wutTrimCb);
     if (err != E_NO_ERROR) {
         APP_TRACE_INFO1("Error starting 32kHz crystal trim %d", err);
     }

--- a/Examples/MAX32690/Bluetooth/BLE_dats/main.c
+++ b/Examples/MAX32690/Bluetooth/BLE_dats/main.c
@@ -272,7 +272,7 @@ int main(void)
 
     /* Execute the trim procedure */
     wutTrimComplete = 0;
-    MXC_WUT_TrimCrystalAsync(wutTrimCb);
+    MXC_WUT_TrimCrystalAsync(MXC_WUT0, wutTrimCb);
     while (!wutTrimComplete) {}
 
     /* Shutdown the 32 MHz crystal and the BLE DBB */

--- a/Examples/MAX32690/Bluetooth/BLE_fit/main.c
+++ b/Examples/MAX32690/Bluetooth/BLE_fit/main.c
@@ -272,7 +272,7 @@ int main(void)
 
     /* Execute the trim procedure */
     wutTrimComplete = 0;
-    MXC_WUT_TrimCrystalAsync(wutTrimCb);
+    MXC_WUT_TrimCrystalAsync(MXC_WUT0, wutTrimCb);
     while (!wutTrimComplete) {}
 
     /* Shutdown the 32 MHz crystal and the BLE DBB */

--- a/Examples/MAX32690/Bluetooth/BLE_otac/main.c
+++ b/Examples/MAX32690/Bluetooth/BLE_otac/main.c
@@ -273,7 +273,7 @@ int main(void)
 
     /* Execute the trim procedure */
     wutTrimComplete = 0;
-    MXC_WUT_TrimCrystalAsync(wutTrimCb);
+    MXC_WUT_TrimCrystalAsync(MXC_WUT0, wutTrimCb);
     while (!wutTrimComplete) {}
 
     /* Shutdown the 32 MHz crystal and the BLE DBB */

--- a/Examples/MAX32690/Bluetooth/BLE_otas/dats_main.c
+++ b/Examples/MAX32690/Bluetooth/BLE_otas/dats_main.c
@@ -349,7 +349,7 @@ static void trimStart(void)
     extern void wutTrimCb(int err);
 
     /* Start the 32 kHz crystal trim procedure */
-    err = MXC_WUT_TrimCrystalAsync(wutTrimCb);
+    err = MXC_WUT_TrimCrystalAsync(MXC_WUT0, wutTrimCb);
     if (err != E_NO_ERROR) {
         APP_TRACE_INFO1("Error starting 32kHz crystal trim %d", err);
     }

--- a/Examples/MAX32690/Bluetooth/BLE_otas/main.c
+++ b/Examples/MAX32690/Bluetooth/BLE_otas/main.c
@@ -276,7 +276,7 @@ int main(void)
 
     /* Execute the trim procedure */
     wutTrimComplete = 0;
-    MXC_WUT_TrimCrystalAsync(wutTrimCb);
+    MXC_WUT_TrimCrystalAsync(MXC_WUT0, wutTrimCb);
     while (!wutTrimComplete) {}
 
     /* Stop here to measure the 32 kHz clock */

--- a/Examples/MAX32690/Bluetooth/RF_Test/freertos_tickless.c
+++ b/Examples/MAX32690/Bluetooth/RF_Test/freertos_tickless.c
@@ -160,7 +160,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     /* Determine if we need to snapshot the PalBb clock */
     if (schTimerActive) {
         /* Snapshot the current WUT value with the PalBb clock */
-        MXC_WUT_Store(MXC_WUT0);
+        MXC_WUT_StoreCount(MXC_WUT0);
         preCapture = MXC_WUT_GetCount(MXC_WUT0);
         schUsec = PalTimerGetExpTime();
 
@@ -176,7 +176,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
         }
     } else {
         /* Snapshot the current WUT value */
-        MXC_WUT_Edge(MXC_WUT0);
+        MXC_WUT_WaitForEdge(MXC_WUT0);
         preCapture = MXC_WUT_GetCount(MXC_WUT0);
         bleSleepTicks = 0;
         schUsec = 0;
@@ -238,7 +238,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     }
 
     /* Recalculate dsWutTicks for the FreeRTOS tick counter update */
-    MXC_WUT_Edge(MXC_WUT0);
+    MXC_WUT_WaitForEdge(MXC_WUT0);
     postCapture = MXC_WUT_GetCount(MXC_WUT0);
     dsWutTicks = postCapture - preCapture;
 

--- a/Examples/MAX32690/Bluetooth/RF_Test/freertos_tickless.c
+++ b/Examples/MAX32690/Bluetooth/RF_Test/freertos_tickless.c
@@ -60,7 +60,7 @@
 int freertos_permit_tickless(void)
 {
     /* Can not disable BLE DBB and 32 MHz clock while trim procedure is ongoing */
-    if (MXC_WUT_TrimPending() != E_NO_ERROR) {
+    if (MXC_WUT_TrimPending(MXC_WUT0) != E_NO_ERROR) {
         return E_BUSY;
     }
 
@@ -160,8 +160,8 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     /* Determine if we need to snapshot the PalBb clock */
     if (schTimerActive) {
         /* Snapshot the current WUT value with the PalBb clock */
-        MXC_WUT_Store();
-        preCapture = MXC_WUT_GetCount();
+        MXC_WUT_Store(MXC_WUT0);
+        preCapture = MXC_WUT_GetCount(MXC_WUT0);
         schUsec = PalTimerGetExpTime();
 
         /* Adjust idleTicks for the time it takes to restart the BLE hardware */
@@ -176,8 +176,8 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
         }
     } else {
         /* Snapshot the current WUT value */
-        MXC_WUT_Edge();
-        preCapture = MXC_WUT_GetCount();
+        MXC_WUT_Edge(MXC_WUT0);
+        preCapture = MXC_WUT_GetCount(MXC_WUT0);
         bleSleepTicks = 0;
         schUsec = 0;
     }
@@ -222,7 +222,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
             PalBbRestore();
 
             /* Restore the BB counter */
-            MXC_WUT_RestoreBBClock(BB_CLK_RATE_HZ);
+            MXC_WUT_RestoreBBClock(MXC_WUT0, BB_CLK_RATE_HZ);
 
             /* Restart the BLE scheduler timer */
             dsWutTicks = MXC_WUT->cnt - preCapture;
@@ -238,8 +238,8 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     }
 
     /* Recalculate dsWutTicks for the FreeRTOS tick counter update */
-    MXC_WUT_Edge();
-    postCapture = MXC_WUT_GetCount();
+    MXC_WUT_Edge(MXC_WUT0);
+    postCapture = MXC_WUT_GetCount(MXC_WUT0);
     dsWutTicks = postCapture - preCapture;
 
     /*

--- a/Examples/MAX32690/FreeRTOSDemo/freertos_tickless.c
+++ b/Examples/MAX32690/FreeRTOSDemo/freertos_tickless.c
@@ -134,10 +134,10 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     MXC_GPIO_OutSet(uart_rts.port, uart_rts.mask);
 
     /* Snapshot the current WUT value */
-    MXC_WUT_Edge(MXC_WUT0);
+    MXC_WUT_WaitForEdge(MXC_WUT0);
     pre_capture = MXC_WUT_GetCount(MXC_WUT0);
     MXC_WUT_SetCompare(MXC_WUT0, pre_capture + wut_ticks);
-    MXC_WUT_Edge(MXC_WUT0);
+    MXC_WUT_WaitForEdge(MXC_WUT0);
 
     LED_Off(1);
 

--- a/Examples/MAX32690/FreeRTOSDemo/freertos_tickless.c
+++ b/Examples/MAX32690/FreeRTOSDemo/freertos_tickless.c
@@ -67,7 +67,7 @@ __attribute__((weak)) int freertos_permit_tickless(void)
  */
 void wutHitSnooze(void)
 {
-    wutSnooze = MXC_WUT_GetCount() + MAX_WUT_SNOOZE;
+    wutSnooze = MXC_WUT_GetCount(MXC_WUT0) + MAX_WUT_SNOOZE;
     wutSnoozeValid = 1;
 }
 
@@ -108,7 +108,7 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     }
 
     /* Check the WUT snooze */
-    if (wutSnoozeValid && (MXC_WUT_GetCount() < wutSnooze)) {
+    if (wutSnoozeValid && (MXC_WUT_GetCount(MXC_WUT0) < wutSnooze)) {
         /* Finish out the rest of this tick with normal sleep */
         MXC_LP_EnterSleepMode();
         return;
@@ -134,16 +134,16 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     MXC_GPIO_OutSet(uart_rts.port, uart_rts.mask);
 
     /* Snapshot the current WUT value */
-    MXC_WUT_Edge();
-    pre_capture = MXC_WUT_GetCount();
-    MXC_WUT_SetCompare(pre_capture + wut_ticks);
-    MXC_WUT_Edge();
+    MXC_WUT_Edge(MXC_WUT0);
+    pre_capture = MXC_WUT_GetCount(MXC_WUT0);
+    MXC_WUT_SetCompare(MXC_WUT0, pre_capture + wut_ticks);
+    MXC_WUT_Edge(MXC_WUT0);
 
     LED_Off(1);
 
     MXC_LP_EnterStandbyMode();
 
-    post_capture = MXC_WUT_GetCount();
+    post_capture = MXC_WUT_GetCount(MXC_WUT0);
     actual_ticks = post_capture - pre_capture;
 
     LED_On(1);

--- a/Examples/MAX32690/FreeRTOSDemo/main.c
+++ b/Examples/MAX32690/FreeRTOSDemo/main.c
@@ -345,7 +345,7 @@ int freertos_permit_tickless(void)
  */
 void WUT_IRQHandler(void)
 {
-    MXC_WUT_IntClear();
+    MXC_WUT_ClearFlags();
     NVIC_ClearPendingIRQ(WUT0_IRQn);
 }
 

--- a/Examples/MAX32690/FreeRTOSDemo/main.c
+++ b/Examples/MAX32690/FreeRTOSDemo/main.c
@@ -345,7 +345,7 @@ int freertos_permit_tickless(void)
  */
 void WUT_IRQHandler(void)
 {
-    MXC_WUT_ClearFlags();
+    MXC_WUT_ClearFlags(MXC_WUT0);
     NVIC_ClearPendingIRQ(WUT0_IRQn);
 }
 
@@ -374,7 +374,7 @@ int main(void)
 #if configUSE_TICKLESS_IDLE
 
     /* Initialize Wakeup timer */
-    MXC_WUT_Init(MXC_WUT_PRES_1);
+    MXC_WUT_Init(MXC_WUT0, MXC_WUT_PRES_1);
     mxc_wut_cfg_t wut_cfg;
     wut_cfg.mode = MXC_WUT_MODE_COMPARE;
     wut_cfg.cmp_cnt = 0xFFFFFFFF;
@@ -386,8 +386,8 @@ int main(void)
     NVIC_EnableIRQ(WUT_IRQn);
 
     /* Configure and start the WUT */
-    MXC_WUT_Config(&wut_cfg);
-    MXC_WUT_Enable();
+    MXC_WUT_Config(MXC_WUT0, &wut_cfg);
+    MXC_WUT_Enable(MXC_WUT0);
 
     /* Setup CTS interrupt */
     MXC_GPIO_IntConfig(&uart_cts, MXC_GPIO_INT_FALLING);

--- a/Examples/MAX32690/WUT/main.c
+++ b/Examples/MAX32690/WUT/main.c
@@ -57,7 +57,7 @@ void setTrigger(int waitForTrigger)
 
 void WUT0_IRQHandler(void)
 {
-    MXC_WUT_IntClear();
+    MXC_WUT_ClearFlags(MXC_WUT0);
 }
 
 int main(void)
@@ -75,15 +75,15 @@ int main(void)
     printf("wakeup timer to wake the device in %d Miliseconds.\n\n", MILLISECONDS_WUT);
 
     // Initialize WUT
-    MXC_WUT_Init(MXC_WUT_PRES_1);
+    MXC_WUT_Init(MXC_WUT0, MXC_WUT_PRES_1);
 
     // Get ticks based off of milliseconds
-    MXC_WUT_GetTicks(MILLISECONDS_WUT, MXC_WUT_UNIT_MILLISEC, &ticks);
+    MXC_WUT_GetTicks(MXC_WUT0, MILLISECONDS_WUT, MXC_WUT_UNIT_MILLISEC, &ticks);
 
     // Config WUT
     cfg.mode = MXC_WUT_MODE_ONESHOT;
     cfg.cmp_cnt = ticks;
-    MXC_WUT_Config(&cfg);
+    MXC_WUT_Config(MXC_WUT0, &cfg);
     NVIC_EnableIRQ(WUT0_IRQn);
 
     // Enable WUT wakeup event
@@ -95,7 +95,7 @@ int main(void)
 
         // Start WUT
         printf("Entering SLEEP mode.\n");
-        MXC_WUT_Enable();
+        MXC_WUT_Enable(MXC_WUT0);
 
         // Put the chip to sleep
         MXC_LP_EnterSleepMode();

--- a/Examples/MAX78000/CNN/kws20_demo/main.c
+++ b/Examples/MAX78000/CNN/kws20_demo/main.c
@@ -258,7 +258,7 @@ int32_t tot_usec = -100000;
 void WUT_IRQHandler(void)
 {
     i2s_flag = 1;
-    MXC_WUT_IntClear();
+    MXC_WUT_ClearFlags();
 
     tot_usec += WUT_USEC;
     //LED_On(LED2);

--- a/Examples/MAX78000/FreeRTOSDemo/freertos_tickless.c
+++ b/Examples/MAX78000/FreeRTOSDemo/freertos_tickless.c
@@ -134,10 +134,10 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     MXC_GPIO_OutSet(uart_rts.port, uart_rts.mask);
 
     /* Snapshot the current WUT value */
-    MXC_WUT_Edge();
+    MXC_WUT_WaitForEdge();
     pre_capture = MXC_WUT_GetCount();
     MXC_WUT_SetCompare(pre_capture + wut_ticks);
-    MXC_WUT_Edge();
+    MXC_WUT_WaitForEdge();
 
     LED_Off(1);
 

--- a/Examples/MAX78000/FreeRTOSDemo/main.c
+++ b/Examples/MAX78000/FreeRTOSDemo/main.c
@@ -345,7 +345,7 @@ int freertos_permit_tickless(void)
  */
 void WUT_IRQHandler(void)
 {
-    MXC_WUT_IntClear();
+    MXC_WUT_ClearFlags();
     NVIC_ClearPendingIRQ(WUT_IRQn);
 }
 

--- a/Examples/MAX78000/WUT/main.c
+++ b/Examples/MAX78000/WUT/main.c
@@ -65,7 +65,7 @@ void setTrigger(int waitForTrigger)
 
 void WUT_IRQHandler(void)
 {
-    MXC_WUT_IntClear();
+    MXC_WUT_ClearFlags();
 }
 
 // *****************************************************************************

--- a/Examples/MAX78002/CNN/facial_recognition/main.c
+++ b/Examples/MAX78002/CNN/facial_recognition/main.c
@@ -226,7 +226,7 @@ area_t area_2 = { 0, 260, 80, 30 };
 
 void WUT_IRQHandler(void)
 {
-    MXC_WUT_IntClear();
+    MXC_WUT_ClearFlags();
 }
 
 uint32_t ticks_1;

--- a/Examples/MAX78002/CNN/kws20_demo/main.c
+++ b/Examples/MAX78002/CNN/kws20_demo/main.c
@@ -206,7 +206,7 @@ int32_t tot_usec = -100000;
 void WUT_IRQHandler(void)
 {
     i2s_flag = 1;
-    MXC_WUT_IntClear();
+    MXC_WUT_ClearFlags();
 
     tot_usec += WUT_USEC;
 }

--- a/Examples/MAX78002/FreeRTOSDemo/freertos_tickless.c
+++ b/Examples/MAX78002/FreeRTOSDemo/freertos_tickless.c
@@ -134,10 +134,10 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime)
     MXC_GPIO_OutSet(uart_rts.port, uart_rts.mask);
 
     /* Snapshot the current WUT value */
-    MXC_WUT_Edge();
+    MXC_WUT_WaitForEdge();
     pre_capture = MXC_WUT_GetCount();
     MXC_WUT_SetCompare(pre_capture + wut_ticks);
-    MXC_WUT_Edge();
+    MXC_WUT_WaitForEdge();
 
     LED_Off(1);
 

--- a/Examples/MAX78002/FreeRTOSDemo/main.c
+++ b/Examples/MAX78002/FreeRTOSDemo/main.c
@@ -345,7 +345,7 @@ int freertos_permit_tickless(void)
  */
 void WUT_IRQHandler(void)
 {
-    MXC_WUT_IntClear();
+    MXC_WUT_ClearFlags();
     NVIC_ClearPendingIRQ(WUT_IRQn);
 }
 

--- a/Examples/MAX78002/WUT/main.c
+++ b/Examples/MAX78002/WUT/main.c
@@ -66,7 +66,7 @@ void setTrigger(int waitForTrigger)
 
 void WUT_IRQHandler(void)
 {
-    MXC_WUT_IntClear();
+    MXC_WUT_ClearFlags();
 }
 
 // *****************************************************************************

--- a/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_rtc.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_rtc.c
@@ -64,7 +64,7 @@ static struct {
 __attribute__((weak)) void WUT_IRQHandler(void)
 {
     PalLedOn(PAL_LED_ID_CPU_ACTIVE);
-    MXC_WUT_IntClear();
+    MXC_WUT_ClearFlags();
     NVIC_ClearPendingIRQ(WUT_IRQn);
 }
 

--- a/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_rtc.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_rtc.c
@@ -69,14 +69,14 @@ static struct {
 void WUT0_IRQHandler(void)
 {
   PalLedOn(PAL_LED_ID_CPU_ACTIVE);
-  MXC_WUT_Handler(MXC_WUT0);
+  MXC_WUT_Handler(PAL_WUT);
 
 }
 #else
 void WUT1_IRQHandler(void)
 {
   PalLedOn(PAL_LED_ID_CPU_ACTIVE);
-  MXC_WUT_Handler(MXC_WUT0);
+  MXC_WUT_Handler(PAL_WUT);
 
 }
 #endif
@@ -102,7 +102,7 @@ PalRtcState_t PalRtcGetState(void)
 /*************************************************************************************************/
 void PalRtcCompareSet(uint8_t channelId, uint32_t value)
 {
-  MXC_WUT_SetCompare(MXC_WUT0, value);
+  MXC_WUT_SetCompare(PAL_WUT, value);
 }
 
 /*************************************************************************************************/
@@ -117,15 +117,15 @@ void PalRtcInit(void)
   cfg.mode = MXC_WUT_MODE_COMPARE;
   cfg.cmp_cnt = PAL_MAX_RTC_COUNTER_VAL;
 
-  MXC_WUT_Init(MXC_WUT0, MXC_WUT_PRES_1);
-  MXC_WUT_Config(MXC_WUT0, &cfg);
+  MXC_WUT_Init(PAL_WUT, MXC_WUT_PRES_1);
+  MXC_WUT_Config(PAL_WUT, &cfg);
   MXC_LP_EnableWUTAlarmWakeup();
 
   NVIC_ClearPendingIRQ(PAL_WUT_IRQn);
   NVIC_EnableIRQ(PAL_WUT_IRQn);
 
   /* Enable WUT */
-  MXC_WUT_Enable(MXC_WUT0);
+  MXC_WUT_Enable(PAL_WUT);
 
   palRtcCb.state = PAL_RTC_STATE_READY;
 }
@@ -142,7 +142,7 @@ void PalRtcInit(void)
 /*************************************************************************************************/
 uint32_t PalRtcCounterGet(void)
 {
-  uint32_t count = MXC_WUT_GetCount(MXC_WUT0);
+  uint32_t count = MXC_WUT_GetCount(PAL_WUT);
 
   return count;
 }
@@ -168,6 +168,6 @@ void PalRtcEnableCompareIrq(uint8_t channelId)
 /*************************************************************************************************/
 void PalRtcDisableCompareIrq(uint8_t channelId)
 {
-  MXC_WUT_ClearFlags(MXC_WUT0);
+  MXC_WUT_ClearFlags(PAL_WUT);
   NVIC_DisableIRQ(PAL_WUT_IRQn);
 }

--- a/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_rtc.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_rtc.c
@@ -69,14 +69,14 @@ static struct {
 void WUT0_IRQHandler(void)
 {
   PalLedOn(PAL_LED_ID_CPU_ACTIVE);
-  MXC_WUT_Handler();
+  MXC_WUT_Handler(MXC_WUT0);
 
 }
 #else
 void WUT1_IRQHandler(void)
 {
   PalLedOn(PAL_LED_ID_CPU_ACTIVE);
-  MXC_WUT_Handler();
+  MXC_WUT_Handler(MXC_WUT0);
 
 }
 #endif
@@ -102,7 +102,7 @@ PalRtcState_t PalRtcGetState(void)
 /*************************************************************************************************/
 void PalRtcCompareSet(uint8_t channelId, uint32_t value)
 {
-  MXC_WUT_SetCompare(value);
+  MXC_WUT_SetCompare(MXC_WUT0, value);
 }
 
 /*************************************************************************************************/
@@ -117,15 +117,15 @@ void PalRtcInit(void)
   cfg.mode = MXC_WUT_MODE_COMPARE;
   cfg.cmp_cnt = PAL_MAX_RTC_COUNTER_VAL;
 
-  MXC_WUT_Init(MXC_WUT_PRES_1);
-  MXC_WUT_Config(&cfg);
+  MXC_WUT_Init(MXC_WUT0, MXC_WUT_PRES_1);
+  MXC_WUT_Config(MXC_WUT0, &cfg);
   MXC_LP_EnableWUTAlarmWakeup();
 
   NVIC_ClearPendingIRQ(PAL_WUT_IRQn);
   NVIC_EnableIRQ(PAL_WUT_IRQn);
 
   /* Enable WUT */
-  MXC_WUT_Enable();
+  MXC_WUT_Enable(MXC_WUT0);
 
   palRtcCb.state = PAL_RTC_STATE_READY;
 }
@@ -142,7 +142,7 @@ void PalRtcInit(void)
 /*************************************************************************************************/
 uint32_t PalRtcCounterGet(void)
 {
-  uint32_t count = MXC_WUT_GetCount();
+  uint32_t count = MXC_WUT_GetCount(MXC_WUT0);
 
   return count;
 }
@@ -168,6 +168,6 @@ void PalRtcEnableCompareIrq(uint8_t channelId)
 /*************************************************************************************************/
 void PalRtcDisableCompareIrq(uint8_t channelId)
 {
-  MXC_WUT_IntClear();
+  MXC_WUT_ClearFlags(MXC_WUT0);
   NVIC_DisableIRQ(PAL_WUT_IRQn);
 }

--- a/Libraries/PeriphDrivers/Include/MAX32655/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/wut.h
@@ -172,7 +172,15 @@ void MXC_WUT_ClearFlags(mxc_wut_regs_t *wut);
  * @param   wut  Pointer to Wakeup Timer instance to get interrupt staus from.
  * @return  Returns the interrupt status. 1 if interrupt has occurred.
  */
-uint32_t MXC_WUT_IntStatus(mxc_wut_regs_t *wut);
+__attribute__((deprecated("Use MXC_WUT_GetFlags instead.  See wut.h for more details."))) uint32_t
+MXC_WUT_IntStatus(mxc_wut_regs_t *wut);
+
+/**
+ * @brief   Get the timer interrupt status.
+ * @param   wut  Pointer to Wakeup Timer instance to get interrupt staus from.
+ * @return  Returns the interrupt status. 1 if interrupt has occurred.
+ */
+uint32_t MXC_WUT_GetFlags(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Set the timer compare count.
@@ -216,13 +224,27 @@ int MXC_WUT_GetTime(mxc_wut_regs_t *wut, uint32_t ticks, uint32_t *time, mxc_wut
  * @brief   Wait for an edge of the WUT count register.
  * @param   wut  Pointer to Wakeup Timer instance to wait on.
  */
-void MXC_WUT_Edge(mxc_wut_regs_t *wut);
+__attribute__((deprecated("Use MXC_WUT_WaitForEdge instead.  See wut.h for more details."))) void
+MXC_WUT_Edge(mxc_wut_regs_t *wut);
+
+/**
+ * @brief   Wait for an edge of the WUT count register.
+ * @param   wut  Pointer to Wakeup Timer instance to wait on.
+ */
+void MXC_WUT_WaitForEdge(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Store the count and snapshot values.
  * @param   wut  Pointer to Wakeup Timer instance to store count and snapshot values for.
  */
-void MXC_WUT_Store(mxc_wut_regs_t *wut);
+__attribute__((deprecated("Use MXC_WUT_StoreCount instead.  See wut.h for more details."))) void
+MXC_WUT_Store(mxc_wut_regs_t *wut);
+
+/**
+ * @brief   Store the count and snapshot values.
+ * @param   wut  Pointer to Wakeup Timer instance to store count and snapshot values for.
+ */
+void MXC_WUT_StoreCount(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Restore the DBB clock with the stored count and snapshot values.

--- a/Libraries/PeriphDrivers/Include/MAX32655/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/wut.h
@@ -164,6 +164,7 @@ MXC_WUT_IntClear(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Clear the timer interrupt.
+ * @param   wut  Pointer to Wakeup Timer instance to clear interrupt flags for.
  */
 void MXC_WUT_ClearFlags(mxc_wut_regs_t *wut);
 
@@ -177,7 +178,7 @@ MXC_WUT_IntStatus(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Get the timer interrupt status.
- * @param   wut  Pointer to Wakeup Timer instance to get interrupt staus from.
+ * @param   wut  Pointer to Wakeup Timer instance to get interrupt status from.
  * @return  Returns the interrupt status. 1 if interrupt has occurred.
  */
 uint32_t MXC_WUT_GetFlags(mxc_wut_regs_t *wut);

--- a/Libraries/PeriphDrivers/Include/MAX32655/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/wut.h
@@ -159,8 +159,7 @@ uint32_t MXC_WUT_GetCount(mxc_wut_regs_t *wut);
  * @brief   Clear the timer interrupt.
  * @param   wut  Pointer to Wakeup Timer instance to clear interrupts for.
  */
-__attribute__((
-    deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details.")))void
+__attribute__((deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details."))) void
 MXC_WUT_IntClear(mxc_wut_regs_t *wut);
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32655/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/wut.h
@@ -159,7 +159,14 @@ uint32_t MXC_WUT_GetCount(mxc_wut_regs_t *wut);
  * @brief   Clear the timer interrupt.
  * @param   wut  Pointer to Wakeup Timer instance to clear interrupts for.
  */
-void MXC_WUT_IntClear(mxc_wut_regs_t *wut);
+__attribute__((
+    deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details.")))void
+MXC_WUT_IntClear(mxc_wut_regs_t *wut);
+
+/**
+ * @brief   Clear the timer interrupt.
+ */
+void MXC_WUT_ClearFlags(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Get the timer interrupt status.

--- a/Libraries/PeriphDrivers/Include/MAX32657/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/wut.h
@@ -170,7 +170,15 @@ void MXC_WUT_ClearFlags(mxc_wut_regs_t *wut);
  * @param   wut  Pointer to Wakeup Timer instance to get interrupt staus from.
  * @return  Returns the interrupt status. 1 if interrupt has occurred.
  */
-uint32_t MXC_WUT_IntStatus(mxc_wut_regs_t *wut);
+__attribute__((deprecated("Use MXC_WUT_GetFlags instead.  See wut.h for more details."))) uint32_t
+MXC_WUT_IntStatus(mxc_wut_regs_t *wut);
+
+/**
+ * @brief   Get the timer interrupt status.
+ * @param   wut  Pointer to Wakeup Timer instance to get interrupt staus from.
+ * @return  Returns the interrupt status. 1 if interrupt has occurred.
+ */
+uint32_t MXC_WUT_GetFlags(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Set the timer compare count.
@@ -214,13 +222,27 @@ int MXC_WUT_GetTime(mxc_wut_regs_t *wut, uint32_t ticks, uint32_t *time, mxc_wut
  * @brief   Wait for an edge of the WUT count register.
  * @param   wut  Pointer to Wakeup Timer instance to wait on.
  */
-void MXC_WUT_Edge(mxc_wut_regs_t *wut);
+__attribute__((deprecated("Use MXC_WUT_WaitForEdge instead.  See wut.h for more details."))) void
+MXC_WUT_Edge(mxc_wut_regs_t *wut);
+
+/**
+ * @brief   Wait for an edge of the WUT count register.
+ * @param   wut  Pointer to Wakeup Timer instance to wait on.
+ */
+void MXC_WUT_WaitForEdge(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Store the count and snapshot values.
  * @param   wut  Pointer to Wakeup Timer instance to store count and snapshot values for.
  */
-void MXC_WUT_Store(mxc_wut_regs_t *wut);
+__attribute__((deprecated("Use MXC_WUT_StoreCount instead.  See wut.h for more details."))) void
+MXC_WUT_Store(mxc_wut_regs_t *wut);
+
+/**
+ * @brief   Store the count and snapshot values.
+ * @param   wut  Pointer to Wakeup Timer instance to store count and snapshot values for.
+ */
+void MXC_WUT_StoreCount(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Restore the DBB clock with the stored count and snapshot values.

--- a/Libraries/PeriphDrivers/Include/MAX32657/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/wut.h
@@ -157,8 +157,7 @@ uint32_t MXC_WUT_GetCount(mxc_wut_regs_t *wut);
  * @brief   Clear the timer interrupt.
  * @param   wut  Pointer to Wakeup Timer instance to clear interrupts for.
  */
-__attribute__((
-    deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details.")))void
+__attribute__((deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details."))) void
 MXC_WUT_IntClear(mxc_wut_regs_t *wut);
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32657/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/wut.h
@@ -162,6 +162,7 @@ MXC_WUT_IntClear(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Clear the timer interrupt.
+ * @param   wut  Pointer to Wakeup Timer instance to clear interrupt flags for.
  */
 void MXC_WUT_ClearFlags(mxc_wut_regs_t *wut);
 
@@ -175,7 +176,7 @@ MXC_WUT_IntStatus(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Get the timer interrupt status.
- * @param   wut  Pointer to Wakeup Timer instance to get interrupt staus from.
+ * @param   wut  Pointer to Wakeup Timer instance to get interrupt status from.
  * @return  Returns the interrupt status. 1 if interrupt has occurred.
  */
 uint32_t MXC_WUT_GetFlags(mxc_wut_regs_t *wut);

--- a/Libraries/PeriphDrivers/Include/MAX32657/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/wut.h
@@ -157,7 +157,14 @@ uint32_t MXC_WUT_GetCount(mxc_wut_regs_t *wut);
  * @brief   Clear the timer interrupt.
  * @param   wut  Pointer to Wakeup Timer instance to clear interrupts for.
  */
-void MXC_WUT_IntClear(mxc_wut_regs_t *wut);
+__attribute__((
+    deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details.")))void
+MXC_WUT_IntClear(mxc_wut_regs_t *wut);
+
+/**
+ * @brief   Clear the timer interrupt.
+ */
+void MXC_WUT_ClearFlags(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Get the timer interrupt status.

--- a/Libraries/PeriphDrivers/Include/MAX32665/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/wut.h
@@ -158,7 +158,14 @@ uint32_t MXC_WUT_GetCount(void);
 /**
  * @brief   Clear the timer interrupt.
  */
-void MXC_WUT_IntClear(void);
+__attribute__((
+    deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details.")))void
+MXC_WUT_IntClear(void);
+
+/**
+ * @brief   Clear the timer interrupt.
+ */
+void MXC_WUT_ClearFlags(void);
 
 /**
  * @brief   Get the timer interrupt status.

--- a/Libraries/PeriphDrivers/Include/MAX32665/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/wut.h
@@ -158,8 +158,7 @@ uint32_t MXC_WUT_GetCount(void);
 /**
  * @brief   Clear the timer interrupt.
  */
-__attribute__((
-    deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details.")))void
+__attribute__((deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details."))) void
 MXC_WUT_IntClear(void);
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32665/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/wut.h
@@ -170,7 +170,14 @@ void MXC_WUT_ClearFlags(void);
  * @brief   Get the timer interrupt status.
  * @return  Returns the interrupt status. 1 if interrupt has occurred.
  */
-uint32_t MXC_WUT_IntStatus(void);
+__attribute__((deprecated("Use MXC_WUT_GetFlags instead.  See wut.h for more details."))) uint32_t
+MXC_WUT_IntStatus(void);
+
+/**
+ * @brief   Get the timer interrupt status.
+ * @return  Returns the interrupt status. 1 if interrupt has occurred.
+ */
+uint32_t MXC_WUT_GetFlags(void);
 
 /**
  * @brief   Set the timer compare count.
@@ -209,12 +216,24 @@ int MXC_WUT_GetTime(uint32_t ticks, uint32_t *time, mxc_wut_unit_t *units);
 /**
  * @brief   Wait for an edge of the WUT count register.
  */
-void MXC_WUT_Edge(void);
+__attribute__((deprecated("Use MXC_WUT_WaitForEdge instead.  See wut.h for more details."))) void
+MXC_WUT_Edge(void);
+
+/**
+ * @brief   Wait for an edge of the WUT count register.
+ */
+void MXC_WUT_WaitForEdge(void);
 
 /**
  * @brief   Store the count and snapshot values.
  */
-void MXC_WUT_Store(void);
+__attribute__((deprecated("Use MXC_WUT_StoreCount instead.  See wut.h for more details."))) void
+MXC_WUT_Store(void);
+
+/**
+ * @brief   Store the count and snapshot values.
+ */
+void MXC_WUT_StoreCount(void);
 
 /**
  * @brief   Restore the DBB clock with the stored count and snapshot values.

--- a/Libraries/PeriphDrivers/Include/MAX32680/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/wut.h
@@ -172,7 +172,15 @@ void MXC_WUT_ClearFlags(mxc_wut_regs_t *wut);
  * @param      wut        Pointer to Wakeup Timer instance to get interrupt status from.
  * @return  Returns the interrupt status. 1 if interrupt has occurred.
  */
-uint32_t MXC_WUT_IntStatus(mxc_wut_regs_t *wut);
+__attribute__((deprecated("Use MXC_WUT_GetFlags instead.  See wut.h for more details."))) uint32_t
+MXC_WUT_IntStatus(mxc_wut_regs_t *wut);
+
+/**
+ * @brief   Get the timer interrupt status.
+ * @param      wut        Pointer to Wakeup Timer instance to get interrupt status from.
+ * @return  Returns the interrupt status. 1 if interrupt has occurred.
+ */
+uint32_t MXC_WUT_GetFlags(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Set the timer compare count.
@@ -216,13 +224,27 @@ int MXC_WUT_GetTime(mxc_wut_regs_t *wut, uint32_t ticks, uint32_t *time, mxc_wut
  * @brief   Wait for an edge of the WUT count register.
  * @param   wut        Pointer to Wakeup Timer instance to wait on.
  */
-void MXC_WUT_Edge(mxc_wut_regs_t *wut);
+__attribute__((deprecated("Use MXC_WUT_WaitForEdge instead.  See wut.h for more details."))) void
+MXC_WUT_Edge(mxc_wut_regs_t *wut);
+
+/**
+ * @brief   Wait for an edge of the WUT count register.
+ * @param   wut        Pointer to Wakeup Timer instance to wait on.
+ */
+void MXC_WUT_WaitForEdge(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Store the count and snapshot values.
  * @param   wut        Pointer to Wakeup Timer instance to store count and snapshot values for.
  */
-void MXC_WUT_Store(mxc_wut_regs_t *wut);
+__attribute__((deprecated("Use MXC_WUT_StoreCount instead.  See wut.h for more details."))) void
+MXC_WUT_Store(mxc_wut_regs_t *wut);
+
+/**
+ * @brief   Store the count and snapshot values.
+ * @param   wut        Pointer to Wakeup Timer instance to store count and snapshot values for.
+ */
+void MXC_WUT_StoreCount(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Restore the DBB clock with the stored count and snapshot values.

--- a/Libraries/PeriphDrivers/Include/MAX32680/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/wut.h
@@ -164,6 +164,7 @@ MXC_WUT_IntClear(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Clear the timer interrupt.
+ * @param   wut  Pointer to Wakeup Timer instance to clear interrupt flags for.
  */
 void MXC_WUT_ClearFlags(mxc_wut_regs_t *wut);
 

--- a/Libraries/PeriphDrivers/Include/MAX32680/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/wut.h
@@ -159,7 +159,14 @@ uint32_t MXC_WUT_GetCount(mxc_wut_regs_t *wut);
  * @brief   Clear the timer interrupt.
  * @param   wut        Pointer to Wakeup Timer instance to clear interrupts for.
  */
-void MXC_WUT_IntClear(mxc_wut_regs_t *wut);
+__attribute__((
+    deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details.")))void
+MXC_WUT_IntClear(mxc_wut_regs_t *wut);
+
+/**
+ * @brief   Clear the timer interrupt.
+ */
+void MXC_WUT_ClearFlags(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Get the timer interrupt status.

--- a/Libraries/PeriphDrivers/Include/MAX32680/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/wut.h
@@ -159,8 +159,7 @@ uint32_t MXC_WUT_GetCount(mxc_wut_regs_t *wut);
  * @brief   Clear the timer interrupt.
  * @param   wut        Pointer to Wakeup Timer instance to clear interrupts for.
  */
-__attribute__((
-    deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details.")))void
+__attribute__((deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details."))) void
 MXC_WUT_IntClear(mxc_wut_regs_t *wut);
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32690/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/wut.h
@@ -158,19 +158,13 @@ uint32_t MXC_WUT_GetCount(mxc_wut_regs_t *wut);
 /**
  * @brief   Clear the timer interrupt.
  */
-__attribute__((deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details."))) void
-MXC_WUT_IntClear(void);
-
-/**
- * @brief   Clear the timer interrupt.
- */
 void MXC_WUT_ClearFlags(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Get the timer interrupt status.
  * @return  Returns the interrupt status. 1 if interrupt has occurred.
  */
-uint32_t MXC_WUT_IntStatus(mxc_wut_regs_t *wut);
+uint32_t MXC_WUT_GetFlags(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Set the timer compare count.
@@ -209,12 +203,12 @@ int MXC_WUT_GetTime(mxc_wut_regs_t *wut, uint32_t ticks, uint32_t *time, mxc_wut
 /**
  * @brief   Wait for an edge of the WUT count register.
  */
-void MXC_WUT_Edge(mxc_wut_regs_t *wut);
+void MXC_WUT_WaitForEdge(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Store the count and snapshot values.
  */
-void MXC_WUT_Store(mxc_wut_regs_t *wut);
+void MXC_WUT_StoreCount(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Restore the DBB clock with the stored count and snapshot values.

--- a/Libraries/PeriphDrivers/Include/MAX32690/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/wut.h
@@ -158,8 +158,7 @@ uint32_t MXC_WUT_GetCount(mxc_wut_regs_t *wut);
 /**
  * @brief   Clear the timer interrupt.
  */
-__attribute__((
-    deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details.")))void
+__attribute__((deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details."))) void
 MXC_WUT_IntClear(void);
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32690/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/wut.h
@@ -159,7 +159,7 @@ uint32_t MXC_WUT_GetCount(mxc_wut_regs_t *wut);
  * @brief   Clear the timer interrupt.
  */
 __attribute__((
-    deprecated("Use MXC_NVIC_SetVector instead.  See nvic_table.h for more details.")))void
+    deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details.")))void
 MXC_WUT_IntClear(void);
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32690/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/wut.h
@@ -112,62 +112,73 @@ typedef void (*mxc_wut_complete_cb_t)(int result);
 
 /**
  * @brief      Initialize timer module clock.
+ * @param      wut        Pointer to Wakeup Timer instance to initialize.
  * @param      pres       Prescaler value. 
  */
 void MXC_WUT_Init(mxc_wut_regs_t *wut, mxc_wut_pres_t pres);
 
 /**
  * @brief      Shutdown timer module clock.
+ * @param      wut        Pointer to Wakeup Timer instance to shutdown.
  */
 void MXC_WUT_Shutdown(mxc_wut_regs_t *wut);
 
 /**
  * @brief      Enable the timer. 
+ * @param      wut        Pointer to Wakeup Timer instance to enable.
  */
 void MXC_WUT_Enable(mxc_wut_regs_t *wut);
 
 /**
  * @brief      Disable the timer.
+ * @param      wut        Pointer to Wakeup Timer instance to disable.
  */
 void MXC_WUT_Disable(mxc_wut_regs_t *wut);
 
 /**
  * @brief      Configure the timer.
+ * @param      wut  Pointer to Wakeup Timer instance to configure.
  * @param      cfg  Pointer to timer configuration struct.
  */
 void MXC_WUT_Config(mxc_wut_regs_t *wut, const mxc_wut_cfg_t *cfg);
 
 /**
  * @brief   Get the timer compare count.
+ * @param   wut  Pointer to Wakeup Timer instance to get compare value from.
  * @return  Returns the current compare count.
  */
 uint32_t MXC_WUT_GetCompare(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Get the timer capture count.
+ * @param   wut  Pointer to Wakeup Timer instance to get capture count value from.
  * @return  Returns the most recent capture count.
  */
 uint32_t MXC_WUT_GetCapture(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Get the timer count.
+ * @param   wut  Pointer to Wakeup Timer instance to get count value from.
  * @return  Returns the current count.
  */
 uint32_t MXC_WUT_GetCount(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Clear the timer interrupt.
+ * @param   wut  Pointer to Wakeup Timer instance to clear interrupt flags for.
  */
 void MXC_WUT_ClearFlags(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Get the timer interrupt status.
+ * @param   wut  Pointer to Wakeup Timer instance to get interrupt status from.
  * @return  Returns the interrupt status. 1 if interrupt has occurred.
  */
 uint32_t MXC_WUT_GetFlags(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Set the timer compare count.
+ * @param   wut      Pointer to Wakeup Timer instance to set compare value for.
  * @param   cmp_cnt New compare count.
  * @note    This function does not protect against output glitches in PWM mode.
  *          Use MXC_WUT_PWMSetPeriod when in PWM mode.
@@ -176,12 +187,14 @@ void MXC_WUT_SetCompare(mxc_wut_regs_t *wut, uint32_t cmp_cnt);
 
 /**
  * @brief   Set the timer count.
+ * @param   wut     Pointer to Wakeup Timer instance to set count value for.
  * @param   cnt     New count.
  */
 void MXC_WUT_SetCount(mxc_wut_regs_t *wut, uint32_t cnt);
 
 /**
  * @brief   Convert real time to timer ticks.
+ * @param   wut     Pointer to Wakeup Timer instance to get tick count for.
  * @param   time    Number of units of time.
  * @param   units   Which units of time you want to convert.
  * @param   ticks   Pointer to store the number of ticks calculated.
@@ -192,6 +205,7 @@ int MXC_WUT_GetTicks(mxc_wut_regs_t *wut, uint32_t time, mxc_wut_unit_t units, u
 
 /**
  * @brief   Convert timer ticks to real time.
+ * @param   wut     Pointer to Wakeup Timer instance to get time for.
  * @param   ticks   Number of ticks.
  * @param   time    Pointer to store number of units of time.
  * @param   units   Pointer to store the units that time represents.
@@ -202,16 +216,19 @@ int MXC_WUT_GetTime(mxc_wut_regs_t *wut, uint32_t ticks, uint32_t *time, mxc_wut
 
 /**
  * @brief   Wait for an edge of the WUT count register.
+ * @param   wut  Pointer to Wakeup Timer instance to wait on.
  */
 void MXC_WUT_WaitForEdge(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Store the count and snapshot values.
+ * @param   wut  Pointer to Wakeup Timer instance to store count and snapshot values for.
  */
 void MXC_WUT_StoreCount(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Restore the DBB clock with the stored count and snapshot values.
+ * @param   wut      Pointer to Wakeup Timer instance restore count and snapshot values for.
  * @param   dbbFreq  Frequency of DBB clock.
  */
 void MXC_WUT_RestoreBBClock(mxc_wut_regs_t *wut, uint32_t dbbFreq);
@@ -219,18 +236,21 @@ void MXC_WUT_RestoreBBClock(mxc_wut_regs_t *wut, uint32_t dbbFreq);
 /**
  * @brief   Get the difference between the stored counter value 
  *          and the current counter value.
+ * @param   wut  Pointer to Wakeup Timer instance to get current sleep ticks for.
  * @return  Returns the current counter value - stored counter value.
  */
 uint32_t MXC_WUT_GetSleepTicks(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Delays for the given number of milliseconds.
+ * @param   wut  Pointer to Wakeup Timer instance to use as the delay timer.
  * @param   waitMs  Number of milliseconds to wait.
  */
 void MXC_WUT_Delay_MS(mxc_wut_regs_t *wut, uint32_t waitMs);
 
 /**
  * @brief   Trim the 32 kHz crystal load settings, blocks until complete.
+ * @param   wut  Pointer to Wakeup Timer instance to trim.
  * @details This procedure uses the WUT and the BLE DBB, driven by the 32 MHz crystal,
  *          to trim the load settings of the 32 kHz crystal. This procedure will only
  *          work if the BLE DBB is initialized and running.
@@ -241,6 +261,7 @@ int MXC_WUT_TrimCrystal(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Trim the 32 kHz crystal load settings, non-blocking interrupt based.
+ * @param   wut  Pointer to Wakeup Timer instance to trim.
  * @details This procedure uses the WUT and the BLE DBB, driven by the 32 MHz crystal,
  *          to trim the load settings of the 32 kHz crystal. This procedure will only
  *          work if the BLE DBB is initialized and running.
@@ -252,6 +273,7 @@ int MXC_WUT_TrimCrystalAsync(mxc_wut_regs_t *wut, mxc_wut_complete_cb_t cb);
 
 /**
  * @brief   Check to see if the trim procedure is ongoing.
+ * @param   wut  Pointer to Wakeup Timer instance to check trim status for.
  * @details Must leave the 32 MHz clock and BLE DBB running while the trim procedure is pending.
  * @return  #E_NO_ERROR If trim is complete, E_BUSY if trim procedure is ongoing.
  */
@@ -259,7 +281,7 @@ int MXC_WUT_TrimPending(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Interrupt handler for trim procedure.
- *
+ * @param   wut  Pointer to Wakeup Timer instance to handle interrupts for.
  * @return  #E_NO_ERROR If trim is complete, E_BUSY if trim procedure is ongoing.
  */
 int MXC_WUT_Handler(mxc_wut_regs_t *wut);

--- a/Libraries/PeriphDrivers/Include/MAX32690/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/wut.h
@@ -114,57 +114,64 @@ typedef void (*mxc_wut_complete_cb_t)(int result);
  * @brief      Initialize timer module clock.
  * @param      pres       Prescaler value. 
  */
-void MXC_WUT_Init(mxc_wut_pres_t pres);
+void MXC_WUT_Init(mxc_wut_regs_t *wut, mxc_wut_pres_t pres);
 
 /**
  * @brief      Shutdown timer module clock.
  */
-void MXC_WUT_Shutdown(void);
+void MXC_WUT_Shutdown(mxc_wut_regs_t *wut);
 
 /**
  * @brief      Enable the timer. 
  */
-void MXC_WUT_Enable(void);
+void MXC_WUT_Enable(mxc_wut_regs_t *wut);
 
 /**
  * @brief      Disable the timer.
  */
-void MXC_WUT_Disable(void);
+void MXC_WUT_Disable(mxc_wut_regs_t *wut);
 
 /**
  * @brief      Configure the timer.
  * @param      cfg  Pointer to timer configuration struct.
  */
-void MXC_WUT_Config(const mxc_wut_cfg_t *cfg);
+void MXC_WUT_Config(mxc_wut_regs_t *wut, const mxc_wut_cfg_t *cfg);
 
 /**
  * @brief   Get the timer compare count.
  * @return  Returns the current compare count.
  */
-uint32_t MXC_WUT_GetCompare(void);
+uint32_t MXC_WUT_GetCompare(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Get the timer capture count.
  * @return  Returns the most recent capture count.
  */
-uint32_t MXC_WUT_GetCapture(void);
+uint32_t MXC_WUT_GetCapture(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Get the timer count.
  * @return  Returns the current count.
  */
-uint32_t MXC_WUT_GetCount(void);
+uint32_t MXC_WUT_GetCount(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Clear the timer interrupt.
  */
-void MXC_WUT_IntClear(void);
+__attribute__((
+    deprecated("Use MXC_NVIC_SetVector instead.  See nvic_table.h for more details.")))void
+MXC_WUT_IntClear(void);
+
+/**
+ * @brief   Clear the timer interrupt.
+ */
+void MXC_WUT_ClearFlags(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Get the timer interrupt status.
  * @return  Returns the interrupt status. 1 if interrupt has occurred.
  */
-uint32_t MXC_WUT_IntStatus(void);
+uint32_t MXC_WUT_IntStatus(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Set the timer compare count.
@@ -172,13 +179,13 @@ uint32_t MXC_WUT_IntStatus(void);
  * @note    This function does not protect against output glitches in PWM mode.
  *          Use MXC_WUT_PWMSetPeriod when in PWM mode.
  */
-void MXC_WUT_SetCompare(uint32_t cmp_cnt);
+void MXC_WUT_SetCompare(mxc_wut_regs_t *wut, uint32_t cmp_cnt);
 
 /**
  * @brief   Set the timer count.
  * @param   cnt     New count.
  */
-void MXC_WUT_SetCount(uint32_t cnt);
+void MXC_WUT_SetCount(mxc_wut_regs_t *wut, uint32_t cnt);
 
 /**
  * @brief   Convert real time to timer ticks.
@@ -188,7 +195,7 @@ void MXC_WUT_SetCount(uint32_t cnt);
  * @return     #E_NO_ERROR If everything is successful. 
  * @return     @ref MXC_Error_Codes If function is unsuccessful.
  */
-int MXC_WUT_GetTicks(uint32_t time, mxc_wut_unit_t units, uint32_t *ticks);
+int MXC_WUT_GetTicks(mxc_wut_regs_t *wut, uint32_t time, mxc_wut_unit_t units, uint32_t *ticks);
 
 /**
  * @brief   Convert timer ticks to real time.
@@ -198,36 +205,36 @@ int MXC_WUT_GetTicks(uint32_t time, mxc_wut_unit_t units, uint32_t *ticks);
  * @return     #E_NO_ERROR If everything is successful. 
  * @return     @ref MXC_Error_Codes If function is unsuccessful.
  */
-int MXC_WUT_GetTime(uint32_t ticks, uint32_t *time, mxc_wut_unit_t *units);
+int MXC_WUT_GetTime(mxc_wut_regs_t *wut, uint32_t ticks, uint32_t *time, mxc_wut_unit_t *units);
 
 /**
  * @brief   Wait for an edge of the WUT count register.
  */
-void MXC_WUT_Edge(void);
+void MXC_WUT_Edge(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Store the count and snapshot values.
  */
-void MXC_WUT_Store(void);
+void MXC_WUT_Store(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Restore the DBB clock with the stored count and snapshot values.
  * @param   dbbFreq  Frequency of DBB clock.
  */
-void MXC_WUT_RestoreBBClock(uint32_t dbbFreq);
+void MXC_WUT_RestoreBBClock(mxc_wut_regs_t *wut, uint32_t dbbFreq);
 
 /**
  * @brief   Get the difference between the stored counter value 
  *          and the current counter value.
  * @return  Returns the current counter value - stored counter value.
  */
-uint32_t MXC_WUT_GetSleepTicks(void);
+uint32_t MXC_WUT_GetSleepTicks(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Delays for the given number of milliseconds.
  * @param   waitMs  Number of milliseconds to wait.
  */
-void MXC_WUT_Delay_MS(uint32_t waitMs);
+void MXC_WUT_Delay_MS(mxc_wut_regs_t *wut, uint32_t waitMs);
 
 /**
  * @brief   Trim the 32 kHz crystal load settings, blocks until complete.
@@ -237,7 +244,7 @@ void MXC_WUT_Delay_MS(uint32_t waitMs);
  *
  * @return  #E_NO_ERROR If everything is successful.
  */
-int MXC_WUT_TrimCrystal(void);
+int MXC_WUT_TrimCrystal(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Trim the 32 kHz crystal load settings, non-blocking interrupt based.
@@ -248,21 +255,21 @@ int MXC_WUT_TrimCrystal(void);
  * @param   cb Callback for when the trim is complete.
  * @return  #E_NO_ERROR If everything is successful.
  */
-int MXC_WUT_TrimCrystalAsync(mxc_wut_complete_cb_t cb);
+int MXC_WUT_TrimCrystalAsync(mxc_wut_regs_t *wut, mxc_wut_complete_cb_t cb);
 
 /**
  * @brief   Check to see if the trim procedure is ongoing.
  * @details Must leave the 32 MHz clock and BLE DBB running while the trim procedure is pending.
  * @return  #E_NO_ERROR If trim is complete, E_BUSY if trim procedure is ongoing.
  */
-int MXC_WUT_TrimPending(void);
+int MXC_WUT_TrimPending(mxc_wut_regs_t *wut);
 
 /**
  * @brief   Interrupt handler for trim procedure.
  *
  * @return  #E_NO_ERROR If trim is complete, E_BUSY if trim procedure is ongoing.
  */
-int MXC_WUT_Handler(void);
+int MXC_WUT_Handler(mxc_wut_regs_t *wut);
 
 /**@} end of group wut */
 

--- a/Libraries/PeriphDrivers/Include/MAX78000/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/wut.h
@@ -163,7 +163,14 @@ void MXC_WUT_ClearFlags(void);
  * @brief   Get the timer interrupt status.
  * @return  Returns the interrupt status. 1 if interrupt has occurred.
  */
-uint32_t MXC_WUT_IntStatus(void);
+__attribute__((deprecated("Use MXC_WUT_GetFlags instead.  See wut.h for more details."))) uint32_t
+MXC_WUT_IntStatus(void);
+
+/**
+ * @brief   Get the timer interrupt status.
+ * @return  Returns the interrupt status. 1 if interrupt has occurred.
+ */
+uint32_t MXC_WUT_GetFlags(void);
 
 /**
  * @brief   Set the timer compare count.
@@ -202,12 +209,24 @@ int MXC_WUT_GetTime(uint32_t ticks, uint32_t *time, mxc_wut_unit_t *units);
 /**
  * @brief   Wait for an edge of the WUT count register.
  */
-void MXC_WUT_Edge(void);
+__attribute__((deprecated("Use MXC_WUT_WaitForEdge instead.  See wut.h for more details."))) void
+MXC_WUT_Edge(void);
+
+/**
+ * @brief   Wait for an edge of the WUT count register.
+ */
+void MXC_WUT_WaitForEdge(void);
 
 /**
  * @brief   Store the count and snapshot values.
  */
-void MXC_WUT_Store(void);
+__attribute__((deprecated("Use MXC_WUT_StoreCount instead.  See wut.h for more details."))) void
+MXC_WUT_Store(void);
+
+/**
+ * @brief   Store the count and snapshot values.
+ */
+void MXC_WUT_StoreCount(void);
 
 /**
  * @brief   Restore the DBB clock with the stored count and snapshot values.

--- a/Libraries/PeriphDrivers/Include/MAX78000/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/wut.h
@@ -151,7 +151,14 @@ uint32_t MXC_WUT_GetCount(void);
 /**
  * @brief   Clear the timer interrupt.
  */
-void MXC_WUT_IntClear(void);
+__attribute__((
+    deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details.")))void
+MXC_WUT_IntClear(void);
+
+/**
+ * @brief   Clear the timer interrupt.
+ */
+void MXC_WUT_ClearFlags(void);
 
 /**
  * @brief   Get the timer interrupt status.

--- a/Libraries/PeriphDrivers/Include/MAX78000/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/wut.h
@@ -151,8 +151,7 @@ uint32_t MXC_WUT_GetCount(void);
 /**
  * @brief   Clear the timer interrupt.
  */
-__attribute__((
-    deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details.")))void
+__attribute__((deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details."))) void
 MXC_WUT_IntClear(void);
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX78002/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/wut.h
@@ -150,8 +150,7 @@ uint32_t MXC_WUT_GetCount(void);
 /**
  * @brief   Clear the timer interrupt.
  */
-__attribute__((
-    deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details.")))void
+__attribute__((deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details."))) void
 MXC_WUT_IntClear(void);
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX78002/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/wut.h
@@ -162,7 +162,14 @@ void MXC_WUT_ClearFlags(void);
  * @brief   Get the timer interrupt status.
  * @return  Returns the interrupt status. 1 if interrupt has occurred.
  */
-uint32_t MXC_WUT_IntStatus(void);
+__attribute__((deprecated("Use MXC_WUT_GetFlags instead.  See wut.h for more details."))) uint32_t
+MXC_WUT_IntStatus(void);
+
+/**
+ * @brief   Get the timer interrupt status.
+ * @return  Returns the interrupt status. 1 if interrupt has occurred.
+ */
+uint32_t MXC_WUT_GetFlags(void);
 
 /**
  * @brief   Set the timer compare count.
@@ -201,12 +208,24 @@ int MXC_WUT_GetTime(uint32_t ticks, uint32_t *time, mxc_wut_unit_t *units);
 /**
  * @brief   Wait for an edge of the WUT count register.
  */
-void MXC_WUT_Edge(void);
+__attribute__((deprecated("Use MXC_WUT_WaitForEdge instead.  See wut.h for more details."))) void
+MXC_WUT_Edge(void);
+
+/**
+ * @brief   Wait for an edge of the WUT count register.
+ */
+void MXC_WUT_WaitForEdge(void);
 
 /**
  * @brief   Store the count and snapshot values.
  */
-void MXC_WUT_Store(void);
+__attribute__((deprecated("Use MXC_WUT_StoreCount instead.  See wut.h for more details."))) void
+MXC_WUT_Store(void);
+
+/**
+ * @brief   Store the count and snapshot values.
+ */
+void MXC_WUT_StoreCount(void);
 
 /**
  * @brief   Restore the DBB clock with the stored count and snapshot values.

--- a/Libraries/PeriphDrivers/Include/MAX78002/wut.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/wut.h
@@ -150,7 +150,14 @@ uint32_t MXC_WUT_GetCount(void);
 /**
  * @brief   Clear the timer interrupt.
  */
-void MXC_WUT_IntClear(void);
+__attribute__((
+    deprecated("Use MXC_WUT_ClearFlags instead.  See wut.h for more details.")))void
+MXC_WUT_IntClear(void);
+
+/**
+ * @brief   Clear the timer interrupt.
+ */
+void MXC_WUT_ClearFlags(void);
 
 /**
  * @brief   Get the timer interrupt status.

--- a/Libraries/PeriphDrivers/Source/WUT/wut_ai85.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_ai85.c
@@ -111,6 +111,12 @@ uint32_t MXC_WUT_IntStatus(void)
 }
 
 /* ************************************************************************* */
+uint32_t MXC_WUT_GetFlags(void)
+{
+    return MXC_WUT_RevA_IntStatus((mxc_wut_reva_regs_t *)MXC_WUT);
+}
+
+/* ************************************************************************* */
 void MXC_WUT_SetCompare(uint32_t cmp_cnt)
 {
     MXC_WUT_RevA_SetCompare((mxc_wut_reva_regs_t *)MXC_WUT, cmp_cnt);
@@ -142,7 +148,19 @@ void MXC_WUT_Edge(void)
 }
 
 /* ************************************************************************** */
+void MXC_WUT_WaitForEdge(void)
+{
+    MXC_WUT_RevA_Edge((mxc_wut_reva_regs_t *)MXC_WUT);
+}
+
+/* ************************************************************************** */
 void MXC_WUT_Store(void)
+{
+    MXC_WUT_RevA_Store((mxc_wut_reva_regs_t *)MXC_WUT);
+}
+
+/* ************************************************************************** */
+void MXC_WUT_StoreCount(void)
 {
     MXC_WUT_RevA_Store((mxc_wut_reva_regs_t *)MXC_WUT);
 }

--- a/Libraries/PeriphDrivers/Source/WUT/wut_ai85.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_ai85.c
@@ -99,6 +99,12 @@ void MXC_WUT_IntClear(void)
 }
 
 /* ************************************************************************* */
+void MXC_WUT_ClearFlags(void)
+{
+    MXC_WUT_RevA_IntClear((mxc_wut_reva_regs_t *)MXC_WUT);
+}
+
+/* ************************************************************************* */
 uint32_t MXC_WUT_IntStatus(void)
 {
     return MXC_WUT_RevA_IntStatus((mxc_wut_reva_regs_t *)MXC_WUT);
@@ -223,7 +229,7 @@ int MXC_WUT_Handler(void)
     mxc_wut_complete_cb_t cbTemp;
 
     /* Clear the interrupt flags */
-    MXC_WUT_IntClear();
+    MXC_WUT_ClearFlags();
 
     if (!trimPending) {
         return E_NO_ERROR;

--- a/Libraries/PeriphDrivers/Source/WUT/wut_ai87.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_ai87.c
@@ -89,6 +89,12 @@ void MXC_WUT_IntClear(void)
 }
 
 /* ************************************************************************* */
+void MXC_WUT_ClearFlags(void)
+{
+    MXC_WUT_RevA_IntClear((mxc_wut_reva_regs_t *)MXC_WUT);
+}
+
+/* ************************************************************************* */
 uint32_t MXC_WUT_IntStatus(void)
 {
     return MXC_WUT_RevA_IntStatus((mxc_wut_reva_regs_t *)MXC_WUT);

--- a/Libraries/PeriphDrivers/Source/WUT/wut_ai87.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_ai87.c
@@ -101,6 +101,12 @@ uint32_t MXC_WUT_IntStatus(void)
 }
 
 /* ************************************************************************* */
+uint32_t MXC_WUT_GetFlags(void)
+{
+    return MXC_WUT_RevA_IntStatus((mxc_wut_reva_regs_t *)MXC_WUT);
+}
+
+/* ************************************************************************* */
 void MXC_WUT_SetCompare(uint32_t cmp_cnt)
 {
     MXC_WUT_RevA_SetCompare((mxc_wut_reva_regs_t *)MXC_WUT, cmp_cnt);
@@ -132,7 +138,19 @@ void MXC_WUT_Edge(void)
 }
 
 /* ************************************************************************** */
+void MXC_WUT_WaitForEdge(void)
+{
+    MXC_WUT_RevA_Edge((mxc_wut_reva_regs_t *)MXC_WUT);
+}
+
+/* ************************************************************************** */
 void MXC_WUT_Store(void)
+{
+    MXC_WUT_RevA_Store((mxc_wut_reva_regs_t *)MXC_WUT);
+}
+
+/* ************************************************************************** */
+void MXC_WUT_StoreCount(void)
 {
     MXC_WUT_RevA_Store((mxc_wut_reva_regs_t *)MXC_WUT);
 }

--- a/Libraries/PeriphDrivers/Source/WUT/wut_me14.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_me14.c
@@ -118,6 +118,12 @@ uint32_t MXC_WUT_IntStatus(void)
 }
 
 /* ************************************************************************* */
+uint32_t MXC_WUT_GetFlags(void)
+{
+    return MXC_WUT_RevA_IntStatus((mxc_wut_reva_regs_t *)MXC_WUT);
+}
+
+/* ************************************************************************* */
 void MXC_WUT_SetCompare(uint32_t cmp_cnt)
 {
     MXC_WUT_RevA_SetCompare((mxc_wut_reva_regs_t *)MXC_WUT, cmp_cnt);
@@ -149,7 +155,19 @@ void MXC_WUT_Edge(void)
 }
 
 /* ************************************************************************** */
+void MXC_WUT_WaitForEdge(void)
+{
+    MXC_WUT_RevA_Edge((mxc_wut_reva_regs_t *)MXC_WUT);
+}
+
+/* ************************************************************************** */
 void MXC_WUT_Store(void)
+{
+    MXC_WUT_RevA_Store((mxc_wut_reva_regs_t *)MXC_WUT);
+}
+
+/* ************************************************************************** */
+void MXC_WUT_StoreCount(void)
 {
     MXC_WUT_RevA_Store((mxc_wut_reva_regs_t *)MXC_WUT);
 }

--- a/Libraries/PeriphDrivers/Source/WUT/wut_me14.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_me14.c
@@ -106,6 +106,12 @@ void MXC_WUT_IntClear(void)
 }
 
 /* ************************************************************************* */
+void MXC_WUT_ClearFlags(void)
+{
+    MXC_WUT_RevA_IntClear((mxc_wut_reva_regs_t *)MXC_WUT);
+}
+
+/* ************************************************************************* */
 uint32_t MXC_WUT_IntStatus(void)
 {
     return MXC_WUT_RevA_IntStatus((mxc_wut_reva_regs_t *)MXC_WUT);
@@ -234,7 +240,7 @@ int MXC_WUT_Handler(void)
     mxc_wut_complete_cb_t cbTemp;
 
     /* Clear the interrupt flags */
-    MXC_WUT_IntClear();
+    MXC_WUT_ClearFlags();
 
     if (!trimPending) {
         return E_NO_ERROR;

--- a/Libraries/PeriphDrivers/Source/WUT/wut_me17.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_me17.c
@@ -99,6 +99,12 @@ void MXC_WUT_IntClear(mxc_wut_regs_t *wut)
 }
 
 /* ************************************************************************* */
+void MXC_WUT_ClearFlags(mxc_wut_regs_t *wut)
+{
+    MXC_WUT_RevA_IntClear((mxc_wut_reva_regs_t *)wut);
+}
+
+/* ************************************************************************* */
 uint32_t MXC_WUT_IntStatus(mxc_wut_regs_t *wut)
 {
     return MXC_WUT_RevA_IntStatus((mxc_wut_reva_regs_t *)wut);
@@ -223,7 +229,7 @@ int MXC_WUT_Handler(mxc_wut_regs_t *wut)
     mxc_wut_complete_cb_t cbTemp;
 
     /* Clear the interrupt flags */
-    MXC_WUT_IntClear(wut);
+    MXC_WUT_ClearFlags(wut);
 
     if (!trimPending) {
         return E_NO_ERROR;

--- a/Libraries/PeriphDrivers/Source/WUT/wut_me17.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_me17.c
@@ -111,6 +111,12 @@ uint32_t MXC_WUT_IntStatus(mxc_wut_regs_t *wut)
 }
 
 /* ************************************************************************* */
+uint32_t MXC_WUT_GetFlags(mxc_wut_regs_t *wut)
+{
+    return MXC_WUT_RevA_IntStatus((mxc_wut_reva_regs_t *)wut);
+}
+
+/* ************************************************************************* */
 void MXC_WUT_SetCompare(mxc_wut_regs_t *wut, uint32_t cmp_cnt)
 {
     MXC_WUT_RevA_SetCompare((mxc_wut_reva_regs_t *)wut, cmp_cnt);
@@ -142,7 +148,19 @@ void MXC_WUT_Edge(mxc_wut_regs_t *wut)
 }
 
 /* ************************************************************************** */
+void MXC_WUT_WaitForEdge(mxc_wut_regs_t *wut)
+{
+    MXC_WUT_RevA_Edge((mxc_wut_reva_regs_t *)wut);
+}
+
+/* ************************************************************************** */
 void MXC_WUT_Store(mxc_wut_regs_t *wut)
+{
+    MXC_WUT_RevA_Store((mxc_wut_reva_regs_t *)wut);
+}
+
+/* ************************************************************************** */
+void MXC_WUT_StoreCount(mxc_wut_regs_t *wut)
 {
     MXC_WUT_RevA_Store((mxc_wut_reva_regs_t *)wut);
 }

--- a/Libraries/PeriphDrivers/Source/WUT/wut_me18.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_me18.c
@@ -100,19 +100,13 @@ uint32_t MXC_WUT_GetCount(mxc_wut_regs_t *wut)
 }
 
 /* ************************************************************************* */
-void MXC_WUT_IntClear(void)
-{
-    MXC_WUT_RevA_IntClear((mxc_wut_reva_regs_t *)MXC_WUT);
-}
-
-/* ************************************************************************* */
 void MXC_WUT_ClearFlags(mxc_wut_regs_t *wut)
 {
     MXC_WUT_RevA_IntClear((mxc_wut_reva_regs_t *)wut);
 }
 
 /* ************************************************************************* */
-uint32_t MXC_WUT_IntStatus(mxc_wut_regs_t *wut)
+uint32_t MXC_WUT_GetFlags(mxc_wut_regs_t *wut)
 {
     return MXC_WUT_RevA_IntStatus((mxc_wut_reva_regs_t *)wut);
 }
@@ -144,13 +138,13 @@ int MXC_WUT_GetTime(mxc_wut_regs_t *wut, uint32_t ticks, uint32_t *time, mxc_wut
 }
 
 /* ************************************************************************** */
-void MXC_WUT_Edge(mxc_wut_regs_t *wut)
+void MXC_WUT_WaitForEdge(mxc_wut_regs_t *wut)
 {
     MXC_WUT_RevA_Edge((mxc_wut_reva_regs_t *)wut);
 }
 
 /* ************************************************************************** */
-void MXC_WUT_Store(mxc_wut_regs_t *wut)
+void MXC_WUT_StoreCount(mxc_wut_regs_t *wut)
 {
     MXC_WUT_RevA_Store((mxc_wut_reva_regs_t *)wut);
 }

--- a/Libraries/PeriphDrivers/Source/WUT/wut_me18.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_me18.c
@@ -49,54 +49,54 @@ static mxc_wut_complete_cb_t cb_async;
 /* **** Functions **** */
 
 /* ************************************************************************** */
-void MXC_WUT_Init(mxc_wut_pres_t pres)
+void MXC_WUT_Init(mxc_wut_regs_t *wut, mxc_wut_pres_t pres)
 {
 #ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
 #endif
-    MXC_WUT_RevA_Init((mxc_wut_reva_regs_t *)MXC_WUT, (mxc_wut_reva_pres_t)pres);
+    MXC_WUT_RevA_Init((mxc_wut_reva_regs_t *)wut, (mxc_wut_reva_pres_t)pres);
 }
 
 /* ************************************************************************** */
-void MXC_WUT_Shutdown(void)
+void MXC_WUT_Shutdown(mxc_wut_regs_t *wut)
 {
-    MXC_WUT_RevA_Shutdown((mxc_wut_reva_regs_t *)MXC_WUT);
+    MXC_WUT_RevA_Shutdown((mxc_wut_reva_regs_t *)wut);
 }
 
 /* ************************************************************************** */
-void MXC_WUT_Enable(void)
+void MXC_WUT_Enable(mxc_wut_regs_t *wut)
 {
-    MXC_WUT_RevA_Enable((mxc_wut_reva_regs_t *)MXC_WUT);
+    MXC_WUT_RevA_Enable((mxc_wut_reva_regs_t *)wut);
 }
 
 /* ************************************************************************** */
-void MXC_WUT_Disable(void)
+void MXC_WUT_Disable(mxc_wut_regs_t *wut)
 {
-    MXC_WUT_RevA_Disable((mxc_wut_reva_regs_t *)MXC_WUT);
+    MXC_WUT_RevA_Disable((mxc_wut_reva_regs_t *)wut);
 }
 
 /* ************************************************************************** */
-void MXC_WUT_Config(const mxc_wut_cfg_t *cfg)
+void MXC_WUT_Config(mxc_wut_regs_t *wut, const mxc_wut_cfg_t *cfg)
 {
-    MXC_WUT_RevA_Config((mxc_wut_reva_regs_t *)MXC_WUT, (mxc_wut_reva_cfg_t *)cfg);
+    MXC_WUT_RevA_Config((mxc_wut_reva_regs_t *)wut, (mxc_wut_reva_cfg_t *)cfg);
 }
 
 /* ************************************************************************** */
-uint32_t MXC_WUT_GetCompare(void)
+uint32_t MXC_WUT_GetCompare(mxc_wut_regs_t *wut)
 {
-    return MXC_WUT_RevA_GetCompare((mxc_wut_reva_regs_t *)MXC_WUT);
+    return MXC_WUT_RevA_GetCompare((mxc_wut_reva_regs_t *)wut);
 }
 
 /* ************************************************************************** */
-uint32_t MXC_WUT_GetCapture(void)
+uint32_t MXC_WUT_GetCapture(mxc_wut_regs_t *wut)
 {
-    return MXC_WUT_RevA_GetCapture((mxc_wut_reva_regs_t *)MXC_WUT);
+    return MXC_WUT_RevA_GetCapture((mxc_wut_reva_regs_t *)wut);
 }
 
 /* ************************************************************************* */
-uint32_t MXC_WUT_GetCount(void)
+uint32_t MXC_WUT_GetCount(mxc_wut_regs_t *wut)
 {
-    return MXC_WUT_RevA_GetCount((mxc_wut_reva_regs_t *)MXC_WUT);
+    return MXC_WUT_RevA_GetCount((mxc_wut_reva_regs_t *)wut);
 }
 
 /* ************************************************************************* */
@@ -106,73 +106,79 @@ void MXC_WUT_IntClear(void)
 }
 
 /* ************************************************************************* */
-uint32_t MXC_WUT_IntStatus(void)
+void MXC_WUT_ClearFlags(mxc_wut_regs_t *wut)
 {
-    return MXC_WUT_RevA_IntStatus((mxc_wut_reva_regs_t *)MXC_WUT);
+    MXC_WUT_RevA_IntClear((mxc_wut_reva_regs_t *)wut);
 }
 
 /* ************************************************************************* */
-void MXC_WUT_SetCompare(uint32_t cmp_cnt)
+uint32_t MXC_WUT_IntStatus(mxc_wut_regs_t *wut)
 {
-    MXC_WUT_RevA_SetCompare((mxc_wut_reva_regs_t *)MXC_WUT, cmp_cnt);
+    return MXC_WUT_RevA_IntStatus((mxc_wut_reva_regs_t *)wut);
 }
 
 /* ************************************************************************* */
-void MXC_WUT_SetCount(uint32_t cnt)
+void MXC_WUT_SetCompare(mxc_wut_regs_t *wut, uint32_t cmp_cnt)
 {
-    MXC_WUT_RevA_SetCount((mxc_wut_reva_regs_t *)MXC_WUT, cnt);
+    MXC_WUT_RevA_SetCompare((mxc_wut_reva_regs_t *)wut, cmp_cnt);
 }
 
 /* ************************************************************************* */
-int MXC_WUT_GetTicks(uint32_t time, mxc_wut_unit_t units, uint32_t *ticks)
+void MXC_WUT_SetCount(mxc_wut_regs_t *wut, uint32_t cnt)
 {
-    return MXC_WUT_RevA_GetTicks((mxc_wut_reva_regs_t *)MXC_WUT, ERTCO_FREQ, time,
+    MXC_WUT_RevA_SetCount((mxc_wut_reva_regs_t *)wut, cnt);
+}
+
+/* ************************************************************************* */
+int MXC_WUT_GetTicks(mxc_wut_regs_t *wut, uint32_t time, mxc_wut_unit_t units, uint32_t *ticks)
+{
+    return MXC_WUT_RevA_GetTicks((mxc_wut_reva_regs_t *)wut, ERTCO_FREQ, time,
                                  (mxc_wut_reva_unit_t)units, ticks);
 }
 
 /* ************************************************************************* */
-int MXC_WUT_GetTime(uint32_t ticks, uint32_t *time, mxc_wut_unit_t *units)
+int MXC_WUT_GetTime(mxc_wut_regs_t *wut, uint32_t ticks, uint32_t *time, mxc_wut_unit_t *units)
 {
-    return MXC_WUT_RevA_GetTime((mxc_wut_reva_regs_t *)MXC_WUT, ERTCO_FREQ, ticks, time,
+    return MXC_WUT_RevA_GetTime((mxc_wut_reva_regs_t *)wut, ERTCO_FREQ, ticks, time,
                                 (mxc_wut_reva_unit_t *)units);
 }
 
 /* ************************************************************************** */
-void MXC_WUT_Edge(void)
+void MXC_WUT_Edge(mxc_wut_regs_t *wut)
 {
-    MXC_WUT_RevA_Edge((mxc_wut_reva_regs_t *)MXC_WUT);
+    MXC_WUT_RevA_Edge((mxc_wut_reva_regs_t *)wut);
 }
 
 /* ************************************************************************** */
-void MXC_WUT_Store(void)
+void MXC_WUT_Store(mxc_wut_regs_t *wut)
 {
-    MXC_WUT_RevA_Store((mxc_wut_reva_regs_t *)MXC_WUT);
+    MXC_WUT_RevA_Store((mxc_wut_reva_regs_t *)wut);
 }
 
 /* ************************************************************************** */
-void MXC_WUT_RestoreBBClock(uint32_t dbbFreq)
+void MXC_WUT_RestoreBBClock(mxc_wut_regs_t *wut, uint32_t dbbFreq)
 {
-    MXC_WUT_RevA_RestoreBBClock((mxc_wut_reva_regs_t *)MXC_WUT, dbbFreq, ERTCO_FREQ);
+    MXC_WUT_RevA_RestoreBBClock((mxc_wut_reva_regs_t *)wut, dbbFreq, ERTCO_FREQ);
 }
 
 /* ************************************************************************** */
-uint32_t MXC_WUT_GetSleepTicks(void)
+uint32_t MXC_WUT_GetSleepTicks(mxc_wut_regs_t *wut)
 {
-    return MXC_WUT_RevA_GetSleepTicks((mxc_wut_reva_regs_t *)MXC_WUT);
+    return MXC_WUT_RevA_GetSleepTicks((mxc_wut_reva_regs_t *)wut);
 }
 
 /* ************************************************************************** */
-void MXC_WUT_Delay_MS(uint32_t waitMs)
+void MXC_WUT_Delay_MS(mxc_wut_regs_t *wut, uint32_t waitMs)
 {
-    MXC_WUT_RevA_Delay_MS((mxc_wut_reva_regs_t *)MXC_WUT, waitMs, ERTCO_FREQ);
+    MXC_WUT_RevA_Delay_MS((mxc_wut_reva_regs_t *)wut, waitMs, ERTCO_FREQ);
 }
 
 /* ************************************************************************** */
-static void MXC_WUT_GetWUTSync(uint32_t *wutCnt, uint32_t *snapshot)
+static void MXC_WUT_GetWUTSync(mxc_wut_regs_t *wut, uint32_t *wutCnt, uint32_t *snapshot)
 {
-    MXC_WUT_RevA_Edge((mxc_wut_reva_regs_t *)MXC_WUT);
-    *wutCnt = MXC_WUT->cnt;
-    *snapshot = MXC_WUT->snapshot;
+    MXC_WUT_RevA_Edge((mxc_wut_reva_regs_t *)wut);
+    *wutCnt = wut->cnt;
+    *snapshot = wut->snapshot;
 }
 
 /* ************************************************************************** */
@@ -185,24 +191,24 @@ static void MXC_WUT_SetTrim(uint32_t trimValue)
 }
 
 /* ************************************************************************** */
-static int MXC_WUT_StarTrim(void)
+static int MXC_WUT_StartTrim(mxc_wut_regs_t *wut)
 {
     uint32_t wutCnt0, wutCnt1;
     uint32_t snapshot0, snapshot1;
     uint32_t trimValue;
 
     /* Make sure the WUT is running in compare mode */
-    if (!(MXC_WUT->ctrl & MXC_F_WUT_REVA_CTRL_TEN)) {
+    if (!(wut->ctrl & MXC_F_WUT_REVA_CTRL_TEN)) {
         return E_UNINITIALIZED;
     }
 
-    if ((MXC_WUT->ctrl & MXC_F_WUT_CTRL_TMODE) != MXC_S_WUT_CTRL_TMODE_COMPARE) {
+    if ((wut->ctrl & MXC_F_WUT_CTRL_TMODE) != MXC_S_WUT_CTRL_TMODE_COMPARE) {
         return E_UNINITIALIZED;
     }
 
     /* Make sure that DBB counter is running */
-    MXC_WUT_GetWUTSync(&wutCnt0, &snapshot0);
-    MXC_WUT_GetWUTSync(&wutCnt1, &snapshot1);
+    MXC_WUT_GetWUTSync(wut, &wutCnt0, &snapshot0);
+    MXC_WUT_GetWUTSync(wut, &wutCnt1, &snapshot1);
     if (snapshot0 == snapshot1) {
         return E_UNINITIALIZED;
     }
@@ -216,7 +222,7 @@ static int MXC_WUT_StarTrim(void)
     bestDiff_async = 0xFFFF;
 
     /* Get the initial snapshot */
-    MXC_WUT_GetWUTSync(&wutCnt0_async, &snapshot0_async);
+    MXC_WUT_GetWUTSync(wut, &wutCnt0_async, &snapshot0_async);
 
     trimPending = 1;
 
@@ -224,7 +230,7 @@ static int MXC_WUT_StarTrim(void)
 }
 
 /* ************************************************************************** */
-int MXC_WUT_Handler(void)
+int MXC_WUT_Handler(mxc_wut_regs_t *wut)
 {
     uint32_t wutCnt1;
     uint32_t snapshot1;
@@ -235,14 +241,14 @@ int MXC_WUT_Handler(void)
     mxc_wut_complete_cb_t cbTemp;
 
     /* Clear the interrupt flags */
-    MXC_WUT_IntClear();
+    MXC_WUT_ClearFlags(wut);
 
     if (!trimPending) {
         return E_NO_ERROR;
     }
 
     /* Store the snapshot */
-    MXC_WUT_GetWUTSync(&wutCnt1, &snapshot1);
+    MXC_WUT_GetWUTSync(wut, &wutCnt1, &snapshot1);
     snapTicks = snapshot1 - snapshot0_async;
     wutTicks = wutCnt1 - wutCnt0_async;
 
@@ -316,11 +322,11 @@ int MXC_WUT_Handler(void)
 
     /* Start the next step */
     MXC_WUT_SetTrim(trimValue);
-    MXC_WUT_GetWUTSync(&wutCnt0_async, &snapshot0_async);
+    MXC_WUT_GetWUTSync(wut, &wutCnt0_async, &snapshot0_async);
 
     if (cb_async != NULL) {
         /* Prime the compare interrupt */
-        MXC_WUT->cmp = MXC_WUT->cnt + WUT_TRIM_TICKS - 1;
+        wut->cmp = wut->cnt + WUT_TRIM_TICKS - 1;
     }
 
     /* Return E_BUSY to indicate the trim procedure is still running */
@@ -328,7 +334,7 @@ int MXC_WUT_Handler(void)
 }
 
 /* ************************************************************************** */
-int MXC_WUT_TrimCrystal(void)
+int MXC_WUT_TrimCrystal(mxc_wut_regs_t *wut)
 {
     int err, i;
 
@@ -336,21 +342,21 @@ int MXC_WUT_TrimCrystal(void)
     cb_async = NULL;
 
     /* Start the trim procedure */
-    err = MXC_WUT_StarTrim();
+    err = MXC_WUT_StartTrim(wut);
     if (err != E_NO_ERROR) {
         return err;
     }
     do {
         for (i = 0; i < (WUT_TRIM_TICKS - 1); i++) {
-            MXC_WUT_RevA_Edge((mxc_wut_reva_regs_t *)MXC_WUT);
+            MXC_WUT_RevA_Edge((mxc_wut_reva_regs_t *)wut);
         }
-    } while (MXC_WUT_Handler() != E_NO_ERROR);
+    } while (MXC_WUT_Handler(wut) != E_NO_ERROR);
 
     return E_NO_ERROR;
 }
 
 /* ************************************************************************** */
-int MXC_WUT_TrimCrystalAsync(mxc_wut_complete_cb_t cb)
+int MXC_WUT_TrimCrystalAsync(mxc_wut_regs_t *wut, mxc_wut_complete_cb_t cb)
 {
     int err;
 
@@ -362,19 +368,19 @@ int MXC_WUT_TrimCrystalAsync(mxc_wut_complete_cb_t cb)
     cb_async = cb;
 
     /* Start the trim procedure */
-    err = MXC_WUT_StarTrim();
+    err = MXC_WUT_StartTrim(wut);
     if (err != E_NO_ERROR) {
         return err;
     }
 
     /* Prime the compare interrupt */
-    MXC_WUT->cmp = MXC_WUT->cnt + WUT_TRIM_TICKS - 1;
+    wut->cmp = wut->cnt + WUT_TRIM_TICKS - 1;
 
     return E_NO_ERROR;
 }
 
 /* ************************************************************************** */
-int MXC_WUT_TrimPending(void)
+int MXC_WUT_TrimPending(mxc_wut_regs_t *wut)
 {
     if (trimPending) {
         return E_BUSY;

--- a/Libraries/PeriphDrivers/Source/WUT/wut_me30.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_me30.c
@@ -109,6 +109,12 @@ uint32_t MXC_WUT_IntStatus(mxc_wut_regs_t *wut)
 }
 
 /* ************************************************************************* */
+uint32_t MXC_WUT_GetFlags(mxc_wut_regs_t *wut)
+{
+    return MXC_WUT_RevA_IntStatus((mxc_wut_reva_regs_t *)wut);
+}
+
+/* ************************************************************************* */
 void MXC_WUT_SetCompare(mxc_wut_regs_t *wut, uint32_t cmp_cnt)
 {
     MXC_WUT_RevA_SetCompare((mxc_wut_reva_regs_t *)wut, cmp_cnt);
@@ -140,7 +146,19 @@ void MXC_WUT_Edge(mxc_wut_regs_t *wut)
 }
 
 /* ************************************************************************** */
+void MXC_WUT_WaitForEdge(mxc_wut_regs_t *wut)
+{
+    MXC_WUT_RevA_Edge((mxc_wut_reva_regs_t *)wut);
+}
+
+/* ************************************************************************** */
 void MXC_WUT_Store(mxc_wut_regs_t *wut)
+{
+    MXC_WUT_RevA_Store((mxc_wut_reva_regs_t *)wut);
+}
+
+/* ************************************************************************** */
+void MXC_WUT_StoreCount(mxc_wut_regs_t *wut)
 {
     MXC_WUT_RevA_Store((mxc_wut_reva_regs_t *)wut);
 }

--- a/Libraries/PeriphDrivers/Source/WUT/wut_me30.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_me30.c
@@ -97,6 +97,12 @@ void MXC_WUT_IntClear(mxc_wut_regs_t *wut)
 }
 
 /* ************************************************************************* */
+void MXC_WUT_ClearFlags(mxc_wut_regs_t *wut)
+{
+    MXC_WUT_RevA_IntClear((mxc_wut_reva_regs_t *)wut);
+}
+
+/* ************************************************************************* */
 uint32_t MXC_WUT_IntStatus(mxc_wut_regs_t *wut)
 {
     return MXC_WUT_RevA_IntStatus((mxc_wut_reva_regs_t *)wut);
@@ -223,7 +229,7 @@ int MXC_WUT_Handler(mxc_wut_regs_t *wut)
     mxc_wut_complete_cb_t cbTemp;
 
     /* Clear the interrupt flags */
-    MXC_WUT_IntClear(wut);
+    MXC_WUT_ClearFlags(wut);
 
     if (!trimPending) {
         return E_NO_ERROR;


### PR DESCRIPTION
### Description

The MAX32690's WUT functions perform operations using a single instance of the wake-up timer. However, the [max32690.h](https://github.com/analogdevicesinc/msdk/blob/eeb59b53912d2831e115f18a2a0dad9b5e3f21af/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.h#L369) file shows that there are **two** instances. This can be confirmed in section 24.1 of the device User Guide.

This is a breaking change as the function prototypes and signatures have been modified to offer a `mxc_wut_regs_t *wut` selection as an argument instead of defaulting to a single WUT instance.

### Deprecation

In favor of the `[action][verb]()` naming scheme for functions, the following functions are being marked as deprecated and updated with a new name:

- `MXC_WUT_IntClear()` is being replaced by `MXC_WUT_ClearFlags()`.
- `MXC_WUT_IntStatus()` is being replaced by `MXC_WUT_GetFlags()`.
- `MXC_WUT_Edge()` is being replaced by `MXC_WUT_WaitForEdge()`.
- `MXC_WUT_Store()` is being replaced by `MXC_WUT_StoreCount()`.

**Note**: Unlike the other impacted devices, the MAX32690 will **not** have old functions marked as deprecated. Instead, these will be updated to their new names immediately as part of the breaking change, due to additional function argument. 

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

