### PR TITLE
fix(CMSIS,PeriphDrivers): Add TMR RevB `CTRL1.async` field which allows asynchronous reads to the PWM and CNT registers

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Include/max32655.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Include/max32655.svd
@@ -11169,6 +11169,12 @@
        <bitWidth>1</bitWidth>
       </field>
       <field>
+       <name>ASYNC</name>
+       <description>Allows asynchronous reads of the PWM and CNT registers.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
        <name>CLKSEL_B</name>
        <description>Timer Clock Select for Timer B</description>
        <bitOffset>16</bitOffset>

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Include/tmr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Include/tmr_regs.h
@@ -7,9 +7,7 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
- * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -382,6 +380,9 @@ typedef struct {
 
 #define MXC_F_TMR_CTRL1_OUTBEN_A_POS                   14 /**< CTRL1_OUTBEN_A Position */
 #define MXC_F_TMR_CTRL1_OUTBEN_A                       ((uint32_t)(0x1UL << MXC_F_TMR_CTRL1_OUTBEN_A_POS)) /**< CTRL1_OUTBEN_A Mask */
+
+#define MXC_F_TMR_CTRL1_ASYNC_POS                      15 /**< CTRL1_ASYNC Position */
+#define MXC_F_TMR_CTRL1_ASYNC                          ((uint32_t)(0x1UL << MXC_F_TMR_CTRL1_ASYNC_POS)) /**< CTRL1_ASYNC Mask */
 
 #define MXC_F_TMR_CTRL1_CLKSEL_B_POS                   16 /**< CTRL1_CLKSEL_B Position */
 #define MXC_F_TMR_CTRL1_CLKSEL_B                       ((uint32_t)(0x3UL << MXC_F_TMR_CTRL1_CLKSEL_B_POS)) /**< CTRL1_CLKSEL_B Mask */

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Include/tmr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Include/tmr_regs.h
@@ -7,7 +7,9 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Analog Devices, Inc.),
+ * Copyright (C) 2023-2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.svd
@@ -10082,6 +10082,12 @@
        <bitWidth>1</bitWidth>
       </field>
       <field>
+       <name>ASYNC</name>
+       <description>Allows asynchronous reads to the PWM and CNT registers.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
        <name>CLKSEL_B</name>
        <description>Timer Clock Select for Timer B</description>
        <bitOffset>16</bitOffset>

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/tmr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/tmr_regs.h
@@ -381,6 +381,9 @@ typedef struct {
 #define MXC_F_TMR_CTRL1_OUTBEN_A_POS                   14 /**< CTRL1_OUTBEN_A Position */
 #define MXC_F_TMR_CTRL1_OUTBEN_A                       ((uint32_t)(0x1UL << MXC_F_TMR_CTRL1_OUTBEN_A_POS)) /**< CTRL1_OUTBEN_A Mask */
 
+#define MXC_F_TMR_CTRL1_ASYNC_POS                      15 /**< CTRL1_ASYNC Position */
+#define MXC_F_TMR_CTRL1_ASYNC                          ((uint32_t)(0x1UL << MXC_F_TMR_CTRL1_ASYNC_POS)) /**< CTRL1_ASYNC Mask */
+
 #define MXC_F_TMR_CTRL1_CLKSEL_B_POS                   16 /**< CTRL1_CLKSEL_B Position */
 #define MXC_F_TMR_CTRL1_CLKSEL_B                       ((uint32_t)(0x3UL << MXC_F_TMR_CTRL1_CLKSEL_B_POS)) /**< CTRL1_CLKSEL_B Mask */
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Include/max32670.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Include/max32670.svd
@@ -8542,6 +8542,12 @@
        <bitWidth>1</bitWidth>
       </field>
       <field>
+       <name>ASYNC</name>
+       <description>Allows asynchronous reads to the PWM and CNT registers.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
        <name>CLKSEL_B</name>
        <description>Timer Clock Select for Timer B</description>
        <bitOffset>16</bitOffset>

--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Include/tmr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Include/tmr_regs.h
@@ -7,9 +7,7 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
- * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -382,6 +380,9 @@ typedef struct {
 
 #define MXC_F_TMR_CTRL1_OUTBEN_A_POS                   14 /**< CTRL1_OUTBEN_A Position */
 #define MXC_F_TMR_CTRL1_OUTBEN_A                       ((uint32_t)(0x1UL << MXC_F_TMR_CTRL1_OUTBEN_A_POS)) /**< CTRL1_OUTBEN_A Mask */
+
+#define MXC_F_TMR_CTRL1_ASYNC_POS                      15 /**< CTRL1_ASYNC Position */
+#define MXC_F_TMR_CTRL1_ASYNC                          ((uint32_t)(0x1UL << MXC_F_TMR_CTRL1_ASYNC_POS)) /**< CTRL1_ASYNC Mask */
 
 #define MXC_F_TMR_CTRL1_CLKSEL_B_POS                   16 /**< CTRL1_CLKSEL_B Position */
 #define MXC_F_TMR_CTRL1_CLKSEL_B                       ((uint32_t)(0x3UL << MXC_F_TMR_CTRL1_CLKSEL_B_POS)) /**< CTRL1_CLKSEL_B Mask */

--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Include/tmr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Include/tmr_regs.h
@@ -7,7 +7,9 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Analog Devices, Inc.),
+ * Copyright (C) 2023-2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.svd
@@ -11667,6 +11667,12 @@
        <bitWidth>1</bitWidth>
       </field>
       <field>
+       <name>ASYNC</name>
+       <description>Allows asynchronous reads to the PWM and CNT registers.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
        <name>CLKSEL_B</name>
        <description>Timer Clock Select for Timer B</description>
        <bitOffset>16</bitOffset>

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Include/tmr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Include/tmr_regs.h
@@ -7,9 +7,7 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
- * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -382,6 +380,9 @@ typedef struct {
 
 #define MXC_F_TMR_CTRL1_OUTBEN_A_POS                   14 /**< CTRL1_OUTBEN_A Position */
 #define MXC_F_TMR_CTRL1_OUTBEN_A                       ((uint32_t)(0x1UL << MXC_F_TMR_CTRL1_OUTBEN_A_POS)) /**< CTRL1_OUTBEN_A Mask */
+
+#define MXC_F_TMR_CTRL1_ASYNC_POS                      15 /**< CTRL1_ASYNC Position */
+#define MXC_F_TMR_CTRL1_ASYNC                          ((uint32_t)(0x1UL << MXC_F_TMR_CTRL1_ASYNC_POS)) /**< CTRL1_ASYNC Mask */
 
 #define MXC_F_TMR_CTRL1_CLKSEL_B_POS                   16 /**< CTRL1_CLKSEL_B Position */
 #define MXC_F_TMR_CTRL1_CLKSEL_B                       ((uint32_t)(0x3UL << MXC_F_TMR_CTRL1_CLKSEL_B_POS)) /**< CTRL1_CLKSEL_B Mask */

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Include/tmr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Include/tmr_regs.h
@@ -7,7 +7,9 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Analog Devices, Inc.),
+ * Copyright (C) 2023-2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.svd
@@ -8548,6 +8548,12 @@
        <bitWidth>1</bitWidth>
       </field>
       <field>
+       <name>ASYNC</name>
+       <description>Allows asynchronous reads to the PWM and CNT registers.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
        <name>CLKSEL_B</name>
        <description>Timer Clock Select for Timer B</description>
        <bitOffset>16</bitOffset>

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Include/tmr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Include/tmr_regs.h
@@ -7,9 +7,7 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
- * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -382,6 +380,9 @@ typedef struct {
 
 #define MXC_F_TMR_CTRL1_OUTBEN_A_POS                   14 /**< CTRL1_OUTBEN_A Position */
 #define MXC_F_TMR_CTRL1_OUTBEN_A                       ((uint32_t)(0x1UL << MXC_F_TMR_CTRL1_OUTBEN_A_POS)) /**< CTRL1_OUTBEN_A Mask */
+
+#define MXC_F_TMR_CTRL1_ASYNC_POS                      15 /**< CTRL1_ASYNC Position */
+#define MXC_F_TMR_CTRL1_ASYNC                          ((uint32_t)(0x1UL << MXC_F_TMR_CTRL1_ASYNC_POS)) /**< CTRL1_ASYNC Mask */
 
 #define MXC_F_TMR_CTRL1_CLKSEL_B_POS                   16 /**< CTRL1_CLKSEL_B Position */
 #define MXC_F_TMR_CTRL1_CLKSEL_B                       ((uint32_t)(0x3UL << MXC_F_TMR_CTRL1_CLKSEL_B_POS)) /**< CTRL1_CLKSEL_B Mask */

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Include/tmr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Include/tmr_regs.h
@@ -7,7 +7,9 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Analog Devices, Inc.),
+ * Copyright (C) 2023-2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.svd
@@ -19455,6 +19455,12 @@ signal(s) on transition(s) from low to high or high to low when PM.USBWKEN is se
        <bitWidth>1</bitWidth>
       </field>
       <field>
+       <name>ASYNC</name>
+       <description>Allows asynchronous reads of the PWM and CNT registers.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
        <name>CLKSEL_B</name>
        <description>Timer Clock Select for Timer B</description>
        <bitOffset>16</bitOffset>

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/tmr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/tmr_regs.h
@@ -7,9 +7,7 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
- * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -382,6 +380,9 @@ typedef struct {
 
 #define MXC_F_TMR_CTRL1_OUTBEN_A_POS                   14 /**< CTRL1_OUTBEN_A Position */
 #define MXC_F_TMR_CTRL1_OUTBEN_A                       ((uint32_t)(0x1UL << MXC_F_TMR_CTRL1_OUTBEN_A_POS)) /**< CTRL1_OUTBEN_A Mask */
+
+#define MXC_F_TMR_CTRL1_ASYNC_POS                      15 /**< CTRL1_ASYNC Position */
+#define MXC_F_TMR_CTRL1_ASYNC                          ((uint32_t)(0x1UL << MXC_F_TMR_CTRL1_ASYNC_POS)) /**< CTRL1_ASYNC Mask */
 
 #define MXC_F_TMR_CTRL1_CLKSEL_B_POS                   16 /**< CTRL1_CLKSEL_B Position */
 #define MXC_F_TMR_CTRL1_CLKSEL_B                       ((uint32_t)(0x3UL << MXC_F_TMR_CTRL1_CLKSEL_B_POS)) /**< CTRL1_CLKSEL_B Mask */

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/tmr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/tmr_regs.h
@@ -7,7 +7,9 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Analog Devices, Inc.),
+ * Copyright (C) 2023-2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Include/max78000.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Include/max78000.svd
@@ -11102,6 +11102,12 @@
        <bitWidth>1</bitWidth>
       </field>
       <field>
+       <name>ASYNC</name>
+       <description>Allows asynchronous reads of the PWM and CNT registers.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
        <name>CLKSEL_B</name>
        <description>Timer Clock Select for Timer B</description>
        <bitOffset>16</bitOffset>

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Include/tmr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Include/tmr_regs.h
@@ -7,9 +7,7 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
- * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -382,6 +380,9 @@ typedef struct {
 
 #define MXC_F_TMR_CTRL1_OUTBEN_A_POS                   14 /**< CTRL1_OUTBEN_A Position */
 #define MXC_F_TMR_CTRL1_OUTBEN_A                       ((uint32_t)(0x1UL << MXC_F_TMR_CTRL1_OUTBEN_A_POS)) /**< CTRL1_OUTBEN_A Mask */
+
+#define MXC_F_TMR_CTRL1_ASYNC_POS                      15 /**< CTRL1_ASYNC Position */
+#define MXC_F_TMR_CTRL1_ASYNC                          ((uint32_t)(0x1UL << MXC_F_TMR_CTRL1_ASYNC_POS)) /**< CTRL1_ASYNC Mask */
 
 #define MXC_F_TMR_CTRL1_CLKSEL_B_POS                   16 /**< CTRL1_CLKSEL_B Position */
 #define MXC_F_TMR_CTRL1_CLKSEL_B                       ((uint32_t)(0x3UL << MXC_F_TMR_CTRL1_CLKSEL_B_POS)) /**< CTRL1_CLKSEL_B Mask */

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Include/tmr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Include/tmr_regs.h
@@ -7,7 +7,9 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Analog Devices, Inc.),
+ * Copyright (C) 2023-2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Include/max78002.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Include/max78002.svd
@@ -16843,6 +16843,12 @@ signal(s) on transition(s) from low to high or high to low when PM.USBWKEN is se
        <bitWidth>1</bitWidth>
       </field>
       <field>
+       <name>ASYNC</name>
+       <description>Allows asynchronous reads of the PWM and CNT registers.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
        <name>CLKSEL_B</name>
        <description>Timer Clock Select for Timer B</description>
        <bitOffset>16</bitOffset>

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Include/tmr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Include/tmr_regs.h
@@ -7,9 +7,7 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
- * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -382,6 +380,9 @@ typedef struct {
 
 #define MXC_F_TMR_CTRL1_OUTBEN_A_POS                   14 /**< CTRL1_OUTBEN_A Position */
 #define MXC_F_TMR_CTRL1_OUTBEN_A                       ((uint32_t)(0x1UL << MXC_F_TMR_CTRL1_OUTBEN_A_POS)) /**< CTRL1_OUTBEN_A Mask */
+
+#define MXC_F_TMR_CTRL1_ASYNC_POS                      15 /**< CTRL1_ASYNC Position */
+#define MXC_F_TMR_CTRL1_ASYNC                          ((uint32_t)(0x1UL << MXC_F_TMR_CTRL1_ASYNC_POS)) /**< CTRL1_ASYNC Mask */
 
 #define MXC_F_TMR_CTRL1_CLKSEL_B_POS                   16 /**< CTRL1_CLKSEL_B Position */
 #define MXC_F_TMR_CTRL1_CLKSEL_B                       ((uint32_t)(0x3UL << MXC_F_TMR_CTRL1_CLKSEL_B_POS)) /**< CTRL1_CLKSEL_B Mask */

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Include/tmr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Include/tmr_regs.h
@@ -7,7 +7,9 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Analog Devices, Inc.),
+ * Copyright (C) 2023-2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb.svd
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb.svd
@@ -1,662 +1,668 @@
-<?xml version="1.0" encoding="utf-8" standalone="no"?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="svd_schema.xsd">
- <peripheral>
-  <name>TMR</name>
-  <description>Low-Power Configurable Timer</description>
-  <baseAddress>0x40010000</baseAddress>
-  <addressBlock>
-   <offset>0x00</offset>
-   <size>0x1000</size>
-   <usage>registers</usage>
-  </addressBlock>
-  <interrupt>
-   <name>TMR</name>
-<!-- IRQ Name -->
-   <value>1</value>
-<!-- IRQ Number Device Specific -->
-  </interrupt>
-  <registers>
-   <register>
-    <name>CNT</name>
-    <description>Timer Counter Register.</description>
-    <addressOffset>0x00</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>COUNT</name>
-      <description>The current count value for the timer. This field increments as the timer counts.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>32</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>CMP</name>
-    <description>Timer Compare Register.</description>
-    <addressOffset>0x04</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>COMPARE</name>
-      <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>32</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>PWM</name>
-    <description>Timer PWM Register.</description>
-    <addressOffset>0x08</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>PWM</name>
-      <description>Timer PWM Match:
+  <peripheral>
+    <name>TMR</name>
+    <description>Low-Power Configurable Timer</description>
+    <baseAddress>0x40010000</baseAddress>
+    <addressBlock>
+      <offset>0x00</offset>
+      <size>0x1000</size>
+      <usage>registers</usage>
+    </addressBlock>
+    <interrupt>
+      <name>TMR</name>
+      <!-- IRQ Name -->
+      <value>1</value>
+      <!-- IRQ Number Device Specific -->
+    </interrupt>
+    <registers>
+      <register>
+        <name>CNT</name>
+        <description>Timer Counter Register.</description>
+        <addressOffset>0x00</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>COUNT</name>
+            <description>The current count value for the timer. This field increments as the timer counts.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>32</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>CMP</name>
+        <description>Timer Compare Register.</description>
+        <addressOffset>0x04</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>COMPARE</name>
+            <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>32</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>PWM</name>
+        <description>Timer PWM Register.</description>
+        <addressOffset>0x08</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>PWM</name>
+            <description>Timer PWM Match:
                 In PWM Mode, this field sets the count value for the first transition period of the PWM cycle. At the end of the cycle where CNT equals PWM, the PWM output transitions to the second period of the PWM cycle. The second PWM period count is stored in the CMP register. The value set for PWM must me less than the value set in CMP for PWM mode operation. Timer Capture Value:
                 In Capture, Compare, and Capture/Compare modes, this field is used to store the CNT value when a Capture, Compare, or Capture/Compare event occurs.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>32</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>INTFL</name>
-    <description>Timer Interrupt Status Register.</description>
-    <addressOffset>0x0C</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>IRQ_A</name>
-      <description>Interrupt Flag for Timer A.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WRDONE_A</name>
-      <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WR_DIS_A</name>
-      <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
-      <bitOffset>9</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>IRQ_B</name>
-      <description>Interrupt Flag for Timer B.</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WRDONE_B</name>
-      <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WR_DIS_B</name>
-      <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
-      <bitOffset>25</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>CTRL0</name>
-    <description>Timer Control Register.</description>
-    <addressOffset>0x10</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>MODE_A</name>
-      <description>Mode Select for Timer A</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>ONE_SHOT</name>
-        <description>One-Shot Mode</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CONTINUOUS</name>
-        <description>Continuous Mode</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COUNTER</name>
-        <description>Counter Mode</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>PWM</name>
-        <description>PWM Mode</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPTURE</name>
-        <description>Capture Mode</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COMPARE</name>
-        <description>Compare Mode</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>GATED</name>
-        <description>Gated Mode</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPCOMP</name>
-        <description>Capture/Compare Mode</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DUAL_EDGE</name>
-        <description>Dual Edge Capture Mode</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>IGATED</name>
-        <description>Inactive Gated Mode</description>
-        <value>14</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>CLKDIV_A</name>
-      <description>Clock Divider Select for Timer A</description>
-      <bitOffset>4</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>DIV_BY_1</name>
-        <description>Prescaler Divide-By-1</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2</name>
-        <description>Prescaler Divide-By-2</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4</name>
-        <description>Prescaler Divide-By-4</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_8</name>
-        <description>Prescaler Divide-By-8</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_16</name>
-        <description>Prescaler Divide-By-16</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_32</name>
-        <description>Prescaler Divide-By-32</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_64</name>
-        <description>Prescaler Divide-By-64</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_128</name>
-        <description>Prescaler Divide-By-128</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_256</name>
-        <description>Prescaler Divide-By-256</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_512</name>
-        <description>Prescaler Divide-By-512</description>
-        <value>9</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_1024</name>
-        <description>Prescaler Divide-By-1024</description>
-        <value>10</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2048</name>
-        <description>Prescaler Divide-By-2048</description>
-        <value>11</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4096</name>
-        <description>TBD</description>
-        <value>12</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>POL_A</name>
-      <description>Timer Polarity for Timer A</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMSYNC_A</name>
-      <description>PWM Synchronization Mode for Timer A</description>
-      <bitOffset>9</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLHPOL_A</name>
-      <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
-      <bitOffset>10</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLLPOL_A</name>
-      <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
-      <bitOffset>11</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMCKBD_A</name>
-      <description>PWM Phase A-Prime Output Disable for Timer A</description>
-      <bitOffset>12</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>RST_A</name>
-      <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
-      <bitOffset>13</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_A</name>
-      <description>Write 1 to Enable CLK_TMR for Timer A</description>
-      <bitOffset>14</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EN_A</name>
-      <description>Enable for Timer A</description>
-      <bitOffset>15</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>MODE_B</name>
-      <description>Mode Select for Timer B</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>ONE_SHOT</name>
-        <description>One-Shot Mode</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CONTINUOUS</name>
-        <description>Continuous Mode</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COUNTER</name>
-        <description>Counter Mode</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>PWM</name>
-        <description>PWM Mode</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPTURE</name>
-        <description>Capture Mode</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COMPARE</name>
-        <description>Compare Mode</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>GATED</name>
-        <description>Gated Mode</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPCOMP</name>
-        <description>Capture/Compare Mode</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DUAL_EDGE</name>
-        <description>Dual Edge Capture Mode</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>IGATED</name>
-        <description>Inactive Gated Mode</description>
-        <value>14</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>CLKDIV_B</name>
-      <description>Clock Divider Select for Timer B</description>
-      <bitOffset>20</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>DIV_BY_1</name>
-        <description>Prescaler Divide-By-1</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2</name>
-        <description>Prescaler Divide-By-2</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4</name>
-        <description>Prescaler Divide-By-4</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_8</name>
-        <description>Prescaler Divide-By-8</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_16</name>
-        <description>Prescaler Divide-By-16</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_32</name>
-        <description>Prescaler Divide-By-32</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_64</name>
-        <description>Prescaler Divide-By-64</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_128</name>
-        <description>Prescaler Divide-By-128</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_256</name>
-        <description>Prescaler Divide-By-256</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_512</name>
-        <description>Prescaler Divide-By-512</description>
-        <value>9</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_1024</name>
-        <description>Prescaler Divide-By-1024</description>
-        <value>10</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2048</name>
-        <description>Prescaler Divide-By-2048</description>
-        <value>11</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4096</name>
-        <description>TBD</description>
-        <value>12</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>POL_B</name>
-      <description>Timer Polarity for Timer B</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMSYNC_B</name>
-      <description>PWM Synchronization Mode for Timer B</description>
-      <bitOffset>25</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLHPOL_B</name>
-      <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
-      <bitOffset>26</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLLPOL_B</name>
-      <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
-      <bitOffset>27</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMCKBD_B</name>
-      <description>PWM Phase A-Prime Output Disable for Timer B</description>
-      <bitOffset>28</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>     
-     <field>
-      <name>RST_B</name>
-      <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
-      <bitOffset>29</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_B</name>
-      <description>Write 1 to Enable CLK_TMR for Timer B</description>
-      <bitOffset>30</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EN_B</name>
-      <description>Enable for Timer B</description>
-      <bitOffset>31</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>NOLCMP</name>
-    <description>Timer Non-Overlapping Compare Register.</description>
-    <addressOffset>0x14</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>LO_A</name>
-      <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-     <field>
-      <name>HI_A</name>
-      <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-     <field>
-      <name>LO_B</name>
-      <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-     <field>
-      <name>HI_B</name>
-      <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>CTRL1</name>
-    <description>Timer Configuration Register.</description>
-    <addressOffset>0x18</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>CLKSEL_A</name>
-      <description>Timer Clock Select for Timer A</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_A</name>
-      <description>Timer A Enable Status</description>
-      <bitOffset>2</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKRDY_A</name>
-      <description>CLK_TMR Ready Flag for Timer A</description>
-      <bitOffset>3</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EVENT_SEL_A</name>
-      <description>Event Select for Timer A</description>
-      <bitOffset>4</bitOffset>
-      <bitWidth>3</bitWidth>
-     </field>
-     <field>
-      <name>NEGTRIG_A</name>
-      <description>Negative Edge Trigger for Event for Timer A</description>
-      <bitOffset>7</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>IE_A</name>
-      <description>Interrupt Enable for Timer A</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CAPEVENT_SEL_A</name>
-      <description>Capture Event Select for Timer A</description>
-      <bitOffset>9</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>SW_CAPEVENT_A</name>
-      <description>Software Capture Event for Timer A</description>
-      <bitOffset>11</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WE_A</name>
-      <description>Wake-Up Enable for Timer A</description>
-      <bitOffset>12</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>OUTEN_A</name>
-      <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
-      <bitOffset>13</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>OUTBEN_A</name>
-      <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
-      <bitOffset>14</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKSEL_B</name>
-      <description>Timer Clock Select for Timer B</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_B</name>
-      <description>Timer B Enable Status</description>
-      <bitOffset>18</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKRDY_B</name>
-      <description>CLK_TMR Ready Flag for Timer B</description>
-      <bitOffset>19</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EVENT_SEL_B</name>
-      <description>Event Select for Timer B</description>
-      <bitOffset>20</bitOffset>
-      <bitWidth>3</bitWidth>
-     </field>
-     <field>
-      <name>NEGTRIG_B</name>
-      <description>Negative Edge Trigger for Event for Timer B</description>
-      <bitOffset>23</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>IE_B</name>
-      <description>Interrupt Enable for Timer B</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CAPEVENT_SEL_B</name>
-      <description>Capture Event Select for Timer B</description>
-      <bitOffset>25</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>SW_CAPEVENT_B</name>
-      <description>Software Capture Event for Timer B</description>
-      <bitOffset>27</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WE_B</name>
-      <description>Wake-Up Enable for Timer B</description>
-      <bitOffset>28</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CASCADE</name>
-      <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
-      <bitOffset>31</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>WKFL</name>
-    <description>Timer Wakeup Status Register.</description>
-    <addressOffset>0x1C</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>A</name>
-      <description>Wake-Up Flag for Timer A</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>B</name>
-      <description>Wake-Up Flag for Timer B</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-  </registers>
- </peripheral>
-<!-- LPTIMER Low-Power Configurable Timer -->
+            <bitOffset>0</bitOffset>
+            <bitWidth>32</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>INTFL</name>
+        <description>Timer Interrupt Status Register.</description>
+        <addressOffset>0x0C</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>IRQ_A</name>
+            <description>Interrupt Flag for Timer A.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WRDONE_A</name>
+            <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WR_DIS_A</name>
+            <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>IRQ_B</name>
+            <description>Interrupt Flag for Timer B.</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WRDONE_B</name>
+            <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WR_DIS_B</name>
+            <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
+            <bitOffset>25</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>CTRL0</name>
+        <description>Timer Control Register.</description>
+        <addressOffset>0x10</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>MODE_A</name>
+            <description>Mode Select for Timer A</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>ONE_SHOT</name>
+                <description>One-Shot Mode</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CONTINUOUS</name>
+                <description>Continuous Mode</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COUNTER</name>
+                <description>Counter Mode</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>PWM</name>
+                <description>PWM Mode</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPTURE</name>
+                <description>Capture Mode</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COMPARE</name>
+                <description>Compare Mode</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>GATED</name>
+                <description>Gated Mode</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPCOMP</name>
+                <description>Capture/Compare Mode</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DUAL_EDGE</name>
+                <description>Dual Edge Capture Mode</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>IGATED</name>
+                <description>Inactive Gated Mode</description>
+                <value>14</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>CLKDIV_A</name>
+            <description>Clock Divider Select for Timer A</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>DIV_BY_1</name>
+                <description>Prescaler Divide-By-1</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2</name>
+                <description>Prescaler Divide-By-2</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4</name>
+                <description>Prescaler Divide-By-4</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_8</name>
+                <description>Prescaler Divide-By-8</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_16</name>
+                <description>Prescaler Divide-By-16</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_32</name>
+                <description>Prescaler Divide-By-32</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_64</name>
+                <description>Prescaler Divide-By-64</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_128</name>
+                <description>Prescaler Divide-By-128</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_256</name>
+                <description>Prescaler Divide-By-256</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_512</name>
+                <description>Prescaler Divide-By-512</description>
+                <value>9</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_1024</name>
+                <description>Prescaler Divide-By-1024</description>
+                <value>10</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2048</name>
+                <description>Prescaler Divide-By-2048</description>
+                <value>11</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4096</name>
+                <description>TBD</description>
+                <value>12</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>POL_A</name>
+            <description>Timer Polarity for Timer A</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMSYNC_A</name>
+            <description>PWM Synchronization Mode for Timer A</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLHPOL_A</name>
+            <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLLPOL_A</name>
+            <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMCKBD_A</name>
+            <description>PWM Phase A-Prime Output Disable for Timer A</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>RST_A</name>
+            <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_A</name>
+            <description>Write 1 to Enable CLK_TMR for Timer A</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EN_A</name>
+            <description>Enable for Timer A</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>MODE_B</name>
+            <description>Mode Select for Timer B</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>ONE_SHOT</name>
+                <description>One-Shot Mode</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CONTINUOUS</name>
+                <description>Continuous Mode</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COUNTER</name>
+                <description>Counter Mode</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>PWM</name>
+                <description>PWM Mode</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPTURE</name>
+                <description>Capture Mode</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COMPARE</name>
+                <description>Compare Mode</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>GATED</name>
+                <description>Gated Mode</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPCOMP</name>
+                <description>Capture/Compare Mode</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DUAL_EDGE</name>
+                <description>Dual Edge Capture Mode</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>IGATED</name>
+                <description>Inactive Gated Mode</description>
+                <value>14</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>CLKDIV_B</name>
+            <description>Clock Divider Select for Timer B</description>
+            <bitOffset>20</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>DIV_BY_1</name>
+                <description>Prescaler Divide-By-1</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2</name>
+                <description>Prescaler Divide-By-2</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4</name>
+                <description>Prescaler Divide-By-4</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_8</name>
+                <description>Prescaler Divide-By-8</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_16</name>
+                <description>Prescaler Divide-By-16</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_32</name>
+                <description>Prescaler Divide-By-32</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_64</name>
+                <description>Prescaler Divide-By-64</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_128</name>
+                <description>Prescaler Divide-By-128</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_256</name>
+                <description>Prescaler Divide-By-256</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_512</name>
+                <description>Prescaler Divide-By-512</description>
+                <value>9</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_1024</name>
+                <description>Prescaler Divide-By-1024</description>
+                <value>10</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2048</name>
+                <description>Prescaler Divide-By-2048</description>
+                <value>11</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4096</name>
+                <description>TBD</description>
+                <value>12</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>POL_B</name>
+            <description>Timer Polarity for Timer B</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMSYNC_B</name>
+            <description>PWM Synchronization Mode for Timer B</description>
+            <bitOffset>25</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLHPOL_B</name>
+            <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
+            <bitOffset>26</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLLPOL_B</name>
+            <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
+            <bitOffset>27</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMCKBD_B</name>
+            <description>PWM Phase A-Prime Output Disable for Timer B</description>
+            <bitOffset>28</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>RST_B</name>
+            <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
+            <bitOffset>29</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_B</name>
+            <description>Write 1 to Enable CLK_TMR for Timer B</description>
+            <bitOffset>30</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EN_B</name>
+            <description>Enable for Timer B</description>
+            <bitOffset>31</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>NOLCMP</name>
+        <description>Timer Non-Overlapping Compare Register.</description>
+        <addressOffset>0x14</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>LO_A</name>
+            <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+          <field>
+            <name>HI_A</name>
+            <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+          <field>
+            <name>LO_B</name>
+            <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+          <field>
+            <name>HI_B</name>
+            <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>CTRL1</name>
+        <description>Timer Configuration Register.</description>
+        <addressOffset>0x18</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>CLKSEL_A</name>
+            <description>Timer Clock Select for Timer A</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_A</name>
+            <description>Timer A Enable Status</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKRDY_A</name>
+            <description>CLK_TMR Ready Flag for Timer A</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EVENT_SEL_A</name>
+            <description>Event Select for Timer A</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>3</bitWidth>
+          </field>
+          <field>
+            <name>NEGTRIG_A</name>
+            <description>Negative Edge Trigger for Event for Timer A</description>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>IE_A</name>
+            <description>Interrupt Enable for Timer A</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CAPEVENT_SEL_A</name>
+            <description>Capture Event Select for Timer A</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>SW_CAPEVENT_A</name>
+            <description>Software Capture Event for Timer A</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WE_A</name>
+            <description>Wake-Up Enable for Timer A</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>OUTEN_A</name>
+            <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>OUTBEN_A</name>
+            <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>ASYNC</name>
+            <description>Allows asynchronous reads of the PWM and CNT registers.</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKSEL_B</name>
+            <description>Timer Clock Select for Timer B</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_B</name>
+            <description>Timer B Enable Status</description>
+            <bitOffset>18</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKRDY_B</name>
+            <description>CLK_TMR Ready Flag for Timer B</description>
+            <bitOffset>19</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EVENT_SEL_B</name>
+            <description>Event Select for Timer B</description>
+            <bitOffset>20</bitOffset>
+            <bitWidth>3</bitWidth>
+          </field>
+          <field>
+            <name>NEGTRIG_B</name>
+            <description>Negative Edge Trigger for Event for Timer B</description>
+            <bitOffset>23</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>IE_B</name>
+            <description>Interrupt Enable for Timer B</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CAPEVENT_SEL_B</name>
+            <description>Capture Event Select for Timer B</description>
+            <bitOffset>25</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>SW_CAPEVENT_B</name>
+            <description>Software Capture Event for Timer B</description>
+            <bitOffset>27</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WE_B</name>
+            <description>Wake-Up Enable for Timer B</description>
+            <bitOffset>28</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CASCADE</name>
+            <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
+            <bitOffset>31</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>WKFL</name>
+        <description>Timer Wakeup Status Register.</description>
+        <addressOffset>0x1C</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>A</name>
+            <description>Wake-Up Flag for Timer A</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>B</name>
+            <description>Wake-Up Flag for Timer B</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+    </registers>
+  </peripheral>
+  <!-- LPTIMER Low-Power Configurable Timer -->
 </device>

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb_me15.svd
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb_me15.svd
@@ -1,662 +1,668 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="svd_schema.xsd">
- <peripheral>
-  <name>TMR</name>
-  <description>Low-Power Configurable Timer</description>
-  <baseAddress>0x40010000</baseAddress>
-  <addressBlock>
-   <offset>0x00</offset>
-   <size>0x1000</size>
-   <usage>registers</usage>
-  </addressBlock>
-  <interrupt>
-   <name>TMR</name>
-<!-- IRQ Name -->
-   <value>1</value>
-<!-- IRQ Number Device Specific -->
-  </interrupt>
-  <registers>
-   <register>
-    <name>CNT</name>
-    <description>Timer Counter Register.</description>
-    <addressOffset>0x00</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>COUNT</name>
-      <description>The current count value for the timer. This field increments as the timer counts.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>32</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>CMP</name>
-    <description>Timer Compare Register.</description>
-    <addressOffset>0x04</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>COMPARE</name>
-      <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>32</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>PWM</name>
-    <description>Timer PWM Register.</description>
-    <addressOffset>0x08</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>PWM</name>
-      <description>Timer PWM Match:
+  <peripheral>
+    <name>TMR</name>
+    <description>Low-Power Configurable Timer</description>
+    <baseAddress>0x40010000</baseAddress>
+    <addressBlock>
+      <offset>0x00</offset>
+      <size>0x1000</size>
+      <usage>registers</usage>
+    </addressBlock>
+    <interrupt>
+      <name>TMR</name>
+      <!-- IRQ Name -->
+      <value>1</value>
+      <!-- IRQ Number Device Specific -->
+    </interrupt>
+    <registers>
+      <register>
+        <name>CNT</name>
+        <description>Timer Counter Register.</description>
+        <addressOffset>0x00</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>COUNT</name>
+            <description>The current count value for the timer. This field increments as the timer counts.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>32</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>CMP</name>
+        <description>Timer Compare Register.</description>
+        <addressOffset>0x04</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>COMPARE</name>
+            <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>32</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>PWM</name>
+        <description>Timer PWM Register.</description>
+        <addressOffset>0x08</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>PWM</name>
+            <description>Timer PWM Match:
                 In PWM Mode, this field sets the count value for the first transition period of the PWM cycle. At the end of the cycle where CNT equals PWM, the PWM output transitions to the second period of the PWM cycle. The second PWM period count is stored in the CMP register. The value set for PWM must me less than the value set in CMP for PWM mode operation. Timer Capture Value:
                 In Capture, Compare, and Capture/Compare modes, this field is used to store the CNT value when a Capture, Compare, or Capture/Compare event occurs.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>32</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>INTFL</name>
-    <description>Timer Interrupt Status Register.</description>
-    <addressOffset>0x0C</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>IRQ_A</name>
-      <description>Interrupt Flag for Timer A.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WRDONE_A</name>
-      <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WR_DIS_A</name>
-      <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
-      <bitOffset>9</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>IRQ_B</name>
-      <description>Interrupt Flag for Timer B.</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WRDONE_B</name>
-      <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WR_DIS_B</name>
-      <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
-      <bitOffset>25</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>CTRL0</name>
-    <description>Timer Control Register.</description>
-    <addressOffset>0x10</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>MODE_A</name>
-      <description>Mode Select for Timer A</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>ONE_SHOT</name>
-        <description>One-Shot Mode</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CONTINUOUS</name>
-        <description>Continuous Mode</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COUNTER</name>
-        <description>Counter Mode</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>PWM</name>
-        <description>PWM Mode</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPTURE</name>
-        <description>Capture Mode</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COMPARE</name>
-        <description>Compare Mode</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>GATED</name>
-        <description>Gated Mode</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPCOMP</name>
-        <description>Capture/Compare Mode</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DUAL_EDGE</name>
-        <description>Dual Edge Capture Mode</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>IGATED</name>
-        <description>Inactive Gated Mode</description>
-        <value>14</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>CLKDIV_A</name>
-      <description>Clock Divider Select for Timer A</description>
-      <bitOffset>4</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>DIV_BY_1</name>
-        <description>Prescaler Divide-By-1</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2</name>
-        <description>Prescaler Divide-By-2</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4</name>
-        <description>Prescaler Divide-By-4</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_8</name>
-        <description>Prescaler Divide-By-8</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_16</name>
-        <description>Prescaler Divide-By-16</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_32</name>
-        <description>Prescaler Divide-By-32</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_64</name>
-        <description>Prescaler Divide-By-64</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_128</name>
-        <description>Prescaler Divide-By-128</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_256</name>
-        <description>Prescaler Divide-By-256</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_512</name>
-        <description>Prescaler Divide-By-512</description>
-        <value>9</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_1024</name>
-        <description>Prescaler Divide-By-1024</description>
-        <value>10</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2048</name>
-        <description>Prescaler Divide-By-2048</description>
-        <value>11</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4096</name>
-        <description>TBD</description>
-        <value>12</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>POL_A</name>
-      <description>Timer Polarity for Timer A</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMSYNC_A</name>
-      <description>PWM Synchronization Mode for Timer A</description>
-      <bitOffset>9</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLHPOL_A</name>
-      <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
-      <bitOffset>10</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLLPOL_A</name>
-      <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
-      <bitOffset>11</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMCKBD_A</name>
-      <description>PWM Phase A-Prime Output Disable for Timer A</description>
-      <bitOffset>12</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>RST_A</name>
-      <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
-      <bitOffset>13</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_A</name>
-      <description>Write 1 to Enable CLK_TMR for Timer A</description>
-      <bitOffset>14</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EN_A</name>
-      <description>Enable for Timer A</description>
-      <bitOffset>15</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>MODE_B</name>
-      <description>Mode Select for Timer B</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>ONE_SHOT</name>
-        <description>One-Shot Mode</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CONTINUOUS</name>
-        <description>Continuous Mode</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COUNTER</name>
-        <description>Counter Mode</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>PWM</name>
-        <description>PWM Mode</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPTURE</name>
-        <description>Capture Mode</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COMPARE</name>
-        <description>Compare Mode</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>GATED</name>
-        <description>Gated Mode</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPCOMP</name>
-        <description>Capture/Compare Mode</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DUAL_EDGE</name>
-        <description>Dual Edge Capture Mode</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>IGATED</name>
-        <description>Inactive Gated Mode</description>
-        <value>14</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>CLKDIV_B</name>
-      <description>Clock Divider Select for Timer B</description>
-      <bitOffset>20</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>DIV_BY_1</name>
-        <description>Prescaler Divide-By-1</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2</name>
-        <description>Prescaler Divide-By-2</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4</name>
-        <description>Prescaler Divide-By-4</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_8</name>
-        <description>Prescaler Divide-By-8</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_16</name>
-        <description>Prescaler Divide-By-16</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_32</name>
-        <description>Prescaler Divide-By-32</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_64</name>
-        <description>Prescaler Divide-By-64</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_128</name>
-        <description>Prescaler Divide-By-128</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_256</name>
-        <description>Prescaler Divide-By-256</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_512</name>
-        <description>Prescaler Divide-By-512</description>
-        <value>9</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_1024</name>
-        <description>Prescaler Divide-By-1024</description>
-        <value>10</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2048</name>
-        <description>Prescaler Divide-By-2048</description>
-        <value>11</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4096</name>
-        <description>TBD</description>
-        <value>12</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>POL_B</name>
-      <description>Timer Polarity for Timer B</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMSYNC_B</name>
-      <description>PWM Synchronization Mode for Timer B</description>
-      <bitOffset>25</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLHPOL_B</name>
-      <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
-      <bitOffset>26</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLLPOL_B</name>
-      <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
-      <bitOffset>27</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMCKBD_B</name>
-      <description>PWM Phase A-Prime Output Disable for Timer B</description>
-      <bitOffset>28</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>     
-     <field>
-      <name>RST_B</name>
-      <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
-      <bitOffset>29</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_B</name>
-      <description>Write 1 to Enable CLK_TMR for Timer B</description>
-      <bitOffset>30</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EN_B</name>
-      <description>Enable for Timer B</description>
-      <bitOffset>31</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>NOLCMP</name>
-    <description>Timer Non-Overlapping Compare Register.</description>
-    <addressOffset>0x14</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>LO_A</name>
-      <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-     <field>
-      <name>HI_A</name>
-      <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-     <field>
-      <name>LO_B</name>
-      <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-     <field>
-      <name>HI_B</name>
-      <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>CTRL1</name>
-    <description>Timer Configuration Register.</description>
-    <addressOffset>0x18</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>CLKSEL_A</name>
-      <description>Timer Clock Select for Timer A</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_A</name>
-      <description>Timer A Enable Status</description>
-      <bitOffset>2</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKRDY_A</name>
-      <description>CLK_TMR Ready Flag for Timer A</description>
-      <bitOffset>3</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EVENT_SEL_A</name>
-      <description>Event Select for Timer A</description>
-      <bitOffset>4</bitOffset>
-      <bitWidth>3</bitWidth>
-     </field>
-     <field>
-      <name>NEGTRIG_A</name>
-      <description>Negative Edge Trigger for Event for Timer A</description>
-      <bitOffset>7</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>IE_A</name>
-      <description>Interrupt Enable for Timer A</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CAPEVENT_SEL_A</name>
-      <description>Capture Event Select for Timer A</description>
-      <bitOffset>9</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>SW_CAPEVENT_A</name>
-      <description>Software Capture Event for Timer A</description>
-      <bitOffset>11</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WE_A</name>
-      <description>Wake-Up Enable for Timer A</description>
-      <bitOffset>12</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>OUTEN_A</name>
-      <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
-      <bitOffset>13</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>OUTBEN_A</name>
-      <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
-      <bitOffset>14</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKSEL_B</name>
-      <description>Timer Clock Select for Timer B</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_B</name>
-      <description>Timer B Enable Status</description>
-      <bitOffset>18</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKRDY_B</name>
-      <description>CLK_TMR Ready Flag for Timer B</description>
-      <bitOffset>19</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EVENT_SEL_B</name>
-      <description>Event Select for Timer B</description>
-      <bitOffset>20</bitOffset>
-      <bitWidth>3</bitWidth>
-     </field>
-     <field>
-      <name>NEGTRIG_B</name>
-      <description>Negative Edge Trigger for Event for Timer B</description>
-      <bitOffset>23</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>IE_B</name>
-      <description>Interrupt Enable for Timer B</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CAPEVENT_SEL_B</name>
-      <description>Capture Event Select for Timer B</description>
-      <bitOffset>25</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>SW_CAPEVENT_B</name>
-      <description>Software Capture Event for Timer B</description>
-      <bitOffset>27</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WE_B</name>
-      <description>Wake-Up Enable for Timer B</description>
-      <bitOffset>28</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CASCADE</name>
-      <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
-      <bitOffset>31</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>WKFL</name>
-    <description>Timer Wakeup Status Register.</description>
-    <addressOffset>0x1C</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>A</name>
-      <description>Wake-Up Flag for Timer A</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>B</name>
-      <description>Wake-Up Flag for Timer B</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-  </registers>
- </peripheral>
-<!-- LPTIMER Low-Power Configurable Timer -->
+            <bitOffset>0</bitOffset>
+            <bitWidth>32</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>INTFL</name>
+        <description>Timer Interrupt Status Register.</description>
+        <addressOffset>0x0C</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>IRQ_A</name>
+            <description>Interrupt Flag for Timer A.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WRDONE_A</name>
+            <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WR_DIS_A</name>
+            <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>IRQ_B</name>
+            <description>Interrupt Flag for Timer B.</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WRDONE_B</name>
+            <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WR_DIS_B</name>
+            <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
+            <bitOffset>25</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>CTRL0</name>
+        <description>Timer Control Register.</description>
+        <addressOffset>0x10</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>MODE_A</name>
+            <description>Mode Select for Timer A</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>ONE_SHOT</name>
+                <description>One-Shot Mode</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CONTINUOUS</name>
+                <description>Continuous Mode</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COUNTER</name>
+                <description>Counter Mode</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>PWM</name>
+                <description>PWM Mode</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPTURE</name>
+                <description>Capture Mode</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COMPARE</name>
+                <description>Compare Mode</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>GATED</name>
+                <description>Gated Mode</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPCOMP</name>
+                <description>Capture/Compare Mode</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DUAL_EDGE</name>
+                <description>Dual Edge Capture Mode</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>IGATED</name>
+                <description>Inactive Gated Mode</description>
+                <value>14</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>CLKDIV_A</name>
+            <description>Clock Divider Select for Timer A</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>DIV_BY_1</name>
+                <description>Prescaler Divide-By-1</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2</name>
+                <description>Prescaler Divide-By-2</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4</name>
+                <description>Prescaler Divide-By-4</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_8</name>
+                <description>Prescaler Divide-By-8</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_16</name>
+                <description>Prescaler Divide-By-16</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_32</name>
+                <description>Prescaler Divide-By-32</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_64</name>
+                <description>Prescaler Divide-By-64</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_128</name>
+                <description>Prescaler Divide-By-128</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_256</name>
+                <description>Prescaler Divide-By-256</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_512</name>
+                <description>Prescaler Divide-By-512</description>
+                <value>9</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_1024</name>
+                <description>Prescaler Divide-By-1024</description>
+                <value>10</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2048</name>
+                <description>Prescaler Divide-By-2048</description>
+                <value>11</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4096</name>
+                <description>TBD</description>
+                <value>12</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>POL_A</name>
+            <description>Timer Polarity for Timer A</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMSYNC_A</name>
+            <description>PWM Synchronization Mode for Timer A</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLHPOL_A</name>
+            <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLLPOL_A</name>
+            <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMCKBD_A</name>
+            <description>PWM Phase A-Prime Output Disable for Timer A</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>RST_A</name>
+            <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_A</name>
+            <description>Write 1 to Enable CLK_TMR for Timer A</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EN_A</name>
+            <description>Enable for Timer A</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>MODE_B</name>
+            <description>Mode Select for Timer B</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>ONE_SHOT</name>
+                <description>One-Shot Mode</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CONTINUOUS</name>
+                <description>Continuous Mode</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COUNTER</name>
+                <description>Counter Mode</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>PWM</name>
+                <description>PWM Mode</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPTURE</name>
+                <description>Capture Mode</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COMPARE</name>
+                <description>Compare Mode</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>GATED</name>
+                <description>Gated Mode</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPCOMP</name>
+                <description>Capture/Compare Mode</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DUAL_EDGE</name>
+                <description>Dual Edge Capture Mode</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>IGATED</name>
+                <description>Inactive Gated Mode</description>
+                <value>14</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>CLKDIV_B</name>
+            <description>Clock Divider Select for Timer B</description>
+            <bitOffset>20</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>DIV_BY_1</name>
+                <description>Prescaler Divide-By-1</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2</name>
+                <description>Prescaler Divide-By-2</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4</name>
+                <description>Prescaler Divide-By-4</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_8</name>
+                <description>Prescaler Divide-By-8</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_16</name>
+                <description>Prescaler Divide-By-16</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_32</name>
+                <description>Prescaler Divide-By-32</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_64</name>
+                <description>Prescaler Divide-By-64</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_128</name>
+                <description>Prescaler Divide-By-128</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_256</name>
+                <description>Prescaler Divide-By-256</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_512</name>
+                <description>Prescaler Divide-By-512</description>
+                <value>9</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_1024</name>
+                <description>Prescaler Divide-By-1024</description>
+                <value>10</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2048</name>
+                <description>Prescaler Divide-By-2048</description>
+                <value>11</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4096</name>
+                <description>TBD</description>
+                <value>12</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>POL_B</name>
+            <description>Timer Polarity for Timer B</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMSYNC_B</name>
+            <description>PWM Synchronization Mode for Timer B</description>
+            <bitOffset>25</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLHPOL_B</name>
+            <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
+            <bitOffset>26</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLLPOL_B</name>
+            <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
+            <bitOffset>27</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMCKBD_B</name>
+            <description>PWM Phase A-Prime Output Disable for Timer B</description>
+            <bitOffset>28</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>RST_B</name>
+            <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
+            <bitOffset>29</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_B</name>
+            <description>Write 1 to Enable CLK_TMR for Timer B</description>
+            <bitOffset>30</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EN_B</name>
+            <description>Enable for Timer B</description>
+            <bitOffset>31</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>NOLCMP</name>
+        <description>Timer Non-Overlapping Compare Register.</description>
+        <addressOffset>0x14</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>LO_A</name>
+            <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+          <field>
+            <name>HI_A</name>
+            <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+          <field>
+            <name>LO_B</name>
+            <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+          <field>
+            <name>HI_B</name>
+            <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>CTRL1</name>
+        <description>Timer Configuration Register.</description>
+        <addressOffset>0x18</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>CLKSEL_A</name>
+            <description>Timer Clock Select for Timer A</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_A</name>
+            <description>Timer A Enable Status</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKRDY_A</name>
+            <description>CLK_TMR Ready Flag for Timer A</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EVENT_SEL_A</name>
+            <description>Event Select for Timer A</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>3</bitWidth>
+          </field>
+          <field>
+            <name>NEGTRIG_A</name>
+            <description>Negative Edge Trigger for Event for Timer A</description>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>IE_A</name>
+            <description>Interrupt Enable for Timer A</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CAPEVENT_SEL_A</name>
+            <description>Capture Event Select for Timer A</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>SW_CAPEVENT_A</name>
+            <description>Software Capture Event for Timer A</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WE_A</name>
+            <description>Wake-Up Enable for Timer A</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>OUTEN_A</name>
+            <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>OUTBEN_A</name>
+            <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>ASYNC</name>
+            <description>Allows asynchronous reads to the PWM and CNT registers.</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKSEL_B</name>
+            <description>Timer Clock Select for Timer B</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_B</name>
+            <description>Timer B Enable Status</description>
+            <bitOffset>18</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKRDY_B</name>
+            <description>CLK_TMR Ready Flag for Timer B</description>
+            <bitOffset>19</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EVENT_SEL_B</name>
+            <description>Event Select for Timer B</description>
+            <bitOffset>20</bitOffset>
+            <bitWidth>3</bitWidth>
+          </field>
+          <field>
+            <name>NEGTRIG_B</name>
+            <description>Negative Edge Trigger for Event for Timer B</description>
+            <bitOffset>23</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>IE_B</name>
+            <description>Interrupt Enable for Timer B</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CAPEVENT_SEL_B</name>
+            <description>Capture Event Select for Timer B</description>
+            <bitOffset>25</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>SW_CAPEVENT_B</name>
+            <description>Software Capture Event for Timer B</description>
+            <bitOffset>27</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WE_B</name>
+            <description>Wake-Up Enable for Timer B</description>
+            <bitOffset>28</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CASCADE</name>
+            <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
+            <bitOffset>31</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>WKFL</name>
+        <description>Timer Wakeup Status Register.</description>
+        <addressOffset>0x1C</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>A</name>
+            <description>Wake-Up Flag for Timer A</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>B</name>
+            <description>Wake-Up Flag for Timer B</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+    </registers>
+  </peripheral>
+  <!-- LPTIMER Low-Power Configurable Timer -->
 </device>

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb_me17.svd
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb_me17.svd
@@ -1,662 +1,668 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="svd_schema.xsd">
- <peripheral>
-  <name>TMR</name>
-  <description>Low-Power Configurable Timer</description>
-  <baseAddress>0x40010000</baseAddress>
-  <addressBlock>
-   <offset>0x00</offset>
-   <size>0x1000</size>
-   <usage>registers</usage>
-  </addressBlock>
-  <interrupt>
-   <name>TMR</name>
-<!-- IRQ Name -->
-   <value>1</value>
-<!-- IRQ Number Device Specific -->
-  </interrupt>
-  <registers>
-   <register>
-    <name>CNT</name>
-    <description>Timer Counter Register.</description>
-    <addressOffset>0x00</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>COUNT</name>
-      <description>The current count value for the timer. This field increments as the timer counts.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>32</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>CMP</name>
-    <description>Timer Compare Register.</description>
-    <addressOffset>0x04</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>COMPARE</name>
-      <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>32</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>PWM</name>
-    <description>Timer PWM Register.</description>
-    <addressOffset>0x08</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>PWM</name>
-      <description>Timer PWM Match:
+  <peripheral>
+    <name>TMR</name>
+    <description>Low-Power Configurable Timer</description>
+    <baseAddress>0x40010000</baseAddress>
+    <addressBlock>
+      <offset>0x00</offset>
+      <size>0x1000</size>
+      <usage>registers</usage>
+    </addressBlock>
+    <interrupt>
+      <name>TMR</name>
+      <!-- IRQ Name -->
+      <value>1</value>
+      <!-- IRQ Number Device Specific -->
+    </interrupt>
+    <registers>
+      <register>
+        <name>CNT</name>
+        <description>Timer Counter Register.</description>
+        <addressOffset>0x00</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>COUNT</name>
+            <description>The current count value for the timer. This field increments as the timer counts.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>32</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>CMP</name>
+        <description>Timer Compare Register.</description>
+        <addressOffset>0x04</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>COMPARE</name>
+            <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>32</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>PWM</name>
+        <description>Timer PWM Register.</description>
+        <addressOffset>0x08</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>PWM</name>
+            <description>Timer PWM Match:
                 In PWM Mode, this field sets the count value for the first transition period of the PWM cycle. At the end of the cycle where CNT equals PWM, the PWM output transitions to the second period of the PWM cycle. The second PWM period count is stored in the CMP register. The value set for PWM must me less than the value set in CMP for PWM mode operation. Timer Capture Value:
                 In Capture, Compare, and Capture/Compare modes, this field is used to store the CNT value when a Capture, Compare, or Capture/Compare event occurs.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>32</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>INTFL</name>
-    <description>Timer Interrupt Status Register.</description>
-    <addressOffset>0x0C</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>IRQ_A</name>
-      <description>Interrupt Flag for Timer A.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WRDONE_A</name>
-      <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WR_DIS_A</name>
-      <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
-      <bitOffset>9</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>IRQ_B</name>
-      <description>Interrupt Flag for Timer B.</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WRDONE_B</name>
-      <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WR_DIS_B</name>
-      <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
-      <bitOffset>25</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>CTRL0</name>
-    <description>Timer Control Register.</description>
-    <addressOffset>0x10</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>MODE_A</name>
-      <description>Mode Select for Timer A</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>ONE_SHOT</name>
-        <description>One-Shot Mode</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CONTINUOUS</name>
-        <description>Continuous Mode</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COUNTER</name>
-        <description>Counter Mode</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>PWM</name>
-        <description>PWM Mode</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPTURE</name>
-        <description>Capture Mode</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COMPARE</name>
-        <description>Compare Mode</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>GATED</name>
-        <description>Gated Mode</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPCOMP</name>
-        <description>Capture/Compare Mode</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DUAL_EDGE</name>
-        <description>Dual Edge Capture Mode</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>IGATED</name>
-        <description>Inactive Gated Mode</description>
-        <value>14</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>CLKDIV_A</name>
-      <description>Clock Divider Select for Timer A</description>
-      <bitOffset>4</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>DIV_BY_1</name>
-        <description>Prescaler Divide-By-1</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2</name>
-        <description>Prescaler Divide-By-2</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4</name>
-        <description>Prescaler Divide-By-4</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_8</name>
-        <description>Prescaler Divide-By-8</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_16</name>
-        <description>Prescaler Divide-By-16</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_32</name>
-        <description>Prescaler Divide-By-32</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_64</name>
-        <description>Prescaler Divide-By-64</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_128</name>
-        <description>Prescaler Divide-By-128</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_256</name>
-        <description>Prescaler Divide-By-256</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_512</name>
-        <description>Prescaler Divide-By-512</description>
-        <value>9</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_1024</name>
-        <description>Prescaler Divide-By-1024</description>
-        <value>10</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2048</name>
-        <description>Prescaler Divide-By-2048</description>
-        <value>11</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4096</name>
-        <description>TBD</description>
-        <value>12</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>POL_A</name>
-      <description>Timer Polarity for Timer A</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMSYNC_A</name>
-      <description>PWM Synchronization Mode for Timer A</description>
-      <bitOffset>9</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLHPOL_A</name>
-      <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
-      <bitOffset>10</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLLPOL_A</name>
-      <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
-      <bitOffset>11</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMCKBD_A</name>
-      <description>PWM Phase A-Prime Output Disable for Timer A</description>
-      <bitOffset>12</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>RST_A</name>
-      <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
-      <bitOffset>13</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_A</name>
-      <description>Write 1 to Enable CLK_TMR for Timer A</description>
-      <bitOffset>14</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EN_A</name>
-      <description>Enable for Timer A</description>
-      <bitOffset>15</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>MODE_B</name>
-      <description>Mode Select for Timer B</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>ONE_SHOT</name>
-        <description>One-Shot Mode</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CONTINUOUS</name>
-        <description>Continuous Mode</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COUNTER</name>
-        <description>Counter Mode</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>PWM</name>
-        <description>PWM Mode</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPTURE</name>
-        <description>Capture Mode</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COMPARE</name>
-        <description>Compare Mode</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>GATED</name>
-        <description>Gated Mode</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPCOMP</name>
-        <description>Capture/Compare Mode</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DUAL_EDGE</name>
-        <description>Dual Edge Capture Mode</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>IGATED</name>
-        <description>Inactive Gated Mode</description>
-        <value>14</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>CLKDIV_B</name>
-      <description>Clock Divider Select for Timer B</description>
-      <bitOffset>20</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>DIV_BY_1</name>
-        <description>Prescaler Divide-By-1</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2</name>
-        <description>Prescaler Divide-By-2</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4</name>
-        <description>Prescaler Divide-By-4</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_8</name>
-        <description>Prescaler Divide-By-8</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_16</name>
-        <description>Prescaler Divide-By-16</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_32</name>
-        <description>Prescaler Divide-By-32</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_64</name>
-        <description>Prescaler Divide-By-64</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_128</name>
-        <description>Prescaler Divide-By-128</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_256</name>
-        <description>Prescaler Divide-By-256</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_512</name>
-        <description>Prescaler Divide-By-512</description>
-        <value>9</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_1024</name>
-        <description>Prescaler Divide-By-1024</description>
-        <value>10</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2048</name>
-        <description>Prescaler Divide-By-2048</description>
-        <value>11</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4096</name>
-        <description>TBD</description>
-        <value>12</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>POL_B</name>
-      <description>Timer Polarity for Timer B</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMSYNC_B</name>
-      <description>PWM Synchronization Mode for Timer B</description>
-      <bitOffset>25</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLHPOL_B</name>
-      <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
-      <bitOffset>26</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLLPOL_B</name>
-      <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
-      <bitOffset>27</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMCKBD_B</name>
-      <description>PWM Phase A-Prime Output Disable for Timer B</description>
-      <bitOffset>28</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>     
-     <field>
-      <name>RST_B</name>
-      <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
-      <bitOffset>29</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_B</name>
-      <description>Write 1 to Enable CLK_TMR for Timer B</description>
-      <bitOffset>30</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EN_B</name>
-      <description>Enable for Timer B</description>
-      <bitOffset>31</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>NOLCMP</name>
-    <description>Timer Non-Overlapping Compare Register.</description>
-    <addressOffset>0x14</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>LO_A</name>
-      <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-     <field>
-      <name>HI_A</name>
-      <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-     <field>
-      <name>LO_B</name>
-      <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-     <field>
-      <name>HI_B</name>
-      <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>CTRL1</name>
-    <description>Timer Configuration Register.</description>
-    <addressOffset>0x18</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>CLKSEL_A</name>
-      <description>Timer Clock Select for Timer A</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_A</name>
-      <description>Timer A Enable Status</description>
-      <bitOffset>2</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKRDY_A</name>
-      <description>CLK_TMR Ready Flag for Timer A</description>
-      <bitOffset>3</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EVENT_SEL_A</name>
-      <description>Event Select for Timer A</description>
-      <bitOffset>4</bitOffset>
-      <bitWidth>3</bitWidth>
-     </field>
-     <field>
-      <name>NEGTRIG_A</name>
-      <description>Negative Edge Trigger for Event for Timer A</description>
-      <bitOffset>7</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>IE_A</name>
-      <description>Interrupt Enable for Timer A</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CAPEVENT_SEL_A</name>
-      <description>Capture Event Select for Timer A</description>
-      <bitOffset>9</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>SW_CAPEVENT_A</name>
-      <description>Software Capture Event for Timer A</description>
-      <bitOffset>11</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WE_A</name>
-      <description>Wake-Up Enable for Timer A</description>
-      <bitOffset>12</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>OUTEN_A</name>
-      <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
-      <bitOffset>13</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>OUTBEN_A</name>
-      <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
-      <bitOffset>14</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKSEL_B</name>
-      <description>Timer Clock Select for Timer B</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_B</name>
-      <description>Timer B Enable Status</description>
-      <bitOffset>18</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKRDY_B</name>
-      <description>CLK_TMR Ready Flag for Timer B</description>
-      <bitOffset>19</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EVENT_SEL_B</name>
-      <description>Event Select for Timer B</description>
-      <bitOffset>20</bitOffset>
-      <bitWidth>3</bitWidth>
-     </field>
-     <field>
-      <name>NEGTRIG_B</name>
-      <description>Negative Edge Trigger for Event for Timer B</description>
-      <bitOffset>23</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>IE_B</name>
-      <description>Interrupt Enable for Timer B</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CAPEVENT_SEL_B</name>
-      <description>Capture Event Select for Timer B</description>
-      <bitOffset>25</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>SW_CAPEVENT_B</name>
-      <description>Software Capture Event for Timer B</description>
-      <bitOffset>27</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WE_B</name>
-      <description>Wake-Up Enable for Timer B</description>
-      <bitOffset>28</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CASCADE</name>
-      <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
-      <bitOffset>31</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>WKFL</name>
-    <description>Timer Wakeup Status Register.</description>
-    <addressOffset>0x1C</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>A</name>
-      <description>Wake-Up Flag for Timer A</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>B</name>
-      <description>Wake-Up Flag for Timer B</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-  </registers>
- </peripheral>
-<!-- LPTIMER Low-Power Configurable Timer -->
+            <bitOffset>0</bitOffset>
+            <bitWidth>32</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>INTFL</name>
+        <description>Timer Interrupt Status Register.</description>
+        <addressOffset>0x0C</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>IRQ_A</name>
+            <description>Interrupt Flag for Timer A.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WRDONE_A</name>
+            <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WR_DIS_A</name>
+            <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>IRQ_B</name>
+            <description>Interrupt Flag for Timer B.</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WRDONE_B</name>
+            <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WR_DIS_B</name>
+            <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
+            <bitOffset>25</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>CTRL0</name>
+        <description>Timer Control Register.</description>
+        <addressOffset>0x10</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>MODE_A</name>
+            <description>Mode Select for Timer A</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>ONE_SHOT</name>
+                <description>One-Shot Mode</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CONTINUOUS</name>
+                <description>Continuous Mode</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COUNTER</name>
+                <description>Counter Mode</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>PWM</name>
+                <description>PWM Mode</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPTURE</name>
+                <description>Capture Mode</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COMPARE</name>
+                <description>Compare Mode</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>GATED</name>
+                <description>Gated Mode</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPCOMP</name>
+                <description>Capture/Compare Mode</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DUAL_EDGE</name>
+                <description>Dual Edge Capture Mode</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>IGATED</name>
+                <description>Inactive Gated Mode</description>
+                <value>14</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>CLKDIV_A</name>
+            <description>Clock Divider Select for Timer A</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>DIV_BY_1</name>
+                <description>Prescaler Divide-By-1</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2</name>
+                <description>Prescaler Divide-By-2</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4</name>
+                <description>Prescaler Divide-By-4</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_8</name>
+                <description>Prescaler Divide-By-8</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_16</name>
+                <description>Prescaler Divide-By-16</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_32</name>
+                <description>Prescaler Divide-By-32</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_64</name>
+                <description>Prescaler Divide-By-64</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_128</name>
+                <description>Prescaler Divide-By-128</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_256</name>
+                <description>Prescaler Divide-By-256</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_512</name>
+                <description>Prescaler Divide-By-512</description>
+                <value>9</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_1024</name>
+                <description>Prescaler Divide-By-1024</description>
+                <value>10</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2048</name>
+                <description>Prescaler Divide-By-2048</description>
+                <value>11</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4096</name>
+                <description>TBD</description>
+                <value>12</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>POL_A</name>
+            <description>Timer Polarity for Timer A</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMSYNC_A</name>
+            <description>PWM Synchronization Mode for Timer A</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLHPOL_A</name>
+            <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLLPOL_A</name>
+            <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMCKBD_A</name>
+            <description>PWM Phase A-Prime Output Disable for Timer A</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>RST_A</name>
+            <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_A</name>
+            <description>Write 1 to Enable CLK_TMR for Timer A</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EN_A</name>
+            <description>Enable for Timer A</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>MODE_B</name>
+            <description>Mode Select for Timer B</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>ONE_SHOT</name>
+                <description>One-Shot Mode</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CONTINUOUS</name>
+                <description>Continuous Mode</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COUNTER</name>
+                <description>Counter Mode</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>PWM</name>
+                <description>PWM Mode</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPTURE</name>
+                <description>Capture Mode</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COMPARE</name>
+                <description>Compare Mode</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>GATED</name>
+                <description>Gated Mode</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPCOMP</name>
+                <description>Capture/Compare Mode</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DUAL_EDGE</name>
+                <description>Dual Edge Capture Mode</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>IGATED</name>
+                <description>Inactive Gated Mode</description>
+                <value>14</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>CLKDIV_B</name>
+            <description>Clock Divider Select for Timer B</description>
+            <bitOffset>20</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>DIV_BY_1</name>
+                <description>Prescaler Divide-By-1</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2</name>
+                <description>Prescaler Divide-By-2</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4</name>
+                <description>Prescaler Divide-By-4</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_8</name>
+                <description>Prescaler Divide-By-8</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_16</name>
+                <description>Prescaler Divide-By-16</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_32</name>
+                <description>Prescaler Divide-By-32</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_64</name>
+                <description>Prescaler Divide-By-64</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_128</name>
+                <description>Prescaler Divide-By-128</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_256</name>
+                <description>Prescaler Divide-By-256</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_512</name>
+                <description>Prescaler Divide-By-512</description>
+                <value>9</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_1024</name>
+                <description>Prescaler Divide-By-1024</description>
+                <value>10</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2048</name>
+                <description>Prescaler Divide-By-2048</description>
+                <value>11</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4096</name>
+                <description>TBD</description>
+                <value>12</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>POL_B</name>
+            <description>Timer Polarity for Timer B</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMSYNC_B</name>
+            <description>PWM Synchronization Mode for Timer B</description>
+            <bitOffset>25</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLHPOL_B</name>
+            <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
+            <bitOffset>26</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLLPOL_B</name>
+            <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
+            <bitOffset>27</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMCKBD_B</name>
+            <description>PWM Phase A-Prime Output Disable for Timer B</description>
+            <bitOffset>28</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>RST_B</name>
+            <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
+            <bitOffset>29</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_B</name>
+            <description>Write 1 to Enable CLK_TMR for Timer B</description>
+            <bitOffset>30</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EN_B</name>
+            <description>Enable for Timer B</description>
+            <bitOffset>31</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>NOLCMP</name>
+        <description>Timer Non-Overlapping Compare Register.</description>
+        <addressOffset>0x14</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>LO_A</name>
+            <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+          <field>
+            <name>HI_A</name>
+            <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+          <field>
+            <name>LO_B</name>
+            <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+          <field>
+            <name>HI_B</name>
+            <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>CTRL1</name>
+        <description>Timer Configuration Register.</description>
+        <addressOffset>0x18</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>CLKSEL_A</name>
+            <description>Timer Clock Select for Timer A</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_A</name>
+            <description>Timer A Enable Status</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKRDY_A</name>
+            <description>CLK_TMR Ready Flag for Timer A</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EVENT_SEL_A</name>
+            <description>Event Select for Timer A</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>3</bitWidth>
+          </field>
+          <field>
+            <name>NEGTRIG_A</name>
+            <description>Negative Edge Trigger for Event for Timer A</description>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>IE_A</name>
+            <description>Interrupt Enable for Timer A</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CAPEVENT_SEL_A</name>
+            <description>Capture Event Select for Timer A</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>SW_CAPEVENT_A</name>
+            <description>Software Capture Event for Timer A</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WE_A</name>
+            <description>Wake-Up Enable for Timer A</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>OUTEN_A</name>
+            <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>OUTBEN_A</name>
+            <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>ASYNC</name>
+            <description>Allows asynchronous reads of the PWM and CNT registers.</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKSEL_B</name>
+            <description>Timer Clock Select for Timer B</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_B</name>
+            <description>Timer B Enable Status</description>
+            <bitOffset>18</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKRDY_B</name>
+            <description>CLK_TMR Ready Flag for Timer B</description>
+            <bitOffset>19</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EVENT_SEL_B</name>
+            <description>Event Select for Timer B</description>
+            <bitOffset>20</bitOffset>
+            <bitWidth>3</bitWidth>
+          </field>
+          <field>
+            <name>NEGTRIG_B</name>
+            <description>Negative Edge Trigger for Event for Timer B</description>
+            <bitOffset>23</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>IE_B</name>
+            <description>Interrupt Enable for Timer B</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CAPEVENT_SEL_B</name>
+            <description>Capture Event Select for Timer B</description>
+            <bitOffset>25</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>SW_CAPEVENT_B</name>
+            <description>Software Capture Event for Timer B</description>
+            <bitOffset>27</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WE_B</name>
+            <description>Wake-Up Enable for Timer B</description>
+            <bitOffset>28</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CASCADE</name>
+            <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
+            <bitOffset>31</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>WKFL</name>
+        <description>Timer Wakeup Status Register.</description>
+        <addressOffset>0x1C</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>A</name>
+            <description>Wake-Up Flag for Timer A</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>B</name>
+            <description>Wake-Up Flag for Timer B</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+    </registers>
+  </peripheral>
+  <!-- LPTIMER Low-Power Configurable Timer -->
 </device>

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb_me21.svd
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb_me21.svd
@@ -1,662 +1,668 @@
-<?xml version="1.0" encoding="utf-8" standalone="no"?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="svd_schema.xsd">
- <peripheral>
-  <name>TMR</name>
-  <description>Low-Power Configurable Timer</description>
-  <baseAddress>0x40010000</baseAddress>
-  <addressBlock>
-   <offset>0x00</offset>
-   <size>0x1000</size>
-   <usage>registers</usage>
-  </addressBlock>
-  <interrupt>
-   <name>TMR</name>
-<!-- IRQ Name -->
-   <value>1</value>
-<!-- IRQ Number Device Specific -->
-  </interrupt>
-  <registers>
-   <register>
-    <name>CNT</name>
-    <description>Timer Counter Register.</description>
-    <addressOffset>0x00</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>COUNT</name>
-      <description>The current count value for the timer. This field increments as the timer counts.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>32</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>CMP</name>
-    <description>Timer Compare Register.</description>
-    <addressOffset>0x04</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>COMPARE</name>
-      <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>32</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>PWM</name>
-    <description>Timer PWM Register.</description>
-    <addressOffset>0x08</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>PWM</name>
-      <description>Timer PWM Match:
+  <peripheral>
+    <name>TMR</name>
+    <description>Low-Power Configurable Timer</description>
+    <baseAddress>0x40010000</baseAddress>
+    <addressBlock>
+      <offset>0x00</offset>
+      <size>0x1000</size>
+      <usage>registers</usage>
+    </addressBlock>
+    <interrupt>
+      <name>TMR</name>
+      <!-- IRQ Name -->
+      <value>1</value>
+      <!-- IRQ Number Device Specific -->
+    </interrupt>
+    <registers>
+      <register>
+        <name>CNT</name>
+        <description>Timer Counter Register.</description>
+        <addressOffset>0x00</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>COUNT</name>
+            <description>The current count value for the timer. This field increments as the timer counts.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>32</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>CMP</name>
+        <description>Timer Compare Register.</description>
+        <addressOffset>0x04</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>COMPARE</name>
+            <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>32</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>PWM</name>
+        <description>Timer PWM Register.</description>
+        <addressOffset>0x08</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>PWM</name>
+            <description>Timer PWM Match:
                 In PWM Mode, this field sets the count value for the first transition period of the PWM cycle. At the end of the cycle where CNT equals PWM, the PWM output transitions to the second period of the PWM cycle. The second PWM period count is stored in the CMP register. The value set for PWM must me less than the value set in CMP for PWM mode operation. Timer Capture Value:
                 In Capture, Compare, and Capture/Compare modes, this field is used to store the CNT value when a Capture, Compare, or Capture/Compare event occurs.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>32</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>INTFL</name>
-    <description>Timer Interrupt Status Register.</description>
-    <addressOffset>0x0C</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>IRQ_A</name>
-      <description>Interrupt Flag for Timer A.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WRDONE_A</name>
-      <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WR_DIS_A</name>
-      <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
-      <bitOffset>9</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>IRQ_B</name>
-      <description>Interrupt Flag for Timer B.</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WRDONE_B</name>
-      <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WR_DIS_B</name>
-      <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
-      <bitOffset>25</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>CTRL0</name>
-    <description>Timer Control Register.</description>
-    <addressOffset>0x10</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>MODE_A</name>
-      <description>Mode Select for Timer A</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>ONE_SHOT</name>
-        <description>One-Shot Mode</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CONTINUOUS</name>
-        <description>Continuous Mode</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COUNTER</name>
-        <description>Counter Mode</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>PWM</name>
-        <description>PWM Mode</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPTURE</name>
-        <description>Capture Mode</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COMPARE</name>
-        <description>Compare Mode</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>GATED</name>
-        <description>Gated Mode</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPCOMP</name>
-        <description>Capture/Compare Mode</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DUAL_EDGE</name>
-        <description>Dual Edge Capture Mode</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>IGATED</name>
-        <description>Inactive Gated Mode</description>
-        <value>12</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>CLKDIV_A</name>
-      <description>Clock Divider Select for Timer A</description>
-      <bitOffset>4</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>DIV_BY_1</name>
-        <description>Prescaler Divide-By-1</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2</name>
-        <description>Prescaler Divide-By-2</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4</name>
-        <description>Prescaler Divide-By-4</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_8</name>
-        <description>Prescaler Divide-By-8</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_16</name>
-        <description>Prescaler Divide-By-16</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_32</name>
-        <description>Prescaler Divide-By-32</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_64</name>
-        <description>Prescaler Divide-By-64</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_128</name>
-        <description>Prescaler Divide-By-128</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_256</name>
-        <description>Prescaler Divide-By-256</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_512</name>
-        <description>Prescaler Divide-By-512</description>
-        <value>9</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_1024</name>
-        <description>Prescaler Divide-By-1024</description>
-        <value>10</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2048</name>
-        <description>Prescaler Divide-By-2048</description>
-        <value>11</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4096</name>
-        <description>TBD</description>
-        <value>12</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>POL_A</name>
-      <description>Timer Polarity for Timer A</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMSYNC_A</name>
-      <description>PWM Synchronization Mode for Timer A</description>
-      <bitOffset>9</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLHPOL_A</name>
-      <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
-      <bitOffset>10</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLLPOL_A</name>
-      <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
-      <bitOffset>11</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMCKBD_A</name>
-      <description>PWM Phase A-Prime Output Disable for Timer A</description>
-      <bitOffset>12</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>RST_A</name>
-      <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
-      <bitOffset>13</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_A</name>
-      <description>Write 1 to Enable CLK_TMR for Timer A</description>
-      <bitOffset>14</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EN_A</name>
-      <description>Enable for Timer A</description>
-      <bitOffset>15</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>MODE_B</name>
-      <description>Mode Select for Timer B</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>ONE_SHOT</name>
-        <description>One-Shot Mode</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CONTINUOUS</name>
-        <description>Continuous Mode</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COUNTER</name>
-        <description>Counter Mode</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>PWM</name>
-        <description>PWM Mode</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPTURE</name>
-        <description>Capture Mode</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COMPARE</name>
-        <description>Compare Mode</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>GATED</name>
-        <description>Gated Mode</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPCOMP</name>
-        <description>Capture/Compare Mode</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DUAL_EDGE</name>
-        <description>Dual Edge Capture Mode</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>IGATED</name>
-        <description>Inactive Gated Mode</description>
-        <value>14</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>CLKDIV_B</name>
-      <description>Clock Divider Select for Timer B</description>
-      <bitOffset>20</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>DIV_BY_1</name>
-        <description>Prescaler Divide-By-1</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2</name>
-        <description>Prescaler Divide-By-2</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4</name>
-        <description>Prescaler Divide-By-4</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_8</name>
-        <description>Prescaler Divide-By-8</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_16</name>
-        <description>Prescaler Divide-By-16</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_32</name>
-        <description>Prescaler Divide-By-32</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_64</name>
-        <description>Prescaler Divide-By-64</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_128</name>
-        <description>Prescaler Divide-By-128</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_256</name>
-        <description>Prescaler Divide-By-256</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_512</name>
-        <description>Prescaler Divide-By-512</description>
-        <value>9</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_1024</name>
-        <description>Prescaler Divide-By-1024</description>
-        <value>10</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2048</name>
-        <description>Prescaler Divide-By-2048</description>
-        <value>11</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4096</name>
-        <description>TBD</description>
-        <value>12</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>POL_B</name>
-      <description>Timer Polarity for Timer B</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMSYNC_B</name>
-      <description>PWM Synchronization Mode for Timer B</description>
-      <bitOffset>25</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLHPOL_B</name>
-      <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
-      <bitOffset>26</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLLPOL_B</name>
-      <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
-      <bitOffset>27</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMCKBD_B</name>
-      <description>PWM Phase A-Prime Output Disable for Timer B</description>
-      <bitOffset>28</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>     
-     <field>
-      <name>RST_B</name>
-      <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
-      <bitOffset>29</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_B</name>
-      <description>Write 1 to Enable CLK_TMR for Timer B</description>
-      <bitOffset>30</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EN_B</name>
-      <description>Enable for Timer B</description>
-      <bitOffset>31</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>NOLCMP</name>
-    <description>Timer Non-Overlapping Compare Register.</description>
-    <addressOffset>0x14</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>LO_A</name>
-      <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-     <field>
-      <name>HI_A</name>
-      <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-     <field>
-      <name>LO_B</name>
-      <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-     <field>
-      <name>HI_B</name>
-      <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>CTRL1</name>
-    <description>Timer Configuration Register.</description>
-    <addressOffset>0x18</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>CLKSEL_A</name>
-      <description>Timer Clock Select for Timer A</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_A</name>
-      <description>Timer A Enable Status</description>
-      <bitOffset>2</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKRDY_A</name>
-      <description>CLK_TMR Ready Flag for Timer A</description>
-      <bitOffset>3</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EVENT_SEL_A</name>
-      <description>Event Select for Timer A</description>
-      <bitOffset>4</bitOffset>
-      <bitWidth>3</bitWidth>
-     </field>
-     <field>
-      <name>NEGTRIG_A</name>
-      <description>Negative Edge Trigger for Event for Timer A</description>
-      <bitOffset>7</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>IE_A</name>
-      <description>Interrupt Enable for Timer A</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CAPEVENT_SEL_A</name>
-      <description>Capture Event Select for Timer A</description>
-      <bitOffset>9</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>SW_CAPEVENT_A</name>
-      <description>Software Capture Event for Timer A</description>
-      <bitOffset>11</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WE_A</name>
-      <description>Wake-Up Enable for Timer A</description>
-      <bitOffset>12</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>OUTEN_A</name>
-      <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
-      <bitOffset>13</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>OUTBEN_A</name>
-      <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
-      <bitOffset>14</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKSEL_B</name>
-      <description>Timer Clock Select for Timer B</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_B</name>
-      <description>Timer B Enable Status</description>
-      <bitOffset>18</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKRDY_B</name>
-      <description>CLK_TMR Ready Flag for Timer B</description>
-      <bitOffset>19</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EVENT_SEL_B</name>
-      <description>Event Select for Timer B</description>
-      <bitOffset>20</bitOffset>
-      <bitWidth>3</bitWidth>
-     </field>
-     <field>
-      <name>NEGTRIG_B</name>
-      <description>Negative Edge Trigger for Event for Timer B</description>
-      <bitOffset>23</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>IE_B</name>
-      <description>Interrupt Enable for Timer B</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CAPEVENT_SEL_B</name>
-      <description>Capture Event Select for Timer B</description>
-      <bitOffset>25</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>SW_CAPEVENT_B</name>
-      <description>Software Capture Event for Timer B</description>
-      <bitOffset>27</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WE_B</name>
-      <description>Wake-Up Enable for Timer B</description>
-      <bitOffset>28</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CASCADE</name>
-      <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
-      <bitOffset>31</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>WKFL</name>
-    <description>Timer Wakeup Status Register.</description>
-    <addressOffset>0x1C</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>A</name>
-      <description>Wake-Up Flag for Timer A</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>B</name>
-      <description>Wake-Up Flag for Timer B</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-  </registers>
- </peripheral>
-<!-- LPTIMER Low-Power Configurable Timer -->
+            <bitOffset>0</bitOffset>
+            <bitWidth>32</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>INTFL</name>
+        <description>Timer Interrupt Status Register.</description>
+        <addressOffset>0x0C</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>IRQ_A</name>
+            <description>Interrupt Flag for Timer A.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WRDONE_A</name>
+            <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WR_DIS_A</name>
+            <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>IRQ_B</name>
+            <description>Interrupt Flag for Timer B.</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WRDONE_B</name>
+            <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WR_DIS_B</name>
+            <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
+            <bitOffset>25</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>CTRL0</name>
+        <description>Timer Control Register.</description>
+        <addressOffset>0x10</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>MODE_A</name>
+            <description>Mode Select for Timer A</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>ONE_SHOT</name>
+                <description>One-Shot Mode</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CONTINUOUS</name>
+                <description>Continuous Mode</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COUNTER</name>
+                <description>Counter Mode</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>PWM</name>
+                <description>PWM Mode</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPTURE</name>
+                <description>Capture Mode</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COMPARE</name>
+                <description>Compare Mode</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>GATED</name>
+                <description>Gated Mode</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPCOMP</name>
+                <description>Capture/Compare Mode</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DUAL_EDGE</name>
+                <description>Dual Edge Capture Mode</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>IGATED</name>
+                <description>Inactive Gated Mode</description>
+                <value>12</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>CLKDIV_A</name>
+            <description>Clock Divider Select for Timer A</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>DIV_BY_1</name>
+                <description>Prescaler Divide-By-1</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2</name>
+                <description>Prescaler Divide-By-2</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4</name>
+                <description>Prescaler Divide-By-4</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_8</name>
+                <description>Prescaler Divide-By-8</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_16</name>
+                <description>Prescaler Divide-By-16</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_32</name>
+                <description>Prescaler Divide-By-32</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_64</name>
+                <description>Prescaler Divide-By-64</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_128</name>
+                <description>Prescaler Divide-By-128</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_256</name>
+                <description>Prescaler Divide-By-256</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_512</name>
+                <description>Prescaler Divide-By-512</description>
+                <value>9</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_1024</name>
+                <description>Prescaler Divide-By-1024</description>
+                <value>10</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2048</name>
+                <description>Prescaler Divide-By-2048</description>
+                <value>11</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4096</name>
+                <description>TBD</description>
+                <value>12</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>POL_A</name>
+            <description>Timer Polarity for Timer A</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMSYNC_A</name>
+            <description>PWM Synchronization Mode for Timer A</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLHPOL_A</name>
+            <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLLPOL_A</name>
+            <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMCKBD_A</name>
+            <description>PWM Phase A-Prime Output Disable for Timer A</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>RST_A</name>
+            <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_A</name>
+            <description>Write 1 to Enable CLK_TMR for Timer A</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EN_A</name>
+            <description>Enable for Timer A</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>MODE_B</name>
+            <description>Mode Select for Timer B</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>ONE_SHOT</name>
+                <description>One-Shot Mode</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CONTINUOUS</name>
+                <description>Continuous Mode</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COUNTER</name>
+                <description>Counter Mode</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>PWM</name>
+                <description>PWM Mode</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPTURE</name>
+                <description>Capture Mode</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COMPARE</name>
+                <description>Compare Mode</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>GATED</name>
+                <description>Gated Mode</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPCOMP</name>
+                <description>Capture/Compare Mode</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DUAL_EDGE</name>
+                <description>Dual Edge Capture Mode</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>IGATED</name>
+                <description>Inactive Gated Mode</description>
+                <value>14</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>CLKDIV_B</name>
+            <description>Clock Divider Select for Timer B</description>
+            <bitOffset>20</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>DIV_BY_1</name>
+                <description>Prescaler Divide-By-1</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2</name>
+                <description>Prescaler Divide-By-2</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4</name>
+                <description>Prescaler Divide-By-4</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_8</name>
+                <description>Prescaler Divide-By-8</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_16</name>
+                <description>Prescaler Divide-By-16</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_32</name>
+                <description>Prescaler Divide-By-32</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_64</name>
+                <description>Prescaler Divide-By-64</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_128</name>
+                <description>Prescaler Divide-By-128</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_256</name>
+                <description>Prescaler Divide-By-256</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_512</name>
+                <description>Prescaler Divide-By-512</description>
+                <value>9</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_1024</name>
+                <description>Prescaler Divide-By-1024</description>
+                <value>10</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2048</name>
+                <description>Prescaler Divide-By-2048</description>
+                <value>11</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4096</name>
+                <description>TBD</description>
+                <value>12</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>POL_B</name>
+            <description>Timer Polarity for Timer B</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMSYNC_B</name>
+            <description>PWM Synchronization Mode for Timer B</description>
+            <bitOffset>25</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLHPOL_B</name>
+            <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
+            <bitOffset>26</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLLPOL_B</name>
+            <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
+            <bitOffset>27</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMCKBD_B</name>
+            <description>PWM Phase A-Prime Output Disable for Timer B</description>
+            <bitOffset>28</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>RST_B</name>
+            <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
+            <bitOffset>29</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_B</name>
+            <description>Write 1 to Enable CLK_TMR for Timer B</description>
+            <bitOffset>30</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EN_B</name>
+            <description>Enable for Timer B</description>
+            <bitOffset>31</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>NOLCMP</name>
+        <description>Timer Non-Overlapping Compare Register.</description>
+        <addressOffset>0x14</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>LO_A</name>
+            <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+          <field>
+            <name>HI_A</name>
+            <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+          <field>
+            <name>LO_B</name>
+            <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+          <field>
+            <name>HI_B</name>
+            <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>CTRL1</name>
+        <description>Timer Configuration Register.</description>
+        <addressOffset>0x18</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>CLKSEL_A</name>
+            <description>Timer Clock Select for Timer A</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_A</name>
+            <description>Timer A Enable Status</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKRDY_A</name>
+            <description>CLK_TMR Ready Flag for Timer A</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EVENT_SEL_A</name>
+            <description>Event Select for Timer A</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>3</bitWidth>
+          </field>
+          <field>
+            <name>NEGTRIG_A</name>
+            <description>Negative Edge Trigger for Event for Timer A</description>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>IE_A</name>
+            <description>Interrupt Enable for Timer A</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CAPEVENT_SEL_A</name>
+            <description>Capture Event Select for Timer A</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>SW_CAPEVENT_A</name>
+            <description>Software Capture Event for Timer A</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WE_A</name>
+            <description>Wake-Up Enable for Timer A</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>OUTEN_A</name>
+            <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>OUTBEN_A</name>
+            <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>ASYNC</name>
+            <description>Allows asynchronous reads to the PWM and CNT registers.</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKSEL_B</name>
+            <description>Timer Clock Select for Timer B</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_B</name>
+            <description>Timer B Enable Status</description>
+            <bitOffset>18</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKRDY_B</name>
+            <description>CLK_TMR Ready Flag for Timer B</description>
+            <bitOffset>19</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EVENT_SEL_B</name>
+            <description>Event Select for Timer B</description>
+            <bitOffset>20</bitOffset>
+            <bitWidth>3</bitWidth>
+          </field>
+          <field>
+            <name>NEGTRIG_B</name>
+            <description>Negative Edge Trigger for Event for Timer B</description>
+            <bitOffset>23</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>IE_B</name>
+            <description>Interrupt Enable for Timer B</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CAPEVENT_SEL_B</name>
+            <description>Capture Event Select for Timer B</description>
+            <bitOffset>25</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>SW_CAPEVENT_B</name>
+            <description>Software Capture Event for Timer B</description>
+            <bitOffset>27</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WE_B</name>
+            <description>Wake-Up Enable for Timer B</description>
+            <bitOffset>28</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CASCADE</name>
+            <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
+            <bitOffset>31</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>WKFL</name>
+        <description>Timer Wakeup Status Register.</description>
+        <addressOffset>0x1C</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>A</name>
+            <description>Wake-Up Flag for Timer A</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>B</name>
+            <description>Wake-Up Flag for Timer B</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+    </registers>
+  </peripheral>
+  <!-- LPTIMER Low-Power Configurable Timer -->
 </device>

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb_me30.svd
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb_me30.svd
@@ -1,662 +1,668 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="svd_schema.xsd">
- <peripheral>
-  <name>TMR</name>
-  <description>Low-Power Configurable Timer</description>
-  <baseAddress>0x40010000</baseAddress>
-  <addressBlock>
-   <offset>0x00</offset>
-   <size>0x1000</size>
-   <usage>registers</usage>
-  </addressBlock>
-  <interrupt>
-   <name>TMR</name>
-<!-- IRQ Name -->
-   <value>1</value>
-<!-- IRQ Number Device Specific -->
-  </interrupt>
-  <registers>
-   <register>
-    <name>CNT</name>
-    <description>Timer Counter Register.</description>
-    <addressOffset>0x00</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>COUNT</name>
-      <description>The current count value for the timer. This field increments as the timer counts.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>32</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>CMP</name>
-    <description>Timer Compare Register.</description>
-    <addressOffset>0x04</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>COMPARE</name>
-      <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>32</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>PWM</name>
-    <description>Timer PWM Register.</description>
-    <addressOffset>0x08</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>PWM</name>
-      <description>Timer PWM Match:
+  <peripheral>
+    <name>TMR</name>
+    <description>Low-Power Configurable Timer</description>
+    <baseAddress>0x40010000</baseAddress>
+    <addressBlock>
+      <offset>0x00</offset>
+      <size>0x1000</size>
+      <usage>registers</usage>
+    </addressBlock>
+    <interrupt>
+      <name>TMR</name>
+      <!-- IRQ Name -->
+      <value>1</value>
+      <!-- IRQ Number Device Specific -->
+    </interrupt>
+    <registers>
+      <register>
+        <name>CNT</name>
+        <description>Timer Counter Register.</description>
+        <addressOffset>0x00</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>COUNT</name>
+            <description>The current count value for the timer. This field increments as the timer counts.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>32</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>CMP</name>
+        <description>Timer Compare Register.</description>
+        <addressOffset>0x04</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>COMPARE</name>
+            <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>32</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>PWM</name>
+        <description>Timer PWM Register.</description>
+        <addressOffset>0x08</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>PWM</name>
+            <description>Timer PWM Match:
                 In PWM Mode, this field sets the count value for the first transition period of the PWM cycle. At the end of the cycle where CNT equals PWM, the PWM output transitions to the second period of the PWM cycle. The second PWM period count is stored in the CMP register. The value set for PWM must me less than the value set in CMP for PWM mode operation. Timer Capture Value:
                 In Capture, Compare, and Capture/Compare modes, this field is used to store the CNT value when a Capture, Compare, or Capture/Compare event occurs.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>32</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>INTFL</name>
-    <description>Timer Interrupt Status Register.</description>
-    <addressOffset>0x0C</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>IRQ_A</name>
-      <description>Interrupt Flag for Timer A.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WRDONE_A</name>
-      <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WR_DIS_A</name>
-      <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
-      <bitOffset>9</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>IRQ_B</name>
-      <description>Interrupt Flag for Timer B.</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WRDONE_B</name>
-      <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WR_DIS_B</name>
-      <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
-      <bitOffset>25</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>CTRL0</name>
-    <description>Timer Control Register.</description>
-    <addressOffset>0x10</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>MODE_A</name>
-      <description>Mode Select for Timer A</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>ONE_SHOT</name>
-        <description>One-Shot Mode</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CONTINUOUS</name>
-        <description>Continuous Mode</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COUNTER</name>
-        <description>Counter Mode</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>PWM</name>
-        <description>PWM Mode</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPTURE</name>
-        <description>Capture Mode</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COMPARE</name>
-        <description>Compare Mode</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>GATED</name>
-        <description>Gated Mode</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPCOMP</name>
-        <description>Capture/Compare Mode</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DUAL_EDGE</name>
-        <description>Dual Edge Capture Mode</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>IGATED</name>
-        <description>Inactive Gated Mode</description>
-        <value>14</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>CLKDIV_A</name>
-      <description>Clock Divider Select for Timer A</description>
-      <bitOffset>4</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>DIV_BY_1</name>
-        <description>Prescaler Divide-By-1</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2</name>
-        <description>Prescaler Divide-By-2</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4</name>
-        <description>Prescaler Divide-By-4</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_8</name>
-        <description>Prescaler Divide-By-8</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_16</name>
-        <description>Prescaler Divide-By-16</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_32</name>
-        <description>Prescaler Divide-By-32</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_64</name>
-        <description>Prescaler Divide-By-64</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_128</name>
-        <description>Prescaler Divide-By-128</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_256</name>
-        <description>Prescaler Divide-By-256</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_512</name>
-        <description>Prescaler Divide-By-512</description>
-        <value>9</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_1024</name>
-        <description>Prescaler Divide-By-1024</description>
-        <value>10</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2048</name>
-        <description>Prescaler Divide-By-2048</description>
-        <value>11</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4096</name>
-        <description>TBD</description>
-        <value>12</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>POL_A</name>
-      <description>Timer Polarity for Timer A</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMSYNC_A</name>
-      <description>PWM Synchronization Mode for Timer A</description>
-      <bitOffset>9</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLHPOL_A</name>
-      <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
-      <bitOffset>10</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLLPOL_A</name>
-      <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
-      <bitOffset>11</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMCKBD_A</name>
-      <description>PWM Phase A-Prime Output Disable for Timer A</description>
-      <bitOffset>12</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>RST_A</name>
-      <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
-      <bitOffset>13</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_A</name>
-      <description>Write 1 to Enable CLK_TMR for Timer A</description>
-      <bitOffset>14</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EN_A</name>
-      <description>Enable for Timer A</description>
-      <bitOffset>15</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>MODE_B</name>
-      <description>Mode Select for Timer B</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>ONE_SHOT</name>
-        <description>One-Shot Mode</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CONTINUOUS</name>
-        <description>Continuous Mode</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COUNTER</name>
-        <description>Counter Mode</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>PWM</name>
-        <description>PWM Mode</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPTURE</name>
-        <description>Capture Mode</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>COMPARE</name>
-        <description>Compare Mode</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>GATED</name>
-        <description>Gated Mode</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>CAPCOMP</name>
-        <description>Capture/Compare Mode</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DUAL_EDGE</name>
-        <description>Dual Edge Capture Mode</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>IGATED</name>
-        <description>Inactive Gated Mode</description>
-        <value>14</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>CLKDIV_B</name>
-      <description>Clock Divider Select for Timer B</description>
-      <bitOffset>20</bitOffset>
-      <bitWidth>4</bitWidth>
-      <enumeratedValues>
-       <enumeratedValue>
-        <name>DIV_BY_1</name>
-        <description>Prescaler Divide-By-1</description>
-        <value>0</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2</name>
-        <description>Prescaler Divide-By-2</description>
-        <value>1</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4</name>
-        <description>Prescaler Divide-By-4</description>
-        <value>2</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_8</name>
-        <description>Prescaler Divide-By-8</description>
-        <value>3</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_16</name>
-        <description>Prescaler Divide-By-16</description>
-        <value>4</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_32</name>
-        <description>Prescaler Divide-By-32</description>
-        <value>5</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_64</name>
-        <description>Prescaler Divide-By-64</description>
-        <value>6</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_128</name>
-        <description>Prescaler Divide-By-128</description>
-        <value>7</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_256</name>
-        <description>Prescaler Divide-By-256</description>
-        <value>8</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_512</name>
-        <description>Prescaler Divide-By-512</description>
-        <value>9</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_1024</name>
-        <description>Prescaler Divide-By-1024</description>
-        <value>10</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_2048</name>
-        <description>Prescaler Divide-By-2048</description>
-        <value>11</value>
-       </enumeratedValue>
-       <enumeratedValue>
-        <name>DIV_BY_4096</name>
-        <description>TBD</description>
-        <value>12</value>
-       </enumeratedValue>
-      </enumeratedValues>
-     </field>
-     <field>
-      <name>POL_B</name>
-      <description>Timer Polarity for Timer B</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMSYNC_B</name>
-      <description>PWM Synchronization Mode for Timer B</description>
-      <bitOffset>25</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLHPOL_B</name>
-      <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
-      <bitOffset>26</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>NOLLPOL_B</name>
-      <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
-      <bitOffset>27</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>PWMCKBD_B</name>
-      <description>PWM Phase A-Prime Output Disable for Timer B</description>
-      <bitOffset>28</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>     
-     <field>
-      <name>RST_B</name>
-      <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
-      <bitOffset>29</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_B</name>
-      <description>Write 1 to Enable CLK_TMR for Timer B</description>
-      <bitOffset>30</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EN_B</name>
-      <description>Enable for Timer B</description>
-      <bitOffset>31</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>NOLCMP</name>
-    <description>Timer Non-Overlapping Compare Register.</description>
-    <addressOffset>0x14</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>LO_A</name>
-      <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-     <field>
-      <name>HI_A</name>
-      <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-     <field>
-      <name>LO_B</name>
-      <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-     <field>
-      <name>HI_B</name>
-      <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>8</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>CTRL1</name>
-    <description>Timer Configuration Register.</description>
-    <addressOffset>0x18</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>CLKSEL_A</name>
-      <description>Timer Clock Select for Timer A</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_A</name>
-      <description>Timer A Enable Status</description>
-      <bitOffset>2</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKRDY_A</name>
-      <description>CLK_TMR Ready Flag for Timer A</description>
-      <bitOffset>3</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EVENT_SEL_A</name>
-      <description>Event Select for Timer A</description>
-      <bitOffset>4</bitOffset>
-      <bitWidth>3</bitWidth>
-     </field>
-     <field>
-      <name>NEGTRIG_A</name>
-      <description>Negative Edge Trigger for Event for Timer A</description>
-      <bitOffset>7</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>IE_A</name>
-      <description>Interrupt Enable for Timer A</description>
-      <bitOffset>8</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CAPEVENT_SEL_A</name>
-      <description>Capture Event Select for Timer A</description>
-      <bitOffset>9</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>SW_CAPEVENT_A</name>
-      <description>Software Capture Event for Timer A</description>
-      <bitOffset>11</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WE_A</name>
-      <description>Wake-Up Enable for Timer A</description>
-      <bitOffset>12</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>OUTEN_A</name>
-      <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
-      <bitOffset>13</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>OUTBEN_A</name>
-      <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
-      <bitOffset>14</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKSEL_B</name>
-      <description>Timer Clock Select for Timer B</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>CLKEN_B</name>
-      <description>Timer B Enable Status</description>
-      <bitOffset>18</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CLKRDY_B</name>
-      <description>CLK_TMR Ready Flag for Timer B</description>
-      <bitOffset>19</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>EVENT_SEL_B</name>
-      <description>Event Select for Timer B</description>
-      <bitOffset>20</bitOffset>
-      <bitWidth>3</bitWidth>
-     </field>
-     <field>
-      <name>NEGTRIG_B</name>
-      <description>Negative Edge Trigger for Event for Timer B</description>
-      <bitOffset>23</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>IE_B</name>
-      <description>Interrupt Enable for Timer B</description>
-      <bitOffset>24</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CAPEVENT_SEL_B</name>
-      <description>Capture Event Select for Timer B</description>
-      <bitOffset>25</bitOffset>
-      <bitWidth>2</bitWidth>
-     </field>
-     <field>
-      <name>SW_CAPEVENT_B</name>
-      <description>Software Capture Event for Timer B</description>
-      <bitOffset>27</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>WE_B</name>
-      <description>Wake-Up Enable for Timer B</description>
-      <bitOffset>28</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>CASCADE</name>
-      <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
-      <bitOffset>31</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-   <register>
-    <name>WKFL</name>
-    <description>Timer Wakeup Status Register.</description>
-    <addressOffset>0x1C</addressOffset>
-    <access>read-write</access>
-    <fields>
-     <field>
-      <name>A</name>
-      <description>Wake-Up Flag for Timer A</description>
-      <bitOffset>0</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-     <field>
-      <name>B</name>
-      <description>Wake-Up Flag for Timer B</description>
-      <bitOffset>16</bitOffset>
-      <bitWidth>1</bitWidth>
-     </field>
-    </fields>
-   </register>
-  </registers>
- </peripheral>
-<!-- LPTIMER Low-Power Configurable Timer -->
+            <bitOffset>0</bitOffset>
+            <bitWidth>32</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>INTFL</name>
+        <description>Timer Interrupt Status Register.</description>
+        <addressOffset>0x0C</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>IRQ_A</name>
+            <description>Interrupt Flag for Timer A.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WRDONE_A</name>
+            <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WR_DIS_A</name>
+            <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>IRQ_B</name>
+            <description>Interrupt Flag for Timer B.</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WRDONE_B</name>
+            <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WR_DIS_B</name>
+            <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
+            <bitOffset>25</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>CTRL0</name>
+        <description>Timer Control Register.</description>
+        <addressOffset>0x10</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>MODE_A</name>
+            <description>Mode Select for Timer A</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>ONE_SHOT</name>
+                <description>One-Shot Mode</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CONTINUOUS</name>
+                <description>Continuous Mode</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COUNTER</name>
+                <description>Counter Mode</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>PWM</name>
+                <description>PWM Mode</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPTURE</name>
+                <description>Capture Mode</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COMPARE</name>
+                <description>Compare Mode</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>GATED</name>
+                <description>Gated Mode</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPCOMP</name>
+                <description>Capture/Compare Mode</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DUAL_EDGE</name>
+                <description>Dual Edge Capture Mode</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>IGATED</name>
+                <description>Inactive Gated Mode</description>
+                <value>14</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>CLKDIV_A</name>
+            <description>Clock Divider Select for Timer A</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>DIV_BY_1</name>
+                <description>Prescaler Divide-By-1</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2</name>
+                <description>Prescaler Divide-By-2</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4</name>
+                <description>Prescaler Divide-By-4</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_8</name>
+                <description>Prescaler Divide-By-8</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_16</name>
+                <description>Prescaler Divide-By-16</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_32</name>
+                <description>Prescaler Divide-By-32</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_64</name>
+                <description>Prescaler Divide-By-64</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_128</name>
+                <description>Prescaler Divide-By-128</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_256</name>
+                <description>Prescaler Divide-By-256</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_512</name>
+                <description>Prescaler Divide-By-512</description>
+                <value>9</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_1024</name>
+                <description>Prescaler Divide-By-1024</description>
+                <value>10</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2048</name>
+                <description>Prescaler Divide-By-2048</description>
+                <value>11</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4096</name>
+                <description>TBD</description>
+                <value>12</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>POL_A</name>
+            <description>Timer Polarity for Timer A</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMSYNC_A</name>
+            <description>PWM Synchronization Mode for Timer A</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLHPOL_A</name>
+            <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLLPOL_A</name>
+            <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMCKBD_A</name>
+            <description>PWM Phase A-Prime Output Disable for Timer A</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>RST_A</name>
+            <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_A</name>
+            <description>Write 1 to Enable CLK_TMR for Timer A</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EN_A</name>
+            <description>Enable for Timer A</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>MODE_B</name>
+            <description>Mode Select for Timer B</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>ONE_SHOT</name>
+                <description>One-Shot Mode</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CONTINUOUS</name>
+                <description>Continuous Mode</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COUNTER</name>
+                <description>Counter Mode</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>PWM</name>
+                <description>PWM Mode</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPTURE</name>
+                <description>Capture Mode</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>COMPARE</name>
+                <description>Compare Mode</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>GATED</name>
+                <description>Gated Mode</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>CAPCOMP</name>
+                <description>Capture/Compare Mode</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DUAL_EDGE</name>
+                <description>Dual Edge Capture Mode</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>IGATED</name>
+                <description>Inactive Gated Mode</description>
+                <value>14</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>CLKDIV_B</name>
+            <description>Clock Divider Select for Timer B</description>
+            <bitOffset>20</bitOffset>
+            <bitWidth>4</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>DIV_BY_1</name>
+                <description>Prescaler Divide-By-1</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2</name>
+                <description>Prescaler Divide-By-2</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4</name>
+                <description>Prescaler Divide-By-4</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_8</name>
+                <description>Prescaler Divide-By-8</description>
+                <value>3</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_16</name>
+                <description>Prescaler Divide-By-16</description>
+                <value>4</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_32</name>
+                <description>Prescaler Divide-By-32</description>
+                <value>5</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_64</name>
+                <description>Prescaler Divide-By-64</description>
+                <value>6</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_128</name>
+                <description>Prescaler Divide-By-128</description>
+                <value>7</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_256</name>
+                <description>Prescaler Divide-By-256</description>
+                <value>8</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_512</name>
+                <description>Prescaler Divide-By-512</description>
+                <value>9</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_1024</name>
+                <description>Prescaler Divide-By-1024</description>
+                <value>10</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_2048</name>
+                <description>Prescaler Divide-By-2048</description>
+                <value>11</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>DIV_BY_4096</name>
+                <description>TBD</description>
+                <value>12</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>POL_B</name>
+            <description>Timer Polarity for Timer B</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMSYNC_B</name>
+            <description>PWM Synchronization Mode for Timer B</description>
+            <bitOffset>25</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLHPOL_B</name>
+            <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
+            <bitOffset>26</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>NOLLPOL_B</name>
+            <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
+            <bitOffset>27</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>PWMCKBD_B</name>
+            <description>PWM Phase A-Prime Output Disable for Timer B</description>
+            <bitOffset>28</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>RST_B</name>
+            <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
+            <bitOffset>29</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_B</name>
+            <description>Write 1 to Enable CLK_TMR for Timer B</description>
+            <bitOffset>30</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EN_B</name>
+            <description>Enable for Timer B</description>
+            <bitOffset>31</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>NOLCMP</name>
+        <description>Timer Non-Overlapping Compare Register.</description>
+        <addressOffset>0x14</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>LO_A</name>
+            <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+          <field>
+            <name>HI_A</name>
+            <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+          <field>
+            <name>LO_B</name>
+            <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+          <field>
+            <name>HI_B</name>
+            <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>CTRL1</name>
+        <description>Timer Configuration Register.</description>
+        <addressOffset>0x18</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>CLKSEL_A</name>
+            <description>Timer Clock Select for Timer A</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_A</name>
+            <description>Timer A Enable Status</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKRDY_A</name>
+            <description>CLK_TMR Ready Flag for Timer A</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EVENT_SEL_A</name>
+            <description>Event Select for Timer A</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>3</bitWidth>
+          </field>
+          <field>
+            <name>NEGTRIG_A</name>
+            <description>Negative Edge Trigger for Event for Timer A</description>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>IE_A</name>
+            <description>Interrupt Enable for Timer A</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CAPEVENT_SEL_A</name>
+            <description>Capture Event Select for Timer A</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>SW_CAPEVENT_A</name>
+            <description>Software Capture Event for Timer A</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WE_A</name>
+            <description>Wake-Up Enable for Timer A</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>OUTEN_A</name>
+            <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>OUTBEN_A</name>
+            <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>ASYNC</name>
+            <description>Allows asynchronous reads to the PWM and CNT registers.</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKSEL_B</name>
+            <description>Timer Clock Select for Timer B</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>CLKEN_B</name>
+            <description>Timer B Enable Status</description>
+            <bitOffset>18</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CLKRDY_B</name>
+            <description>CLK_TMR Ready Flag for Timer B</description>
+            <bitOffset>19</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>EVENT_SEL_B</name>
+            <description>Event Select for Timer B</description>
+            <bitOffset>20</bitOffset>
+            <bitWidth>3</bitWidth>
+          </field>
+          <field>
+            <name>NEGTRIG_B</name>
+            <description>Negative Edge Trigger for Event for Timer B</description>
+            <bitOffset>23</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>IE_B</name>
+            <description>Interrupt Enable for Timer B</description>
+            <bitOffset>24</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CAPEVENT_SEL_B</name>
+            <description>Capture Event Select for Timer B</description>
+            <bitOffset>25</bitOffset>
+            <bitWidth>2</bitWidth>
+          </field>
+          <field>
+            <name>SW_CAPEVENT_B</name>
+            <description>Software Capture Event for Timer B</description>
+            <bitOffset>27</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>WE_B</name>
+            <description>Wake-Up Enable for Timer B</description>
+            <bitOffset>28</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>CASCADE</name>
+            <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
+            <bitOffset>31</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>WKFL</name>
+        <description>Timer Wakeup Status Register.</description>
+        <addressOffset>0x1C</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>A</name>
+            <description>Wake-Up Flag for Timer A</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>B</name>
+            <description>Wake-Up Flag for Timer B</description>
+            <bitOffset>16</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+    </registers>
+  </peripheral>
+  <!-- LPTIMER Low-Power Configurable Timer -->
 </device>

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb_regs.h
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb_regs.h
@@ -1,13 +1,13 @@
 /**
  * @file    tmr_revb_regs.h
  * @brief   Registers, Bit Masks and Bit Positions for the TMR_REVB Peripheral Module.
+ * @note    This file is @generated.
+ * @ingroup tmr_revb_registers
  */
 
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
- * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@
  *
  ******************************************************************************/
 
-#ifndef _TMR_REVB_REGS_H_
-#define _TMR_REVB_REGS_H_
+#ifndef LIBRARIES_PERIPHDRIVERS_SOURCE_TMR_TMR_REVB_REGS_H_
+#define LIBRARIES_PERIPHDRIVERS_SOURCE_TMR_TMR_REVB_REGS_H_
 
 /* **** Includes **** */
 #include <stdint.h>
@@ -32,11 +32,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
- 
+
 #if defined (__ICCARM__)
   #pragma system_include
 #endif
- 
+
 #if defined (__CC_ARM)
   #pragma anon_unions
 #endif
@@ -48,7 +48,11 @@ extern "C" {
 #define __IO volatile
 #endif
 #ifndef __I
-#define __I  volatile const
+#ifdef __cplusplus
+#define __I volatile
+#else
+#define __I volatile const
+#endif
 #endif
 #ifndef __O
 #define __O  volatile
@@ -64,7 +68,7 @@ extern "C" {
  * @ingroup     tmr_revb
  * @defgroup    tmr_revb_registers TMR_REVB_Registers
  * @brief       Registers, Bit Masks and Bit Positions for the TMR_REVB Peripheral Module.
- * @details Low-Power Configurable Timer
+ * @details     Low-Power Configurable Timer
  */
 
 /**
@@ -82,31 +86,14 @@ typedef struct {
     __IO uint32_t wkfl;                 /**< <tt>\b 0x1C:</tt> TMR_REVB WKFL Register */
 } mxc_tmr_revb_regs_t;
 
-/* Register offsets for module TMR_REVB */
-/**
- * @ingroup    tmr_revb_registers
- * @defgroup   TMR_REVB_Register_Offsets Register Offsets
- * @brief      TMR_REVB Peripheral Register Offsets from the TMR_REVB Base Peripheral Address. 
- * @{
- */
- #define MXC_R_TMR_REVB_CNT                 ((uint32_t)0x00000000UL) /**< Offset from TMR_REVB Base Address: <tt> 0x0000</tt> */ 
- #define MXC_R_TMR_REVB_CMP                 ((uint32_t)0x00000004UL) /**< Offset from TMR_REVB Base Address: <tt> 0x0004</tt> */ 
- #define MXC_R_TMR_REVB_PWM                 ((uint32_t)0x00000008UL) /**< Offset from TMR_REVB Base Address: <tt> 0x0008</tt> */ 
- #define MXC_R_TMR_REVB_INTFL               ((uint32_t)0x0000000CUL) /**< Offset from TMR_REVB Base Address: <tt> 0x000C</tt> */ 
- #define MXC_R_TMR_REVB_CTRL0               ((uint32_t)0x00000010UL) /**< Offset from TMR_REVB Base Address: <tt> 0x0010</tt> */ 
- #define MXC_R_TMR_REVB_NOLCMP              ((uint32_t)0x00000014UL) /**< Offset from TMR_REVB Base Address: <tt> 0x0014</tt> */ 
- #define MXC_R_TMR_REVB_CTRL1               ((uint32_t)0x00000018UL) /**< Offset from TMR_REVB Base Address: <tt> 0x0018</tt> */ 
- #define MXC_R_TMR_REVB_WKFL                ((uint32_t)0x0000001CUL) /**< Offset from TMR_REVB Base Address: <tt> 0x001C</tt> */ 
-/**@} end of group tmr_revb_registers */
-
 /**
  * @ingroup  tmr_revb_registers
  * @defgroup TMR_REVB_CNT TMR_REVB_CNT
  * @brief    Timer Counter Register.
  * @{
  */
- #define MXC_F_TMR_REVB_CNT_COUNT_POS                   0 /**< CNT_COUNT Position */
- #define MXC_F_TMR_REVB_CNT_COUNT                       ((uint32_t)(0xFFFFFFFFUL << MXC_F_TMR_REVB_CNT_COUNT_POS)) /**< CNT_COUNT Mask */
+#define MXC_F_TMR_REVB_CNT_COUNT_POS                   0 /**< CNT_COUNT Position */
+#define MXC_F_TMR_REVB_CNT_COUNT                       ((uint32_t)(0xFFFFFFFFUL << MXC_F_TMR_REVB_CNT_COUNT_POS)) /**< CNT_COUNT Mask */
 
 /**@} end of group TMR_REVB_CNT_Register */
 
@@ -116,8 +103,8 @@ typedef struct {
  * @brief    Timer Compare Register.
  * @{
  */
- #define MXC_F_TMR_REVB_CMP_COMPARE_POS                 0 /**< CMP_COMPARE Position */
- #define MXC_F_TMR_REVB_CMP_COMPARE                     ((uint32_t)(0xFFFFFFFFUL << MXC_F_TMR_REVB_CMP_COMPARE_POS)) /**< CMP_COMPARE Mask */
+#define MXC_F_TMR_REVB_CMP_COMPARE_POS                 0 /**< CMP_COMPARE Position */
+#define MXC_F_TMR_REVB_CMP_COMPARE                     ((uint32_t)(0xFFFFFFFFUL << MXC_F_TMR_REVB_CMP_COMPARE_POS)) /**< CMP_COMPARE Mask */
 
 /**@} end of group TMR_REVB_CMP_Register */
 
@@ -127,8 +114,8 @@ typedef struct {
  * @brief    Timer PWM Register.
  * @{
  */
- #define MXC_F_TMR_REVB_PWM_PWM_POS                     0 /**< PWM_PWM Position */
- #define MXC_F_TMR_REVB_PWM_PWM                         ((uint32_t)(0xFFFFFFFFUL << MXC_F_TMR_REVB_PWM_PWM_POS)) /**< PWM_PWM Mask */
+#define MXC_F_TMR_REVB_PWM_PWM_POS                     0 /**< PWM_PWM Position */
+#define MXC_F_TMR_REVB_PWM_PWM                         ((uint32_t)(0xFFFFFFFFUL << MXC_F_TMR_REVB_PWM_PWM_POS)) /**< PWM_PWM Mask */
 
 /**@} end of group TMR_REVB_PWM_Register */
 
@@ -138,23 +125,23 @@ typedef struct {
  * @brief    Timer Interrupt Status Register.
  * @{
  */
- #define MXC_F_TMR_REVB_INTFL_IRQ_A_POS                 0 /**< INTFL_IRQ_A Position */
- #define MXC_F_TMR_REVB_INTFL_IRQ_A                     ((uint32_t)(0x1UL << MXC_F_TMR_REVB_INTFL_IRQ_A_POS)) /**< INTFL_IRQ_A Mask */
+#define MXC_F_TMR_REVB_INTFL_IRQ_A_POS                 0 /**< INTFL_IRQ_A Position */
+#define MXC_F_TMR_REVB_INTFL_IRQ_A                     ((uint32_t)(0x1UL << MXC_F_TMR_REVB_INTFL_IRQ_A_POS)) /**< INTFL_IRQ_A Mask */
 
- #define MXC_F_TMR_REVB_INTFL_WRDONE_A_POS              8 /**< INTFL_WRDONE_A Position */
- #define MXC_F_TMR_REVB_INTFL_WRDONE_A                  ((uint32_t)(0x1UL << MXC_F_TMR_REVB_INTFL_WRDONE_A_POS)) /**< INTFL_WRDONE_A Mask */
+#define MXC_F_TMR_REVB_INTFL_WRDONE_A_POS              8 /**< INTFL_WRDONE_A Position */
+#define MXC_F_TMR_REVB_INTFL_WRDONE_A                  ((uint32_t)(0x1UL << MXC_F_TMR_REVB_INTFL_WRDONE_A_POS)) /**< INTFL_WRDONE_A Mask */
 
- #define MXC_F_TMR_REVB_INTFL_WR_DIS_A_POS              9 /**< INTFL_WR_DIS_A Position */
- #define MXC_F_TMR_REVB_INTFL_WR_DIS_A                  ((uint32_t)(0x1UL << MXC_F_TMR_REVB_INTFL_WR_DIS_A_POS)) /**< INTFL_WR_DIS_A Mask */
+#define MXC_F_TMR_REVB_INTFL_WR_DIS_A_POS              9 /**< INTFL_WR_DIS_A Position */
+#define MXC_F_TMR_REVB_INTFL_WR_DIS_A                  ((uint32_t)(0x1UL << MXC_F_TMR_REVB_INTFL_WR_DIS_A_POS)) /**< INTFL_WR_DIS_A Mask */
 
- #define MXC_F_TMR_REVB_INTFL_IRQ_B_POS                 16 /**< INTFL_IRQ_B Position */
- #define MXC_F_TMR_REVB_INTFL_IRQ_B                     ((uint32_t)(0x1UL << MXC_F_TMR_REVB_INTFL_IRQ_B_POS)) /**< INTFL_IRQ_B Mask */
+#define MXC_F_TMR_REVB_INTFL_IRQ_B_POS                 16 /**< INTFL_IRQ_B Position */
+#define MXC_F_TMR_REVB_INTFL_IRQ_B                     ((uint32_t)(0x1UL << MXC_F_TMR_REVB_INTFL_IRQ_B_POS)) /**< INTFL_IRQ_B Mask */
 
- #define MXC_F_TMR_REVB_INTFL_WRDONE_B_POS              24 /**< INTFL_WRDONE_B Position */
- #define MXC_F_TMR_REVB_INTFL_WRDONE_B                  ((uint32_t)(0x1UL << MXC_F_TMR_REVB_INTFL_WRDONE_B_POS)) /**< INTFL_WRDONE_B Mask */
+#define MXC_F_TMR_REVB_INTFL_WRDONE_B_POS              24 /**< INTFL_WRDONE_B Position */
+#define MXC_F_TMR_REVB_INTFL_WRDONE_B                  ((uint32_t)(0x1UL << MXC_F_TMR_REVB_INTFL_WRDONE_B_POS)) /**< INTFL_WRDONE_B Mask */
 
- #define MXC_F_TMR_REVB_INTFL_WR_DIS_B_POS              25 /**< INTFL_WR_DIS_B Position */
- #define MXC_F_TMR_REVB_INTFL_WR_DIS_B                  ((uint32_t)(0x1UL << MXC_F_TMR_REVB_INTFL_WR_DIS_B_POS)) /**< INTFL_WR_DIS_B Mask */
+#define MXC_F_TMR_REVB_INTFL_WR_DIS_B_POS              25 /**< INTFL_WR_DIS_B Position */
+#define MXC_F_TMR_REVB_INTFL_WR_DIS_B                  ((uint32_t)(0x1UL << MXC_F_TMR_REVB_INTFL_WR_DIS_B_POS)) /**< INTFL_WR_DIS_B Mask */
 
 /**@} end of group TMR_REVB_INTFL_Register */
 
@@ -164,157 +151,157 @@ typedef struct {
  * @brief    Timer Control Register.
  * @{
  */
- #define MXC_F_TMR_REVB_CTRL0_MODE_A_POS                0 /**< CTRL0_MODE_A Position */
- #define MXC_F_TMR_REVB_CTRL0_MODE_A                    ((uint32_t)(0xFUL << MXC_F_TMR_REVB_CTRL0_MODE_A_POS)) /**< CTRL0_MODE_A Mask */
- #define MXC_V_TMR_REVB_CTRL0_MODE_A_ONE_SHOT           ((uint32_t)0x0UL) /**< CTRL0_MODE_A_ONE_SHOT Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_A_ONE_SHOT           (MXC_V_TMR_REVB_CTRL0_MODE_A_ONE_SHOT << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_ONE_SHOT Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_A_CONTINUOUS         ((uint32_t)0x1UL) /**< CTRL0_MODE_A_CONTINUOUS Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_A_CONTINUOUS         (MXC_V_TMR_REVB_CTRL0_MODE_A_CONTINUOUS << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_CONTINUOUS Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_A_COUNTER            ((uint32_t)0x2UL) /**< CTRL0_MODE_A_COUNTER Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_A_COUNTER            (MXC_V_TMR_REVB_CTRL0_MODE_A_COUNTER << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_COUNTER Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_A_PWM                ((uint32_t)0x3UL) /**< CTRL0_MODE_A_PWM Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_A_PWM                (MXC_V_TMR_REVB_CTRL0_MODE_A_PWM << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_PWM Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_A_CAPTURE            ((uint32_t)0x4UL) /**< CTRL0_MODE_A_CAPTURE Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_A_CAPTURE            (MXC_V_TMR_REVB_CTRL0_MODE_A_CAPTURE << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_CAPTURE Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_A_COMPARE            ((uint32_t)0x5UL) /**< CTRL0_MODE_A_COMPARE Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_A_COMPARE            (MXC_V_TMR_REVB_CTRL0_MODE_A_COMPARE << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_COMPARE Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_A_GATED              ((uint32_t)0x6UL) /**< CTRL0_MODE_A_GATED Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_A_GATED              (MXC_V_TMR_REVB_CTRL0_MODE_A_GATED << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_GATED Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_A_CAPCOMP            ((uint32_t)0x7UL) /**< CTRL0_MODE_A_CAPCOMP Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_A_CAPCOMP            (MXC_V_TMR_REVB_CTRL0_MODE_A_CAPCOMP << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_CAPCOMP Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_A_DUAL_EDGE          ((uint32_t)0x8UL) /**< CTRL0_MODE_A_DUAL_EDGE Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_A_DUAL_EDGE          (MXC_V_TMR_REVB_CTRL0_MODE_A_DUAL_EDGE << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_DUAL_EDGE Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_A_IGATED             ((uint32_t)0xCUL) /**< CTRL0_MODE_A_IGATED Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_A_IGATED             (MXC_V_TMR_REVB_CTRL0_MODE_A_IGATED << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_IGATED Setting */
+#define MXC_F_TMR_REVB_CTRL0_MODE_A_POS                0 /**< CTRL0_MODE_A Position */
+#define MXC_F_TMR_REVB_CTRL0_MODE_A                    ((uint32_t)(0xFUL << MXC_F_TMR_REVB_CTRL0_MODE_A_POS)) /**< CTRL0_MODE_A Mask */
+#define MXC_V_TMR_REVB_CTRL0_MODE_A_ONE_SHOT           ((uint32_t)0x0UL) /**< CTRL0_MODE_A_ONE_SHOT Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_A_ONE_SHOT           (MXC_V_TMR_REVB_CTRL0_MODE_A_ONE_SHOT << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_ONE_SHOT Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_A_CONTINUOUS         ((uint32_t)0x1UL) /**< CTRL0_MODE_A_CONTINUOUS Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_A_CONTINUOUS         (MXC_V_TMR_REVB_CTRL0_MODE_A_CONTINUOUS << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_CONTINUOUS Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_A_COUNTER            ((uint32_t)0x2UL) /**< CTRL0_MODE_A_COUNTER Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_A_COUNTER            (MXC_V_TMR_REVB_CTRL0_MODE_A_COUNTER << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_COUNTER Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_A_PWM                ((uint32_t)0x3UL) /**< CTRL0_MODE_A_PWM Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_A_PWM                (MXC_V_TMR_REVB_CTRL0_MODE_A_PWM << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_PWM Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_A_CAPTURE            ((uint32_t)0x4UL) /**< CTRL0_MODE_A_CAPTURE Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_A_CAPTURE            (MXC_V_TMR_REVB_CTRL0_MODE_A_CAPTURE << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_CAPTURE Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_A_COMPARE            ((uint32_t)0x5UL) /**< CTRL0_MODE_A_COMPARE Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_A_COMPARE            (MXC_V_TMR_REVB_CTRL0_MODE_A_COMPARE << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_COMPARE Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_A_GATED              ((uint32_t)0x6UL) /**< CTRL0_MODE_A_GATED Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_A_GATED              (MXC_V_TMR_REVB_CTRL0_MODE_A_GATED << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_GATED Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_A_CAPCOMP            ((uint32_t)0x7UL) /**< CTRL0_MODE_A_CAPCOMP Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_A_CAPCOMP            (MXC_V_TMR_REVB_CTRL0_MODE_A_CAPCOMP << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_CAPCOMP Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_A_DUAL_EDGE          ((uint32_t)0x8UL) /**< CTRL0_MODE_A_DUAL_EDGE Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_A_DUAL_EDGE          (MXC_V_TMR_REVB_CTRL0_MODE_A_DUAL_EDGE << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_DUAL_EDGE Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_A_IGATED             ((uint32_t)0xEUL) /**< CTRL0_MODE_A_IGATED Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_A_IGATED             (MXC_V_TMR_REVB_CTRL0_MODE_A_IGATED << MXC_F_TMR_REVB_CTRL0_MODE_A_POS) /**< CTRL0_MODE_A_IGATED Setting */
 
- #define MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS              4 /**< CTRL0_CLKDIV_A Position */
- #define MXC_F_TMR_REVB_CTRL0_CLKDIV_A                  ((uint32_t)(0xFUL << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS)) /**< CTRL0_CLKDIV_A Mask */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_1         ((uint32_t)0x0UL) /**< CTRL0_CLKDIV_A_DIV_BY_1 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_1         (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_1 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_1 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_2         ((uint32_t)0x1UL) /**< CTRL0_CLKDIV_A_DIV_BY_2 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_2         (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_2 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_2 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_4         ((uint32_t)0x2UL) /**< CTRL0_CLKDIV_A_DIV_BY_4 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_4         (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_4 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_4 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_8         ((uint32_t)0x3UL) /**< CTRL0_CLKDIV_A_DIV_BY_8 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_8         (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_8 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_8 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_16        ((uint32_t)0x4UL) /**< CTRL0_CLKDIV_A_DIV_BY_16 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_16        (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_16 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_16 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_32        ((uint32_t)0x5UL) /**< CTRL0_CLKDIV_A_DIV_BY_32 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_32        (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_32 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_32 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_64        ((uint32_t)0x6UL) /**< CTRL0_CLKDIV_A_DIV_BY_64 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_64        (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_64 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_64 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_128       ((uint32_t)0x7UL) /**< CTRL0_CLKDIV_A_DIV_BY_128 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_128       (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_128 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_128 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_256       ((uint32_t)0x8UL) /**< CTRL0_CLKDIV_A_DIV_BY_256 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_256       (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_256 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_256 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_512       ((uint32_t)0x9UL) /**< CTRL0_CLKDIV_A_DIV_BY_512 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_512       (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_512 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_512 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_1024      ((uint32_t)0xAUL) /**< CTRL0_CLKDIV_A_DIV_BY_1024 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_1024      (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_1024 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_1024 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_2048      ((uint32_t)0xBUL) /**< CTRL0_CLKDIV_A_DIV_BY_2048 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_2048      (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_2048 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_2048 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_4096      ((uint32_t)0xCUL) /**< CTRL0_CLKDIV_A_DIV_BY_4096 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_4096      (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_4096 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_4096 Setting */
+#define MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS              4 /**< CTRL0_CLKDIV_A Position */
+#define MXC_F_TMR_REVB_CTRL0_CLKDIV_A                  ((uint32_t)(0xFUL << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS)) /**< CTRL0_CLKDIV_A Mask */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_1         ((uint32_t)0x0UL) /**< CTRL0_CLKDIV_A_DIV_BY_1 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_1         (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_1 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_1 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_2         ((uint32_t)0x1UL) /**< CTRL0_CLKDIV_A_DIV_BY_2 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_2         (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_2 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_2 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_4         ((uint32_t)0x2UL) /**< CTRL0_CLKDIV_A_DIV_BY_4 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_4         (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_4 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_4 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_8         ((uint32_t)0x3UL) /**< CTRL0_CLKDIV_A_DIV_BY_8 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_8         (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_8 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_8 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_16        ((uint32_t)0x4UL) /**< CTRL0_CLKDIV_A_DIV_BY_16 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_16        (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_16 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_16 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_32        ((uint32_t)0x5UL) /**< CTRL0_CLKDIV_A_DIV_BY_32 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_32        (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_32 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_32 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_64        ((uint32_t)0x6UL) /**< CTRL0_CLKDIV_A_DIV_BY_64 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_64        (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_64 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_64 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_128       ((uint32_t)0x7UL) /**< CTRL0_CLKDIV_A_DIV_BY_128 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_128       (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_128 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_128 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_256       ((uint32_t)0x8UL) /**< CTRL0_CLKDIV_A_DIV_BY_256 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_256       (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_256 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_256 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_512       ((uint32_t)0x9UL) /**< CTRL0_CLKDIV_A_DIV_BY_512 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_512       (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_512 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_512 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_1024      ((uint32_t)0xAUL) /**< CTRL0_CLKDIV_A_DIV_BY_1024 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_1024      (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_1024 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_1024 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_2048      ((uint32_t)0xBUL) /**< CTRL0_CLKDIV_A_DIV_BY_2048 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_2048      (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_2048 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_2048 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_4096      ((uint32_t)0xCUL) /**< CTRL0_CLKDIV_A_DIV_BY_4096 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_4096      (MXC_V_TMR_REVB_CTRL0_CLKDIV_A_DIV_BY_4096 << MXC_F_TMR_REVB_CTRL0_CLKDIV_A_POS) /**< CTRL0_CLKDIV_A_DIV_BY_4096 Setting */
 
- #define MXC_F_TMR_REVB_CTRL0_POL_A_POS                 8 /**< CTRL0_POL_A Position */
- #define MXC_F_TMR_REVB_CTRL0_POL_A                     ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_POL_A_POS)) /**< CTRL0_POL_A Mask */
+#define MXC_F_TMR_REVB_CTRL0_POL_A_POS                 8 /**< CTRL0_POL_A Position */
+#define MXC_F_TMR_REVB_CTRL0_POL_A                     ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_POL_A_POS)) /**< CTRL0_POL_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL0_PWMSYNC_A_POS             9 /**< CTRL0_PWMSYNC_A Position */
- #define MXC_F_TMR_REVB_CTRL0_PWMSYNC_A                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_PWMSYNC_A_POS)) /**< CTRL0_PWMSYNC_A Mask */
+#define MXC_F_TMR_REVB_CTRL0_PWMSYNC_A_POS             9 /**< CTRL0_PWMSYNC_A Position */
+#define MXC_F_TMR_REVB_CTRL0_PWMSYNC_A                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_PWMSYNC_A_POS)) /**< CTRL0_PWMSYNC_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL0_NOLHPOL_A_POS             10 /**< CTRL0_NOLHPOL_A Position */
- #define MXC_F_TMR_REVB_CTRL0_NOLHPOL_A                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_NOLHPOL_A_POS)) /**< CTRL0_NOLHPOL_A Mask */
+#define MXC_F_TMR_REVB_CTRL0_NOLHPOL_A_POS             10 /**< CTRL0_NOLHPOL_A Position */
+#define MXC_F_TMR_REVB_CTRL0_NOLHPOL_A                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_NOLHPOL_A_POS)) /**< CTRL0_NOLHPOL_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL0_NOLLPOL_A_POS             11 /**< CTRL0_NOLLPOL_A Position */
- #define MXC_F_TMR_REVB_CTRL0_NOLLPOL_A                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_NOLLPOL_A_POS)) /**< CTRL0_NOLLPOL_A Mask */
+#define MXC_F_TMR_REVB_CTRL0_NOLLPOL_A_POS             11 /**< CTRL0_NOLLPOL_A Position */
+#define MXC_F_TMR_REVB_CTRL0_NOLLPOL_A                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_NOLLPOL_A_POS)) /**< CTRL0_NOLLPOL_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL0_PWMCKBD_A_POS             12 /**< CTRL0_PWMCKBD_A Position */
- #define MXC_F_TMR_REVB_CTRL0_PWMCKBD_A                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_PWMCKBD_A_POS)) /**< CTRL0_PWMCKBD_A Mask */
+#define MXC_F_TMR_REVB_CTRL0_PWMCKBD_A_POS             12 /**< CTRL0_PWMCKBD_A Position */
+#define MXC_F_TMR_REVB_CTRL0_PWMCKBD_A                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_PWMCKBD_A_POS)) /**< CTRL0_PWMCKBD_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL0_RST_A_POS                 13 /**< CTRL0_RST_A Position */
- #define MXC_F_TMR_REVB_CTRL0_RST_A                     ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_RST_A_POS)) /**< CTRL0_RST_A Mask */
+#define MXC_F_TMR_REVB_CTRL0_RST_A_POS                 13 /**< CTRL0_RST_A Position */
+#define MXC_F_TMR_REVB_CTRL0_RST_A                     ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_RST_A_POS)) /**< CTRL0_RST_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL0_CLKEN_A_POS               14 /**< CTRL0_CLKEN_A Position */
- #define MXC_F_TMR_REVB_CTRL0_CLKEN_A                   ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_CLKEN_A_POS)) /**< CTRL0_CLKEN_A Mask */
+#define MXC_F_TMR_REVB_CTRL0_CLKEN_A_POS               14 /**< CTRL0_CLKEN_A Position */
+#define MXC_F_TMR_REVB_CTRL0_CLKEN_A                   ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_CLKEN_A_POS)) /**< CTRL0_CLKEN_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL0_EN_A_POS                  15 /**< CTRL0_EN_A Position */
- #define MXC_F_TMR_REVB_CTRL0_EN_A                      ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_EN_A_POS)) /**< CTRL0_EN_A Mask */
+#define MXC_F_TMR_REVB_CTRL0_EN_A_POS                  15 /**< CTRL0_EN_A Position */
+#define MXC_F_TMR_REVB_CTRL0_EN_A                      ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_EN_A_POS)) /**< CTRL0_EN_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL0_MODE_B_POS                16 /**< CTRL0_MODE_B Position */
- #define MXC_F_TMR_REVB_CTRL0_MODE_B                    ((uint32_t)(0xFUL << MXC_F_TMR_REVB_CTRL0_MODE_B_POS)) /**< CTRL0_MODE_B Mask */
- #define MXC_V_TMR_REVB_CTRL0_MODE_B_ONE_SHOT           ((uint32_t)0x0UL) /**< CTRL0_MODE_B_ONE_SHOT Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_B_ONE_SHOT           (MXC_V_TMR_REVB_CTRL0_MODE_B_ONE_SHOT << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_ONE_SHOT Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_B_CONTINUOUS         ((uint32_t)0x1UL) /**< CTRL0_MODE_B_CONTINUOUS Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_B_CONTINUOUS         (MXC_V_TMR_REVB_CTRL0_MODE_B_CONTINUOUS << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_CONTINUOUS Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_B_COUNTER            ((uint32_t)0x2UL) /**< CTRL0_MODE_B_COUNTER Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_B_COUNTER            (MXC_V_TMR_REVB_CTRL0_MODE_B_COUNTER << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_COUNTER Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_B_PWM                ((uint32_t)0x3UL) /**< CTRL0_MODE_B_PWM Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_B_PWM                (MXC_V_TMR_REVB_CTRL0_MODE_B_PWM << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_PWM Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_B_CAPTURE            ((uint32_t)0x4UL) /**< CTRL0_MODE_B_CAPTURE Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_B_CAPTURE            (MXC_V_TMR_REVB_CTRL0_MODE_B_CAPTURE << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_CAPTURE Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_B_COMPARE            ((uint32_t)0x5UL) /**< CTRL0_MODE_B_COMPARE Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_B_COMPARE            (MXC_V_TMR_REVB_CTRL0_MODE_B_COMPARE << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_COMPARE Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_B_GATED              ((uint32_t)0x6UL) /**< CTRL0_MODE_B_GATED Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_B_GATED              (MXC_V_TMR_REVB_CTRL0_MODE_B_GATED << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_GATED Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_B_CAPCOMP            ((uint32_t)0x7UL) /**< CTRL0_MODE_B_CAPCOMP Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_B_CAPCOMP            (MXC_V_TMR_REVB_CTRL0_MODE_B_CAPCOMP << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_CAPCOMP Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_B_DUAL_EDGE          ((uint32_t)0x8UL) /**< CTRL0_MODE_B_DUAL_EDGE Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_B_DUAL_EDGE          (MXC_V_TMR_REVB_CTRL0_MODE_B_DUAL_EDGE << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_DUAL_EDGE Setting */
- #define MXC_V_TMR_REVB_CTRL0_MODE_B_IGATED             ((uint32_t)0xEUL) /**< CTRL0_MODE_B_IGATED Value */
- #define MXC_S_TMR_REVB_CTRL0_MODE_B_IGATED             (MXC_V_TMR_REVB_CTRL0_MODE_B_IGATED << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_IGATED Setting */
+#define MXC_F_TMR_REVB_CTRL0_MODE_B_POS                16 /**< CTRL0_MODE_B Position */
+#define MXC_F_TMR_REVB_CTRL0_MODE_B                    ((uint32_t)(0xFUL << MXC_F_TMR_REVB_CTRL0_MODE_B_POS)) /**< CTRL0_MODE_B Mask */
+#define MXC_V_TMR_REVB_CTRL0_MODE_B_ONE_SHOT           ((uint32_t)0x0UL) /**< CTRL0_MODE_B_ONE_SHOT Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_B_ONE_SHOT           (MXC_V_TMR_REVB_CTRL0_MODE_B_ONE_SHOT << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_ONE_SHOT Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_B_CONTINUOUS         ((uint32_t)0x1UL) /**< CTRL0_MODE_B_CONTINUOUS Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_B_CONTINUOUS         (MXC_V_TMR_REVB_CTRL0_MODE_B_CONTINUOUS << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_CONTINUOUS Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_B_COUNTER            ((uint32_t)0x2UL) /**< CTRL0_MODE_B_COUNTER Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_B_COUNTER            (MXC_V_TMR_REVB_CTRL0_MODE_B_COUNTER << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_COUNTER Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_B_PWM                ((uint32_t)0x3UL) /**< CTRL0_MODE_B_PWM Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_B_PWM                (MXC_V_TMR_REVB_CTRL0_MODE_B_PWM << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_PWM Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_B_CAPTURE            ((uint32_t)0x4UL) /**< CTRL0_MODE_B_CAPTURE Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_B_CAPTURE            (MXC_V_TMR_REVB_CTRL0_MODE_B_CAPTURE << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_CAPTURE Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_B_COMPARE            ((uint32_t)0x5UL) /**< CTRL0_MODE_B_COMPARE Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_B_COMPARE            (MXC_V_TMR_REVB_CTRL0_MODE_B_COMPARE << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_COMPARE Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_B_GATED              ((uint32_t)0x6UL) /**< CTRL0_MODE_B_GATED Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_B_GATED              (MXC_V_TMR_REVB_CTRL0_MODE_B_GATED << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_GATED Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_B_CAPCOMP            ((uint32_t)0x7UL) /**< CTRL0_MODE_B_CAPCOMP Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_B_CAPCOMP            (MXC_V_TMR_REVB_CTRL0_MODE_B_CAPCOMP << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_CAPCOMP Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_B_DUAL_EDGE          ((uint32_t)0x8UL) /**< CTRL0_MODE_B_DUAL_EDGE Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_B_DUAL_EDGE          (MXC_V_TMR_REVB_CTRL0_MODE_B_DUAL_EDGE << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_DUAL_EDGE Setting */
+#define MXC_V_TMR_REVB_CTRL0_MODE_B_IGATED             ((uint32_t)0xEUL) /**< CTRL0_MODE_B_IGATED Value */
+#define MXC_S_TMR_REVB_CTRL0_MODE_B_IGATED             (MXC_V_TMR_REVB_CTRL0_MODE_B_IGATED << MXC_F_TMR_REVB_CTRL0_MODE_B_POS) /**< CTRL0_MODE_B_IGATED Setting */
 
- #define MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS              20 /**< CTRL0_CLKDIV_B Position */
- #define MXC_F_TMR_REVB_CTRL0_CLKDIV_B                  ((uint32_t)(0xFUL << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS)) /**< CTRL0_CLKDIV_B Mask */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_1         ((uint32_t)0x0UL) /**< CTRL0_CLKDIV_B_DIV_BY_1 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_1         (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_1 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_1 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_2         ((uint32_t)0x1UL) /**< CTRL0_CLKDIV_B_DIV_BY_2 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_2         (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_2 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_2 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_4         ((uint32_t)0x2UL) /**< CTRL0_CLKDIV_B_DIV_BY_4 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_4         (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_4 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_4 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_8         ((uint32_t)0x3UL) /**< CTRL0_CLKDIV_B_DIV_BY_8 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_8         (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_8 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_8 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_16        ((uint32_t)0x4UL) /**< CTRL0_CLKDIV_B_DIV_BY_16 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_16        (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_16 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_16 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_32        ((uint32_t)0x5UL) /**< CTRL0_CLKDIV_B_DIV_BY_32 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_32        (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_32 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_32 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_64        ((uint32_t)0x6UL) /**< CTRL0_CLKDIV_B_DIV_BY_64 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_64        (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_64 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_64 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_128       ((uint32_t)0x7UL) /**< CTRL0_CLKDIV_B_DIV_BY_128 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_128       (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_128 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_128 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_256       ((uint32_t)0x8UL) /**< CTRL0_CLKDIV_B_DIV_BY_256 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_256       (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_256 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_256 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_512       ((uint32_t)0x9UL) /**< CTRL0_CLKDIV_B_DIV_BY_512 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_512       (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_512 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_512 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_1024      ((uint32_t)0xAUL) /**< CTRL0_CLKDIV_B_DIV_BY_1024 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_1024      (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_1024 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_1024 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_2048      ((uint32_t)0xBUL) /**< CTRL0_CLKDIV_B_DIV_BY_2048 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_2048      (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_2048 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_2048 Setting */
- #define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_4096      ((uint32_t)0xCUL) /**< CTRL0_CLKDIV_B_DIV_BY_4096 Value */
- #define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_4096      (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_4096 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_4096 Setting */
+#define MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS              20 /**< CTRL0_CLKDIV_B Position */
+#define MXC_F_TMR_REVB_CTRL0_CLKDIV_B                  ((uint32_t)(0xFUL << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS)) /**< CTRL0_CLKDIV_B Mask */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_1         ((uint32_t)0x0UL) /**< CTRL0_CLKDIV_B_DIV_BY_1 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_1         (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_1 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_1 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_2         ((uint32_t)0x1UL) /**< CTRL0_CLKDIV_B_DIV_BY_2 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_2         (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_2 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_2 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_4         ((uint32_t)0x2UL) /**< CTRL0_CLKDIV_B_DIV_BY_4 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_4         (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_4 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_4 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_8         ((uint32_t)0x3UL) /**< CTRL0_CLKDIV_B_DIV_BY_8 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_8         (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_8 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_8 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_16        ((uint32_t)0x4UL) /**< CTRL0_CLKDIV_B_DIV_BY_16 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_16        (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_16 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_16 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_32        ((uint32_t)0x5UL) /**< CTRL0_CLKDIV_B_DIV_BY_32 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_32        (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_32 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_32 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_64        ((uint32_t)0x6UL) /**< CTRL0_CLKDIV_B_DIV_BY_64 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_64        (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_64 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_64 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_128       ((uint32_t)0x7UL) /**< CTRL0_CLKDIV_B_DIV_BY_128 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_128       (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_128 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_128 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_256       ((uint32_t)0x8UL) /**< CTRL0_CLKDIV_B_DIV_BY_256 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_256       (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_256 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_256 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_512       ((uint32_t)0x9UL) /**< CTRL0_CLKDIV_B_DIV_BY_512 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_512       (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_512 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_512 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_1024      ((uint32_t)0xAUL) /**< CTRL0_CLKDIV_B_DIV_BY_1024 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_1024      (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_1024 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_1024 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_2048      ((uint32_t)0xBUL) /**< CTRL0_CLKDIV_B_DIV_BY_2048 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_2048      (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_2048 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_2048 Setting */
+#define MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_4096      ((uint32_t)0xCUL) /**< CTRL0_CLKDIV_B_DIV_BY_4096 Value */
+#define MXC_S_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_4096      (MXC_V_TMR_REVB_CTRL0_CLKDIV_B_DIV_BY_4096 << MXC_F_TMR_REVB_CTRL0_CLKDIV_B_POS) /**< CTRL0_CLKDIV_B_DIV_BY_4096 Setting */
 
- #define MXC_F_TMR_REVB_CTRL0_POL_B_POS                 24 /**< CTRL0_POL_B Position */
- #define MXC_F_TMR_REVB_CTRL0_POL_B                     ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_POL_B_POS)) /**< CTRL0_POL_B Mask */
+#define MXC_F_TMR_REVB_CTRL0_POL_B_POS                 24 /**< CTRL0_POL_B Position */
+#define MXC_F_TMR_REVB_CTRL0_POL_B                     ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_POL_B_POS)) /**< CTRL0_POL_B Mask */
 
- #define MXC_F_TMR_REVB_CTRL0_PWMSYNC_B_POS             25 /**< CTRL0_PWMSYNC_B Position */
- #define MXC_F_TMR_REVB_CTRL0_PWMSYNC_B                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_PWMSYNC_B_POS)) /**< CTRL0_PWMSYNC_B Mask */
+#define MXC_F_TMR_REVB_CTRL0_PWMSYNC_B_POS             25 /**< CTRL0_PWMSYNC_B Position */
+#define MXC_F_TMR_REVB_CTRL0_PWMSYNC_B                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_PWMSYNC_B_POS)) /**< CTRL0_PWMSYNC_B Mask */
 
- #define MXC_F_TMR_REVB_CTRL0_NOLHPOL_B_POS             26 /**< CTRL0_NOLHPOL_B Position */
- #define MXC_F_TMR_REVB_CTRL0_NOLHPOL_B                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_NOLHPOL_B_POS)) /**< CTRL0_NOLHPOL_B Mask */
+#define MXC_F_TMR_REVB_CTRL0_NOLHPOL_B_POS             26 /**< CTRL0_NOLHPOL_B Position */
+#define MXC_F_TMR_REVB_CTRL0_NOLHPOL_B                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_NOLHPOL_B_POS)) /**< CTRL0_NOLHPOL_B Mask */
 
- #define MXC_F_TMR_REVB_CTRL0_NOLLPOL_B_POS             27 /**< CTRL0_NOLLPOL_B Position */
- #define MXC_F_TMR_REVB_CTRL0_NOLLPOL_B                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_NOLLPOL_B_POS)) /**< CTRL0_NOLLPOL_B Mask */
+#define MXC_F_TMR_REVB_CTRL0_NOLLPOL_B_POS             27 /**< CTRL0_NOLLPOL_B Position */
+#define MXC_F_TMR_REVB_CTRL0_NOLLPOL_B                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_NOLLPOL_B_POS)) /**< CTRL0_NOLLPOL_B Mask */
 
- #define MXC_F_TMR_REVB_CTRL0_PWMCKBD_B_POS             28 /**< CTRL0_PWMCKBD_B Position */
- #define MXC_F_TMR_REVB_CTRL0_PWMCKBD_B                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_PWMCKBD_B_POS)) /**< CTRL0_PWMCKBD_B Mask */
+#define MXC_F_TMR_REVB_CTRL0_PWMCKBD_B_POS             28 /**< CTRL0_PWMCKBD_B Position */
+#define MXC_F_TMR_REVB_CTRL0_PWMCKBD_B                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_PWMCKBD_B_POS)) /**< CTRL0_PWMCKBD_B Mask */
 
- #define MXC_F_TMR_REVB_CTRL0_RST_B_POS                 29 /**< CTRL0_RST_B Position */
- #define MXC_F_TMR_REVB_CTRL0_RST_B                     ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_RST_B_POS)) /**< CTRL0_RST_B Mask */
+#define MXC_F_TMR_REVB_CTRL0_RST_B_POS                 29 /**< CTRL0_RST_B Position */
+#define MXC_F_TMR_REVB_CTRL0_RST_B                     ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_RST_B_POS)) /**< CTRL0_RST_B Mask */
 
- #define MXC_F_TMR_REVB_CTRL0_CLKEN_B_POS               30 /**< CTRL0_CLKEN_B Position */
- #define MXC_F_TMR_REVB_CTRL0_CLKEN_B                   ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_CLKEN_B_POS)) /**< CTRL0_CLKEN_B Mask */
+#define MXC_F_TMR_REVB_CTRL0_CLKEN_B_POS               30 /**< CTRL0_CLKEN_B Position */
+#define MXC_F_TMR_REVB_CTRL0_CLKEN_B                   ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_CLKEN_B_POS)) /**< CTRL0_CLKEN_B Mask */
 
- #define MXC_F_TMR_REVB_CTRL0_EN_B_POS                  31 /**< CTRL0_EN_B Position */
- #define MXC_F_TMR_REVB_CTRL0_EN_B                      ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_EN_B_POS)) /**< CTRL0_EN_B Mask */
+#define MXC_F_TMR_REVB_CTRL0_EN_B_POS                  31 /**< CTRL0_EN_B Position */
+#define MXC_F_TMR_REVB_CTRL0_EN_B                      ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL0_EN_B_POS)) /**< CTRL0_EN_B Mask */
 
 /**@} end of group TMR_REVB_CTRL0_Register */
 
@@ -324,17 +311,17 @@ typedef struct {
  * @brief    Timer Non-Overlapping Compare Register.
  * @{
  */
- #define MXC_F_TMR_REVB_NOLCMP_LO_A_POS                 0 /**< NOLCMP_LO_A Position */
- #define MXC_F_TMR_REVB_NOLCMP_LO_A                     ((uint32_t)(0xFFUL << MXC_F_TMR_REVB_NOLCMP_LO_A_POS)) /**< NOLCMP_LO_A Mask */
+#define MXC_F_TMR_REVB_NOLCMP_LO_A_POS                 0 /**< NOLCMP_LO_A Position */
+#define MXC_F_TMR_REVB_NOLCMP_LO_A                     ((uint32_t)(0xFFUL << MXC_F_TMR_REVB_NOLCMP_LO_A_POS)) /**< NOLCMP_LO_A Mask */
 
- #define MXC_F_TMR_REVB_NOLCMP_HI_A_POS                 8 /**< NOLCMP_HI_A Position */
- #define MXC_F_TMR_REVB_NOLCMP_HI_A                     ((uint32_t)(0xFFUL << MXC_F_TMR_REVB_NOLCMP_HI_A_POS)) /**< NOLCMP_HI_A Mask */
+#define MXC_F_TMR_REVB_NOLCMP_HI_A_POS                 8 /**< NOLCMP_HI_A Position */
+#define MXC_F_TMR_REVB_NOLCMP_HI_A                     ((uint32_t)(0xFFUL << MXC_F_TMR_REVB_NOLCMP_HI_A_POS)) /**< NOLCMP_HI_A Mask */
 
- #define MXC_F_TMR_REVB_NOLCMP_LO_B_POS                 16 /**< NOLCMP_LO_B Position */
- #define MXC_F_TMR_REVB_NOLCMP_LO_B                     ((uint32_t)(0xFFUL << MXC_F_TMR_REVB_NOLCMP_LO_B_POS)) /**< NOLCMP_LO_B Mask */
+#define MXC_F_TMR_REVB_NOLCMP_LO_B_POS                 16 /**< NOLCMP_LO_B Position */
+#define MXC_F_TMR_REVB_NOLCMP_LO_B                     ((uint32_t)(0xFFUL << MXC_F_TMR_REVB_NOLCMP_LO_B_POS)) /**< NOLCMP_LO_B Mask */
 
- #define MXC_F_TMR_REVB_NOLCMP_HI_B_POS                 24 /**< NOLCMP_HI_B Position */
- #define MXC_F_TMR_REVB_NOLCMP_HI_B                     ((uint32_t)(0xFFUL << MXC_F_TMR_REVB_NOLCMP_HI_B_POS)) /**< NOLCMP_HI_B Mask */
+#define MXC_F_TMR_REVB_NOLCMP_HI_B_POS                 24 /**< NOLCMP_HI_B Position */
+#define MXC_F_TMR_REVB_NOLCMP_HI_B                     ((uint32_t)(0xFFUL << MXC_F_TMR_REVB_NOLCMP_HI_B_POS)) /**< NOLCMP_HI_B Mask */
 
 /**@} end of group TMR_REVB_NOLCMP_Register */
 
@@ -344,68 +331,71 @@ typedef struct {
  * @brief    Timer Configuration Register.
  * @{
  */
- #define MXC_F_TMR_REVB_CTRL1_CLKSEL_A_POS              0 /**< CTRL1_CLKSEL_A Position */
- #define MXC_F_TMR_REVB_CTRL1_CLKSEL_A                  ((uint32_t)(0x3UL << MXC_F_TMR_REVB_CTRL1_CLKSEL_A_POS)) /**< CTRL1_CLKSEL_A Mask */
+#define MXC_F_TMR_REVB_CTRL1_CLKSEL_A_POS              0 /**< CTRL1_CLKSEL_A Position */
+#define MXC_F_TMR_REVB_CTRL1_CLKSEL_A                  ((uint32_t)(0x3UL << MXC_F_TMR_REVB_CTRL1_CLKSEL_A_POS)) /**< CTRL1_CLKSEL_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_CLKEN_A_POS               2 /**< CTRL1_CLKEN_A Position */
- #define MXC_F_TMR_REVB_CTRL1_CLKEN_A                   ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_CLKEN_A_POS)) /**< CTRL1_CLKEN_A Mask */
+#define MXC_F_TMR_REVB_CTRL1_CLKEN_A_POS               2 /**< CTRL1_CLKEN_A Position */
+#define MXC_F_TMR_REVB_CTRL1_CLKEN_A                   ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_CLKEN_A_POS)) /**< CTRL1_CLKEN_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_CLKRDY_A_POS              3 /**< CTRL1_CLKRDY_A Position */
- #define MXC_F_TMR_REVB_CTRL1_CLKRDY_A                  ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_CLKRDY_A_POS)) /**< CTRL1_CLKRDY_A Mask */
+#define MXC_F_TMR_REVB_CTRL1_CLKRDY_A_POS              3 /**< CTRL1_CLKRDY_A Position */
+#define MXC_F_TMR_REVB_CTRL1_CLKRDY_A                  ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_CLKRDY_A_POS)) /**< CTRL1_CLKRDY_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_EVENT_SEL_A_POS           4 /**< CTRL1_EVENT_SEL_A Position */
- #define MXC_F_TMR_REVB_CTRL1_EVENT_SEL_A               ((uint32_t)(0x7UL << MXC_F_TMR_REVB_CTRL1_EVENT_SEL_A_POS)) /**< CTRL1_EVENT_SEL_A Mask */
+#define MXC_F_TMR_REVB_CTRL1_EVENT_SEL_A_POS           4 /**< CTRL1_EVENT_SEL_A Position */
+#define MXC_F_TMR_REVB_CTRL1_EVENT_SEL_A               ((uint32_t)(0x7UL << MXC_F_TMR_REVB_CTRL1_EVENT_SEL_A_POS)) /**< CTRL1_EVENT_SEL_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_NEGTRIG_A_POS             7 /**< CTRL1_NEGTRIG_A Position */
- #define MXC_F_TMR_REVB_CTRL1_NEGTRIG_A                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_NEGTRIG_A_POS)) /**< CTRL1_NEGTRIG_A Mask */
+#define MXC_F_TMR_REVB_CTRL1_NEGTRIG_A_POS             7 /**< CTRL1_NEGTRIG_A Position */
+#define MXC_F_TMR_REVB_CTRL1_NEGTRIG_A                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_NEGTRIG_A_POS)) /**< CTRL1_NEGTRIG_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_IE_A_POS                  8 /**< CTRL1_IE_A Position */
- #define MXC_F_TMR_REVB_CTRL1_IE_A                      ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_IE_A_POS)) /**< CTRL1_IE_A Mask */
+#define MXC_F_TMR_REVB_CTRL1_IE_A_POS                  8 /**< CTRL1_IE_A Position */
+#define MXC_F_TMR_REVB_CTRL1_IE_A                      ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_IE_A_POS)) /**< CTRL1_IE_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_CAPEVENT_SEL_A_POS        9 /**< CTRL1_CAPEVENT_SEL_A Position */
- #define MXC_F_TMR_REVB_CTRL1_CAPEVENT_SEL_A            ((uint32_t)(0x3UL << MXC_F_TMR_REVB_CTRL1_CAPEVENT_SEL_A_POS)) /**< CTRL1_CAPEVENT_SEL_A Mask */
+#define MXC_F_TMR_REVB_CTRL1_CAPEVENT_SEL_A_POS        9 /**< CTRL1_CAPEVENT_SEL_A Position */
+#define MXC_F_TMR_REVB_CTRL1_CAPEVENT_SEL_A            ((uint32_t)(0x3UL << MXC_F_TMR_REVB_CTRL1_CAPEVENT_SEL_A_POS)) /**< CTRL1_CAPEVENT_SEL_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_SW_CAPEVENT_A_POS         11 /**< CTRL1_SW_CAPEVENT_A Position */
- #define MXC_F_TMR_REVB_CTRL1_SW_CAPEVENT_A             ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_SW_CAPEVENT_A_POS)) /**< CTRL1_SW_CAPEVENT_A Mask */
+#define MXC_F_TMR_REVB_CTRL1_SW_CAPEVENT_A_POS         11 /**< CTRL1_SW_CAPEVENT_A Position */
+#define MXC_F_TMR_REVB_CTRL1_SW_CAPEVENT_A             ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_SW_CAPEVENT_A_POS)) /**< CTRL1_SW_CAPEVENT_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_WE_A_POS                  12 /**< CTRL1_WE_A Position */
- #define MXC_F_TMR_REVB_CTRL1_WE_A                      ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_WE_A_POS)) /**< CTRL1_WE_A Mask */
+#define MXC_F_TMR_REVB_CTRL1_WE_A_POS                  12 /**< CTRL1_WE_A Position */
+#define MXC_F_TMR_REVB_CTRL1_WE_A                      ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_WE_A_POS)) /**< CTRL1_WE_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_OUTEN_A_POS               13 /**< CTRL1_OUTEN_A Position */
- #define MXC_F_TMR_REVB_CTRL1_OUTEN_A                   ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_OUTEN_A_POS)) /**< CTRL1_OUTEN_A Mask */
+#define MXC_F_TMR_REVB_CTRL1_OUTEN_A_POS               13 /**< CTRL1_OUTEN_A Position */
+#define MXC_F_TMR_REVB_CTRL1_OUTEN_A                   ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_OUTEN_A_POS)) /**< CTRL1_OUTEN_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_OUTBEN_A_POS              14 /**< CTRL1_OUTBEN_A Position */
- #define MXC_F_TMR_REVB_CTRL1_OUTBEN_A                  ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_OUTBEN_A_POS)) /**< CTRL1_OUTBEN_A Mask */
+#define MXC_F_TMR_REVB_CTRL1_OUTBEN_A_POS              14 /**< CTRL1_OUTBEN_A Position */
+#define MXC_F_TMR_REVB_CTRL1_OUTBEN_A                  ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_OUTBEN_A_POS)) /**< CTRL1_OUTBEN_A Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_CLKSEL_B_POS              16 /**< CTRL1_CLKSEL_B Position */
- #define MXC_F_TMR_REVB_CTRL1_CLKSEL_B                  ((uint32_t)(0x3UL << MXC_F_TMR_REVB_CTRL1_CLKSEL_B_POS)) /**< CTRL1_CLKSEL_B Mask */
+#define MXC_F_TMR_REVB_CTRL1_ASYNC_POS                 15 /**< CTRL1_ASYNC Position */
+#define MXC_F_TMR_REVB_CTRL1_ASYNC                     ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_ASYNC_POS)) /**< CTRL1_ASYNC Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_CLKEN_B_POS               18 /**< CTRL1_CLKEN_B Position */
- #define MXC_F_TMR_REVB_CTRL1_CLKEN_B                   ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_CLKEN_B_POS)) /**< CTRL1_CLKEN_B Mask */
+#define MXC_F_TMR_REVB_CTRL1_CLKSEL_B_POS              16 /**< CTRL1_CLKSEL_B Position */
+#define MXC_F_TMR_REVB_CTRL1_CLKSEL_B                  ((uint32_t)(0x3UL << MXC_F_TMR_REVB_CTRL1_CLKSEL_B_POS)) /**< CTRL1_CLKSEL_B Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_CLKRDY_B_POS              19 /**< CTRL1_CLKRDY_B Position */
- #define MXC_F_TMR_REVB_CTRL1_CLKRDY_B                  ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_CLKRDY_B_POS)) /**< CTRL1_CLKRDY_B Mask */
+#define MXC_F_TMR_REVB_CTRL1_CLKEN_B_POS               18 /**< CTRL1_CLKEN_B Position */
+#define MXC_F_TMR_REVB_CTRL1_CLKEN_B                   ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_CLKEN_B_POS)) /**< CTRL1_CLKEN_B Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_EVENT_SEL_B_POS           20 /**< CTRL1_EVENT_SEL_B Position */
- #define MXC_F_TMR_REVB_CTRL1_EVENT_SEL_B               ((uint32_t)(0x7UL << MXC_F_TMR_REVB_CTRL1_EVENT_SEL_B_POS)) /**< CTRL1_EVENT_SEL_B Mask */
+#define MXC_F_TMR_REVB_CTRL1_CLKRDY_B_POS              19 /**< CTRL1_CLKRDY_B Position */
+#define MXC_F_TMR_REVB_CTRL1_CLKRDY_B                  ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_CLKRDY_B_POS)) /**< CTRL1_CLKRDY_B Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_NEGTRIG_B_POS             23 /**< CTRL1_NEGTRIG_B Position */
- #define MXC_F_TMR_REVB_CTRL1_NEGTRIG_B                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_NEGTRIG_B_POS)) /**< CTRL1_NEGTRIG_B Mask */
+#define MXC_F_TMR_REVB_CTRL1_EVENT_SEL_B_POS           20 /**< CTRL1_EVENT_SEL_B Position */
+#define MXC_F_TMR_REVB_CTRL1_EVENT_SEL_B               ((uint32_t)(0x7UL << MXC_F_TMR_REVB_CTRL1_EVENT_SEL_B_POS)) /**< CTRL1_EVENT_SEL_B Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_IE_B_POS                  24 /**< CTRL1_IE_B Position */
- #define MXC_F_TMR_REVB_CTRL1_IE_B                      ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_IE_B_POS)) /**< CTRL1_IE_B Mask */
+#define MXC_F_TMR_REVB_CTRL1_NEGTRIG_B_POS             23 /**< CTRL1_NEGTRIG_B Position */
+#define MXC_F_TMR_REVB_CTRL1_NEGTRIG_B                 ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_NEGTRIG_B_POS)) /**< CTRL1_NEGTRIG_B Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_CAPEVENT_SEL_B_POS        25 /**< CTRL1_CAPEVENT_SEL_B Position */
- #define MXC_F_TMR_REVB_CTRL1_CAPEVENT_SEL_B            ((uint32_t)(0x3UL << MXC_F_TMR_REVB_CTRL1_CAPEVENT_SEL_B_POS)) /**< CTRL1_CAPEVENT_SEL_B Mask */
+#define MXC_F_TMR_REVB_CTRL1_IE_B_POS                  24 /**< CTRL1_IE_B Position */
+#define MXC_F_TMR_REVB_CTRL1_IE_B                      ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_IE_B_POS)) /**< CTRL1_IE_B Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_SW_CAPEVENT_B_POS         27 /**< CTRL1_SW_CAPEVENT_B Position */
- #define MXC_F_TMR_REVB_CTRL1_SW_CAPEVENT_B             ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_SW_CAPEVENT_B_POS)) /**< CTRL1_SW_CAPEVENT_B Mask */
+#define MXC_F_TMR_REVB_CTRL1_CAPEVENT_SEL_B_POS        25 /**< CTRL1_CAPEVENT_SEL_B Position */
+#define MXC_F_TMR_REVB_CTRL1_CAPEVENT_SEL_B            ((uint32_t)(0x3UL << MXC_F_TMR_REVB_CTRL1_CAPEVENT_SEL_B_POS)) /**< CTRL1_CAPEVENT_SEL_B Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_WE_B_POS                  28 /**< CTRL1_WE_B Position */
- #define MXC_F_TMR_REVB_CTRL1_WE_B                      ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_WE_B_POS)) /**< CTRL1_WE_B Mask */
+#define MXC_F_TMR_REVB_CTRL1_SW_CAPEVENT_B_POS         27 /**< CTRL1_SW_CAPEVENT_B Position */
+#define MXC_F_TMR_REVB_CTRL1_SW_CAPEVENT_B             ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_SW_CAPEVENT_B_POS)) /**< CTRL1_SW_CAPEVENT_B Mask */
 
- #define MXC_F_TMR_REVB_CTRL1_CASCADE_POS               31 /**< CTRL1_CASCADE Position */
- #define MXC_F_TMR_REVB_CTRL1_CASCADE                   ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_CASCADE_POS)) /**< CTRL1_CASCADE Mask */
+#define MXC_F_TMR_REVB_CTRL1_WE_B_POS                  28 /**< CTRL1_WE_B Position */
+#define MXC_F_TMR_REVB_CTRL1_WE_B                      ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_WE_B_POS)) /**< CTRL1_WE_B Mask */
+
+#define MXC_F_TMR_REVB_CTRL1_CASCADE_POS               31 /**< CTRL1_CASCADE Position */
+#define MXC_F_TMR_REVB_CTRL1_CASCADE                   ((uint32_t)(0x1UL << MXC_F_TMR_REVB_CTRL1_CASCADE_POS)) /**< CTRL1_CASCADE Mask */
 
 /**@} end of group TMR_REVB_CTRL1_Register */
 
@@ -415,11 +405,11 @@ typedef struct {
  * @brief    Timer Wakeup Status Register.
  * @{
  */
- #define MXC_F_TMR_REVB_WKFL_A_POS                      0 /**< WKFL_A Position */
- #define MXC_F_TMR_REVB_WKFL_A                          ((uint32_t)(0x1UL << MXC_F_TMR_REVB_WKFL_A_POS)) /**< WKFL_A Mask */
+#define MXC_F_TMR_REVB_WKFL_A_POS                      0 /**< WKFL_A Position */
+#define MXC_F_TMR_REVB_WKFL_A                          ((uint32_t)(0x1UL << MXC_F_TMR_REVB_WKFL_A_POS)) /**< WKFL_A Mask */
 
- #define MXC_F_TMR_REVB_WKFL_B_POS                      16 /**< WKFL_B Position */
- #define MXC_F_TMR_REVB_WKFL_B                          ((uint32_t)(0x1UL << MXC_F_TMR_REVB_WKFL_B_POS)) /**< WKFL_B Mask */
+#define MXC_F_TMR_REVB_WKFL_B_POS                      16 /**< WKFL_B Position */
+#define MXC_F_TMR_REVB_WKFL_B                          ((uint32_t)(0x1UL << MXC_F_TMR_REVB_WKFL_B_POS)) /**< WKFL_B Mask */
 
 /**@} end of group TMR_REVB_WKFL_Register */
 
@@ -427,4 +417,4 @@ typedef struct {
 }
 #endif
 
-#endif /* _TMR_REVB_REGS_H_ */
+#endif // LIBRARIES_PERIPHDRIVERS_SOURCE_TMR_TMR_REVB_REGS_H_

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb_regs.h
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb_regs.h
@@ -7,7 +7,9 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Analog Devices, Inc.),
+ * Copyright (C) 2023-2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb_regs.h
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb_regs.h
@@ -7,7 +7,9 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Analog Devices, Inc.),
+ * Copyright (C) 2023-2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb_regs.h
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb_regs.h
@@ -1,13 +1,13 @@
 /**
  * @file    uart_revb_regs.h
  * @brief   Registers, Bit Masks and Bit Positions for the UART_REVB Peripheral Module.
+ * @note    This file is @generated.
+ * @ingroup uart_revb_registers
  */
 
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
- * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2024 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@
  *
  ******************************************************************************/
 
-#ifndef _UART_REVB_REGS_H_
-#define _UART_REVB_REGS_H_
+#ifndef LIBRARIES_PERIPHDRIVERS_SOURCE_UART_UART_REVB_REGS_H_
+#define LIBRARIES_PERIPHDRIVERS_SOURCE_UART_UART_REVB_REGS_H_
 
 /* **** Includes **** */
 #include <stdint.h>
@@ -32,11 +32,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
- 
+
 #if defined (__ICCARM__)
   #pragma system_include
 #endif
- 
+
 #if defined (__CC_ARM)
   #pragma anon_unions
 #endif
@@ -48,7 +48,11 @@ extern "C" {
 #define __IO volatile
 #endif
 #ifndef __I
-#define __I  volatile const
+#ifdef __cplusplus
+#define __I volatile
+#else
+#define __I volatile const
+#endif
 #endif
 #ifndef __O
 #define __O  volatile
@@ -64,7 +68,7 @@ extern "C" {
  * @ingroup     uart_revb
  * @defgroup    uart_revb_registers UART_REVB_Registers
  * @brief       Registers, Bit Masks and Bit Positions for the UART_REVB Peripheral Module.
- * @details UART Low Power Registers
+ * @details     UART Low Power Registers
  */
 
 /**
@@ -87,102 +91,81 @@ typedef struct {
     __IO uint32_t wkfl;                 /**< <tt>\b 0x0038:</tt> UART_REVB WKFL Register */
 } mxc_uart_revb_regs_t;
 
-/* Register offsets for module UART_REVB */
-/**
- * @ingroup    uart_revb_registers
- * @defgroup   UART_REVB_Register_Offsets Register Offsets
- * @brief      UART_REVB Peripheral Register Offsets from the UART_REVB Base Peripheral Address. 
- * @{
- */
- #define MXC_R_UART_REVB_CTRL               ((uint32_t)0x00000000UL) /**< Offset from UART_REVB Base Address: <tt> 0x0000</tt> */ 
- #define MXC_R_UART_REVB_STATUS             ((uint32_t)0x00000004UL) /**< Offset from UART_REVB Base Address: <tt> 0x0004</tt> */ 
- #define MXC_R_UART_REVB_INT_EN             ((uint32_t)0x00000008UL) /**< Offset from UART_REVB Base Address: <tt> 0x0008</tt> */ 
- #define MXC_R_UART_REVB_INT_FL             ((uint32_t)0x0000000CUL) /**< Offset from UART_REVB Base Address: <tt> 0x000C</tt> */ 
- #define MXC_R_UART_REVB_CLKDIV             ((uint32_t)0x00000010UL) /**< Offset from UART_REVB Base Address: <tt> 0x0010</tt> */ 
- #define MXC_R_UART_REVB_OSR                ((uint32_t)0x00000014UL) /**< Offset from UART_REVB Base Address: <tt> 0x0014</tt> */ 
- #define MXC_R_UART_REVB_TXPEEK             ((uint32_t)0x00000018UL) /**< Offset from UART_REVB Base Address: <tt> 0x0018</tt> */ 
- #define MXC_R_UART_REVB_PNR                ((uint32_t)0x0000001CUL) /**< Offset from UART_REVB Base Address: <tt> 0x001C</tt> */ 
- #define MXC_R_UART_REVB_FIFO               ((uint32_t)0x00000020UL) /**< Offset from UART_REVB Base Address: <tt> 0x0020</tt> */ 
- #define MXC_R_UART_REVB_DMA                ((uint32_t)0x00000030UL) /**< Offset from UART_REVB Base Address: <tt> 0x0030</tt> */ 
- #define MXC_R_UART_REVB_WKEN               ((uint32_t)0x00000034UL) /**< Offset from UART_REVB Base Address: <tt> 0x0034</tt> */ 
- #define MXC_R_UART_REVB_WKFL               ((uint32_t)0x00000038UL) /**< Offset from UART_REVB Base Address: <tt> 0x0038</tt> */ 
-/**@} end of group uart_revb_registers */
-
 /**
  * @ingroup  uart_revb_registers
  * @defgroup UART_REVB_CTRL UART_REVB_CTRL
  * @brief    Control register
  * @{
  */
- #define MXC_F_UART_REVB_CTRL_RX_THD_VAL_POS            0 /**< CTRL_RX_THD_VAL Position */
- #define MXC_F_UART_REVB_CTRL_RX_THD_VAL                ((uint32_t)(0xFUL << MXC_F_UART_REVB_CTRL_RX_THD_VAL_POS)) /**< CTRL_RX_THD_VAL Mask */
+#define MXC_F_UART_REVB_CTRL_RX_THD_VAL_POS            0 /**< CTRL_RX_THD_VAL Position */
+#define MXC_F_UART_REVB_CTRL_RX_THD_VAL                ((uint32_t)(0xFUL << MXC_F_UART_REVB_CTRL_RX_THD_VAL_POS)) /**< CTRL_RX_THD_VAL Mask */
 
- #define MXC_F_UART_REVB_CTRL_PAR_EN_POS                4 /**< CTRL_PAR_EN Position */
- #define MXC_F_UART_REVB_CTRL_PAR_EN                    ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_PAR_EN_POS)) /**< CTRL_PAR_EN Mask */
+#define MXC_F_UART_REVB_CTRL_PAR_EN_POS                4 /**< CTRL_PAR_EN Position */
+#define MXC_F_UART_REVB_CTRL_PAR_EN                    ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_PAR_EN_POS)) /**< CTRL_PAR_EN Mask */
 
- #define MXC_F_UART_REVB_CTRL_PAR_EO_POS                5 /**< CTRL_PAR_EO Position */
- #define MXC_F_UART_REVB_CTRL_PAR_EO                    ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_PAR_EO_POS)) /**< CTRL_PAR_EO Mask */
+#define MXC_F_UART_REVB_CTRL_PAR_EO_POS                5 /**< CTRL_PAR_EO Position */
+#define MXC_F_UART_REVB_CTRL_PAR_EO                    ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_PAR_EO_POS)) /**< CTRL_PAR_EO Mask */
 
- #define MXC_F_UART_REVB_CTRL_PAR_MD_POS                6 /**< CTRL_PAR_MD Position */
- #define MXC_F_UART_REVB_CTRL_PAR_MD                    ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_PAR_MD_POS)) /**< CTRL_PAR_MD Mask */
+#define MXC_F_UART_REVB_CTRL_PAR_MD_POS                6 /**< CTRL_PAR_MD Position */
+#define MXC_F_UART_REVB_CTRL_PAR_MD                    ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_PAR_MD_POS)) /**< CTRL_PAR_MD Mask */
 
- #define MXC_F_UART_REVB_CTRL_CTS_DIS_POS               7 /**< CTRL_CTS_DIS Position */
- #define MXC_F_UART_REVB_CTRL_CTS_DIS                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_CTS_DIS_POS)) /**< CTRL_CTS_DIS Mask */
+#define MXC_F_UART_REVB_CTRL_CTS_DIS_POS               7 /**< CTRL_CTS_DIS Position */
+#define MXC_F_UART_REVB_CTRL_CTS_DIS                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_CTS_DIS_POS)) /**< CTRL_CTS_DIS Mask */
 
- #define MXC_F_UART_REVB_CTRL_TX_FLUSH_POS              8 /**< CTRL_TX_FLUSH Position */
- #define MXC_F_UART_REVB_CTRL_TX_FLUSH                  ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_TX_FLUSH_POS)) /**< CTRL_TX_FLUSH Mask */
+#define MXC_F_UART_REVB_CTRL_TX_FLUSH_POS              8 /**< CTRL_TX_FLUSH Position */
+#define MXC_F_UART_REVB_CTRL_TX_FLUSH                  ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_TX_FLUSH_POS)) /**< CTRL_TX_FLUSH Mask */
 
- #define MXC_F_UART_REVB_CTRL_RX_FLUSH_POS              9 /**< CTRL_RX_FLUSH Position */
- #define MXC_F_UART_REVB_CTRL_RX_FLUSH                  ((uint32_t)(0x3UL << MXC_F_UART_REVB_CTRL_RX_FLUSH_POS)) /**< CTRL_RX_FLUSH Mask */
+#define MXC_F_UART_REVB_CTRL_RX_FLUSH_POS              9 /**< CTRL_RX_FLUSH Position */
+#define MXC_F_UART_REVB_CTRL_RX_FLUSH                  ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_RX_FLUSH_POS)) /**< CTRL_RX_FLUSH Mask */
 
- #define MXC_F_UART_REVB_CTRL_CHAR_SIZE_POS             10 /**< CTRL_CHAR_SIZE Position */
- #define MXC_F_UART_REVB_CTRL_CHAR_SIZE                 ((uint32_t)(0x3UL << MXC_F_UART_REVB_CTRL_CHAR_SIZE_POS)) /**< CTRL_CHAR_SIZE Mask */
- #define MXC_V_UART_REVB_CTRL_CHAR_SIZE_5BITS           ((uint32_t)0x0UL) /**< CTRL_CHAR_SIZE_5BITS Value */
- #define MXC_S_UART_REVB_CTRL_CHAR_SIZE_5BITS           (MXC_V_UART_REVB_CTRL_CHAR_SIZE_5BITS << MXC_F_UART_REVB_CTRL_CHAR_SIZE_POS) /**< CTRL_CHAR_SIZE_5BITS Setting */
- #define MXC_V_UART_REVB_CTRL_CHAR_SIZE_6BITS           ((uint32_t)0x1UL) /**< CTRL_CHAR_SIZE_6BITS Value */
- #define MXC_S_UART_REVB_CTRL_CHAR_SIZE_6BITS           (MXC_V_UART_REVB_CTRL_CHAR_SIZE_6BITS << MXC_F_UART_REVB_CTRL_CHAR_SIZE_POS) /**< CTRL_CHAR_SIZE_6BITS Setting */
- #define MXC_V_UART_REVB_CTRL_CHAR_SIZE_7BITS           ((uint32_t)0x2UL) /**< CTRL_CHAR_SIZE_7BITS Value */
- #define MXC_S_UART_REVB_CTRL_CHAR_SIZE_7BITS           (MXC_V_UART_REVB_CTRL_CHAR_SIZE_7BITS << MXC_F_UART_REVB_CTRL_CHAR_SIZE_POS) /**< CTRL_CHAR_SIZE_7BITS Setting */
- #define MXC_V_UART_REVB_CTRL_CHAR_SIZE_8BITS           ((uint32_t)0x3UL) /**< CTRL_CHAR_SIZE_8BITS Value */
- #define MXC_S_UART_REVB_CTRL_CHAR_SIZE_8BITS           (MXC_V_UART_REVB_CTRL_CHAR_SIZE_8BITS << MXC_F_UART_REVB_CTRL_CHAR_SIZE_POS) /**< CTRL_CHAR_SIZE_8BITS Setting */
+#define MXC_F_UART_REVB_CTRL_CHAR_SIZE_POS             10 /**< CTRL_CHAR_SIZE Position */
+#define MXC_F_UART_REVB_CTRL_CHAR_SIZE                 ((uint32_t)(0x3UL << MXC_F_UART_REVB_CTRL_CHAR_SIZE_POS)) /**< CTRL_CHAR_SIZE Mask */
+#define MXC_V_UART_REVB_CTRL_CHAR_SIZE_5BITS           ((uint32_t)0x0UL) /**< CTRL_CHAR_SIZE_5BITS Value */
+#define MXC_S_UART_REVB_CTRL_CHAR_SIZE_5BITS           (MXC_V_UART_REVB_CTRL_CHAR_SIZE_5BITS << MXC_F_UART_REVB_CTRL_CHAR_SIZE_POS) /**< CTRL_CHAR_SIZE_5BITS Setting */
+#define MXC_V_UART_REVB_CTRL_CHAR_SIZE_6BITS           ((uint32_t)0x1UL) /**< CTRL_CHAR_SIZE_6BITS Value */
+#define MXC_S_UART_REVB_CTRL_CHAR_SIZE_6BITS           (MXC_V_UART_REVB_CTRL_CHAR_SIZE_6BITS << MXC_F_UART_REVB_CTRL_CHAR_SIZE_POS) /**< CTRL_CHAR_SIZE_6BITS Setting */
+#define MXC_V_UART_REVB_CTRL_CHAR_SIZE_7BITS           ((uint32_t)0x2UL) /**< CTRL_CHAR_SIZE_7BITS Value */
+#define MXC_S_UART_REVB_CTRL_CHAR_SIZE_7BITS           (MXC_V_UART_REVB_CTRL_CHAR_SIZE_7BITS << MXC_F_UART_REVB_CTRL_CHAR_SIZE_POS) /**< CTRL_CHAR_SIZE_7BITS Setting */
+#define MXC_V_UART_REVB_CTRL_CHAR_SIZE_8BITS           ((uint32_t)0x3UL) /**< CTRL_CHAR_SIZE_8BITS Value */
+#define MXC_S_UART_REVB_CTRL_CHAR_SIZE_8BITS           (MXC_V_UART_REVB_CTRL_CHAR_SIZE_8BITS << MXC_F_UART_REVB_CTRL_CHAR_SIZE_POS) /**< CTRL_CHAR_SIZE_8BITS Setting */
 
- #define MXC_F_UART_REVB_CTRL_STOPBITS_POS              12 /**< CTRL_STOPBITS Position */
- #define MXC_F_UART_REVB_CTRL_STOPBITS                  ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_STOPBITS_POS)) /**< CTRL_STOPBITS Mask */
+#define MXC_F_UART_REVB_CTRL_STOPBITS_POS              12 /**< CTRL_STOPBITS Position */
+#define MXC_F_UART_REVB_CTRL_STOPBITS                  ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_STOPBITS_POS)) /**< CTRL_STOPBITS Mask */
 
- #define MXC_F_UART_REVB_CTRL_HFC_EN_POS                13 /**< CTRL_HFC_EN Position */
- #define MXC_F_UART_REVB_CTRL_HFC_EN                    ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_HFC_EN_POS)) /**< CTRL_HFC_EN Mask */
+#define MXC_F_UART_REVB_CTRL_HFC_EN_POS                13 /**< CTRL_HFC_EN Position */
+#define MXC_F_UART_REVB_CTRL_HFC_EN                    ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_HFC_EN_POS)) /**< CTRL_HFC_EN Mask */
 
- #define MXC_F_UART_REVB_CTRL_RTSDC_POS                 14 /**< CTRL_RTSDC Position */
- #define MXC_F_UART_REVB_CTRL_RTSDC                     ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_RTSDC_POS)) /**< CTRL_RTSDC Mask */
+#define MXC_F_UART_REVB_CTRL_RTSDC_POS                 14 /**< CTRL_RTSDC Position */
+#define MXC_F_UART_REVB_CTRL_RTSDC                     ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_RTSDC_POS)) /**< CTRL_RTSDC Mask */
 
- #define MXC_F_UART_REVB_CTRL_BCLKEN_POS                15 /**< CTRL_BCLKEN Position */
- #define MXC_F_UART_REVB_CTRL_BCLKEN                    ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_BCLKEN_POS)) /**< CTRL_BCLKEN Mask */
+#define MXC_F_UART_REVB_CTRL_BCLKEN_POS                15 /**< CTRL_BCLKEN Position */
+#define MXC_F_UART_REVB_CTRL_BCLKEN                    ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_BCLKEN_POS)) /**< CTRL_BCLKEN Mask */
 
- #define MXC_F_UART_REVB_CTRL_BCLKSRC_POS               16 /**< CTRL_BCLKSRC Position */
- #define MXC_F_UART_REVB_CTRL_BCLKSRC                   ((uint32_t)(0x3UL << MXC_F_UART_REVB_CTRL_BCLKSRC_POS)) /**< CTRL_BCLKSRC Mask */
- #define MXC_V_UART_REVB_CTRL_BCLKSRC_PERIPHERAL_CLOCK  ((uint32_t)0x0UL) /**< CTRL_BCLKSRC_PERIPHERAL_CLOCK Value */
- #define MXC_S_UART_REVB_CTRL_BCLKSRC_PERIPHERAL_CLOCK  (MXC_V_UART_REVB_CTRL_BCLKSRC_PERIPHERAL_CLOCK << MXC_F_UART_REVB_CTRL_BCLKSRC_POS) /**< CTRL_BCLKSRC_PERIPHERAL_CLOCK Setting */
- #define MXC_V_UART_REVB_CTRL_BCLKSRC_CLK1              ((uint32_t)0x1UL) /**< CTRL_BCLKSRC_CLK1 Value */
- #define MXC_S_UART_REVB_CTRL_BCLKSRC_CLK1              (MXC_V_UART_REVB_CTRL_BCLKSRC_CLK1 << MXC_F_UART_REVB_CTRL_BCLKSRC_POS) /**< CTRL_BCLKSRC_CLK1 Setting */
- #define MXC_V_UART_REVB_CTRL_BCLKSRC_CLK2              ((uint32_t)0x2UL) /**< CTRL_BCLKSRC_CLK2 Value */
- #define MXC_S_UART_REVB_CTRL_BCLKSRC_CLK2              (MXC_V_UART_REVB_CTRL_BCLKSRC_CLK2 << MXC_F_UART_REVB_CTRL_BCLKSRC_POS) /**< CTRL_BCLKSRC_CLK2 Setting */
- #define MXC_V_UART_REVB_CTRL_BCLKSRC_CLK3              ((uint32_t)0x3UL) /**< CTRL_BCLKSRC_CLK3 Value */
- #define MXC_S_UART_REVB_CTRL_BCLKSRC_CLK3              (MXC_V_UART_REVB_CTRL_BCLKSRC_CLK3 << MXC_F_UART_REVB_CTRL_BCLKSRC_POS) /**< CTRL_BCLKSRC_CLK3 Setting */
+#define MXC_F_UART_REVB_CTRL_BCLKSRC_POS               16 /**< CTRL_BCLKSRC Position */
+#define MXC_F_UART_REVB_CTRL_BCLKSRC                   ((uint32_t)(0x3UL << MXC_F_UART_REVB_CTRL_BCLKSRC_POS)) /**< CTRL_BCLKSRC Mask */
+#define MXC_V_UART_REVB_CTRL_BCLKSRC_PERIPHERAL_CLOCK  ((uint32_t)0x0UL) /**< CTRL_BCLKSRC_PERIPHERAL_CLOCK Value */
+#define MXC_S_UART_REVB_CTRL_BCLKSRC_PERIPHERAL_CLOCK  (MXC_V_UART_REVB_CTRL_BCLKSRC_PERIPHERAL_CLOCK << MXC_F_UART_REVB_CTRL_BCLKSRC_POS) /**< CTRL_BCLKSRC_PERIPHERAL_CLOCK Setting */
+#define MXC_V_UART_REVB_CTRL_BCLKSRC_CLK1              ((uint32_t)0x1UL) /**< CTRL_BCLKSRC_CLK1 Value */
+#define MXC_S_UART_REVB_CTRL_BCLKSRC_CLK1              (MXC_V_UART_REVB_CTRL_BCLKSRC_CLK1 << MXC_F_UART_REVB_CTRL_BCLKSRC_POS) /**< CTRL_BCLKSRC_CLK1 Setting */
+#define MXC_V_UART_REVB_CTRL_BCLKSRC_CLK2              ((uint32_t)0x2UL) /**< CTRL_BCLKSRC_CLK2 Value */
+#define MXC_S_UART_REVB_CTRL_BCLKSRC_CLK2              (MXC_V_UART_REVB_CTRL_BCLKSRC_CLK2 << MXC_F_UART_REVB_CTRL_BCLKSRC_POS) /**< CTRL_BCLKSRC_CLK2 Setting */
+#define MXC_V_UART_REVB_CTRL_BCLKSRC_CLK3              ((uint32_t)0x3UL) /**< CTRL_BCLKSRC_CLK3 Value */
+#define MXC_S_UART_REVB_CTRL_BCLKSRC_CLK3              (MXC_V_UART_REVB_CTRL_BCLKSRC_CLK3 << MXC_F_UART_REVB_CTRL_BCLKSRC_POS) /**< CTRL_BCLKSRC_CLK3 Setting */
 
- #define MXC_F_UART_REVB_CTRL_DPFE_EN_POS               18 /**< CTRL_DPFE_EN Position */
- #define MXC_F_UART_REVB_CTRL_DPFE_EN                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_DPFE_EN_POS)) /**< CTRL_DPFE_EN Mask */
+#define MXC_F_UART_REVB_CTRL_DPFE_EN_POS               18 /**< CTRL_DPFE_EN Position */
+#define MXC_F_UART_REVB_CTRL_DPFE_EN                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_DPFE_EN_POS)) /**< CTRL_DPFE_EN Mask */
 
- #define MXC_F_UART_REVB_CTRL_BCLKRDY_POS               19 /**< CTRL_BCLKRDY Position */
- #define MXC_F_UART_REVB_CTRL_BCLKRDY                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_BCLKRDY_POS)) /**< CTRL_BCLKRDY Mask */
+#define MXC_F_UART_REVB_CTRL_BCLKRDY_POS               19 /**< CTRL_BCLKRDY Position */
+#define MXC_F_UART_REVB_CTRL_BCLKRDY                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_BCLKRDY_POS)) /**< CTRL_BCLKRDY Mask */
 
- #define MXC_F_UART_REVB_CTRL_UCAGM_POS                 20 /**< CTRL_UCAGM Position */
- #define MXC_F_UART_REVB_CTRL_UCAGM                     ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_UCAGM_POS)) /**< CTRL_UCAGM Mask */
+#define MXC_F_UART_REVB_CTRL_UCAGM_POS                 20 /**< CTRL_UCAGM Position */
+#define MXC_F_UART_REVB_CTRL_UCAGM                     ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_UCAGM_POS)) /**< CTRL_UCAGM Mask */
 
- #define MXC_F_UART_REVB_CTRL_FDM_POS                   21 /**< CTRL_FDM Position */
- #define MXC_F_UART_REVB_CTRL_FDM                       ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_FDM_POS)) /**< CTRL_FDM Mask */
+#define MXC_F_UART_REVB_CTRL_FDM_POS                   21 /**< CTRL_FDM Position */
+#define MXC_F_UART_REVB_CTRL_FDM                       ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_FDM_POS)) /**< CTRL_FDM Mask */
 
- #define MXC_F_UART_REVB_CTRL_DESM_POS                  22 /**< CTRL_DESM Position */
- #define MXC_F_UART_REVB_CTRL_DESM                      ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_DESM_POS)) /**< CTRL_DESM Mask */
+#define MXC_F_UART_REVB_CTRL_DESM_POS                  22 /**< CTRL_DESM Position */
+#define MXC_F_UART_REVB_CTRL_DESM                      ((uint32_t)(0x1UL << MXC_F_UART_REVB_CTRL_DESM_POS)) /**< CTRL_DESM Mask */
 
 /**@} end of group UART_REVB_CTRL_Register */
 
@@ -192,29 +175,29 @@ typedef struct {
  * @brief    Status register
  * @{
  */
- #define MXC_F_UART_REVB_STATUS_TX_BUSY_POS             0 /**< STATUS_TX_BUSY Position */
- #define MXC_F_UART_REVB_STATUS_TX_BUSY                 ((uint32_t)(0x1UL << MXC_F_UART_REVB_STATUS_TX_BUSY_POS)) /**< STATUS_TX_BUSY Mask */
+#define MXC_F_UART_REVB_STATUS_TX_BUSY_POS             0 /**< STATUS_TX_BUSY Position */
+#define MXC_F_UART_REVB_STATUS_TX_BUSY                 ((uint32_t)(0x1UL << MXC_F_UART_REVB_STATUS_TX_BUSY_POS)) /**< STATUS_TX_BUSY Mask */
 
- #define MXC_F_UART_REVB_STATUS_RX_BUSY_POS             1 /**< STATUS_RX_BUSY Position */
- #define MXC_F_UART_REVB_STATUS_RX_BUSY                 ((uint32_t)(0x1UL << MXC_F_UART_REVB_STATUS_RX_BUSY_POS)) /**< STATUS_RX_BUSY Mask */
+#define MXC_F_UART_REVB_STATUS_RX_BUSY_POS             1 /**< STATUS_RX_BUSY Position */
+#define MXC_F_UART_REVB_STATUS_RX_BUSY                 ((uint32_t)(0x1UL << MXC_F_UART_REVB_STATUS_RX_BUSY_POS)) /**< STATUS_RX_BUSY Mask */
 
- #define MXC_F_UART_REVB_STATUS_RX_EM_POS               4 /**< STATUS_RX_EM Position */
- #define MXC_F_UART_REVB_STATUS_RX_EM                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_STATUS_RX_EM_POS)) /**< STATUS_RX_EM Mask */
+#define MXC_F_UART_REVB_STATUS_RX_EM_POS               4 /**< STATUS_RX_EM Position */
+#define MXC_F_UART_REVB_STATUS_RX_EM                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_STATUS_RX_EM_POS)) /**< STATUS_RX_EM Mask */
 
- #define MXC_F_UART_REVB_STATUS_RX_FULL_POS             5 /**< STATUS_RX_FULL Position */
- #define MXC_F_UART_REVB_STATUS_RX_FULL                 ((uint32_t)(0x1UL << MXC_F_UART_REVB_STATUS_RX_FULL_POS)) /**< STATUS_RX_FULL Mask */
+#define MXC_F_UART_REVB_STATUS_RX_FULL_POS             5 /**< STATUS_RX_FULL Position */
+#define MXC_F_UART_REVB_STATUS_RX_FULL                 ((uint32_t)(0x1UL << MXC_F_UART_REVB_STATUS_RX_FULL_POS)) /**< STATUS_RX_FULL Mask */
 
- #define MXC_F_UART_REVB_STATUS_TX_EM_POS               6 /**< STATUS_TX_EM Position */
- #define MXC_F_UART_REVB_STATUS_TX_EM                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_STATUS_TX_EM_POS)) /**< STATUS_TX_EM Mask */
+#define MXC_F_UART_REVB_STATUS_TX_EM_POS               6 /**< STATUS_TX_EM Position */
+#define MXC_F_UART_REVB_STATUS_TX_EM                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_STATUS_TX_EM_POS)) /**< STATUS_TX_EM Mask */
 
- #define MXC_F_UART_REVB_STATUS_TX_FULL_POS             7 /**< STATUS_TX_FULL Position */
- #define MXC_F_UART_REVB_STATUS_TX_FULL                 ((uint32_t)(0x1UL << MXC_F_UART_REVB_STATUS_TX_FULL_POS)) /**< STATUS_TX_FULL Mask */
+#define MXC_F_UART_REVB_STATUS_TX_FULL_POS             7 /**< STATUS_TX_FULL Position */
+#define MXC_F_UART_REVB_STATUS_TX_FULL                 ((uint32_t)(0x1UL << MXC_F_UART_REVB_STATUS_TX_FULL_POS)) /**< STATUS_TX_FULL Mask */
 
- #define MXC_F_UART_REVB_STATUS_RX_LVL_POS              8 /**< STATUS_RX_LVL Position */
- #define MXC_F_UART_REVB_STATUS_RX_LVL                  ((uint32_t)(0xFUL << MXC_F_UART_REVB_STATUS_RX_LVL_POS)) /**< STATUS_RX_LVL Mask */
+#define MXC_F_UART_REVB_STATUS_RX_LVL_POS              8 /**< STATUS_RX_LVL Position */
+#define MXC_F_UART_REVB_STATUS_RX_LVL                  ((uint32_t)(0xFUL << MXC_F_UART_REVB_STATUS_RX_LVL_POS)) /**< STATUS_RX_LVL Mask */
 
- #define MXC_F_UART_REVB_STATUS_TX_LVL_POS              12 /**< STATUS_TX_LVL Position */
- #define MXC_F_UART_REVB_STATUS_TX_LVL                  ((uint32_t)(0xFUL << MXC_F_UART_REVB_STATUS_TX_LVL_POS)) /**< STATUS_TX_LVL Mask */
+#define MXC_F_UART_REVB_STATUS_TX_LVL_POS              12 /**< STATUS_TX_LVL Position */
+#define MXC_F_UART_REVB_STATUS_TX_LVL                  ((uint32_t)(0xFUL << MXC_F_UART_REVB_STATUS_TX_LVL_POS)) /**< STATUS_TX_LVL Mask */
 
 /**@} end of group UART_REVB_STATUS_Register */
 
@@ -224,23 +207,26 @@ typedef struct {
  * @brief    Interrupt Enable control register
  * @{
  */
- #define MXC_F_UART_REVB_INT_EN_RX_FERR_POS             0 /**< INT_EN_RX_FERR Position */
- #define MXC_F_UART_REVB_INT_EN_RX_FERR                 ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_EN_RX_FERR_POS)) /**< INT_EN_RX_FERR Mask */
+#define MXC_F_UART_REVB_INT_EN_RX_FERR_POS             0 /**< INT_EN_RX_FERR Position */
+#define MXC_F_UART_REVB_INT_EN_RX_FERR                 ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_EN_RX_FERR_POS)) /**< INT_EN_RX_FERR Mask */
 
- #define MXC_F_UART_REVB_INT_EN_RX_PAR_POS              1 /**< INT_EN_RX_PAR Position */
- #define MXC_F_UART_REVB_INT_EN_RX_PAR                  ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_EN_RX_PAR_POS)) /**< INT_EN_RX_PAR Mask */
+#define MXC_F_UART_REVB_INT_EN_RX_PAR_POS              1 /**< INT_EN_RX_PAR Position */
+#define MXC_F_UART_REVB_INT_EN_RX_PAR                  ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_EN_RX_PAR_POS)) /**< INT_EN_RX_PAR Mask */
 
- #define MXC_F_UART_REVB_INT_EN_CTS_EV_POS              2 /**< INT_EN_CTS_EV Position */
- #define MXC_F_UART_REVB_INT_EN_CTS_EV                  ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_EN_CTS_EV_POS)) /**< INT_EN_CTS_EV Mask */
+#define MXC_F_UART_REVB_INT_EN_CTS_EV_POS              2 /**< INT_EN_CTS_EV Position */
+#define MXC_F_UART_REVB_INT_EN_CTS_EV                  ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_EN_CTS_EV_POS)) /**< INT_EN_CTS_EV Mask */
 
- #define MXC_F_UART_REVB_INT_EN_RX_OV_POS               3 /**< INT_EN_RX_OV Position */
- #define MXC_F_UART_REVB_INT_EN_RX_OV                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_EN_RX_OV_POS)) /**< INT_EN_RX_OV Mask */
+#define MXC_F_UART_REVB_INT_EN_RX_OV_POS               3 /**< INT_EN_RX_OV Position */
+#define MXC_F_UART_REVB_INT_EN_RX_OV                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_EN_RX_OV_POS)) /**< INT_EN_RX_OV Mask */
 
- #define MXC_F_UART_REVB_INT_EN_RX_THD_POS              4 /**< INT_EN_RX_THD Position */
- #define MXC_F_UART_REVB_INT_EN_RX_THD                  ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_EN_RX_THD_POS)) /**< INT_EN_RX_THD Mask */
+#define MXC_F_UART_REVB_INT_EN_RX_THD_POS              4 /**< INT_EN_RX_THD Position */
+#define MXC_F_UART_REVB_INT_EN_RX_THD                  ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_EN_RX_THD_POS)) /**< INT_EN_RX_THD Mask */
 
- #define MXC_F_UART_REVB_INT_EN_TX_HE_POS               6 /**< INT_EN_TX_HE Position */
- #define MXC_F_UART_REVB_INT_EN_TX_HE                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_EN_TX_HE_POS)) /**< INT_EN_TX_HE Mask */
+#define MXC_F_UART_REVB_INT_EN_TX_OB_POS               5 /**< INT_EN_TX_OB Position */
+#define MXC_F_UART_REVB_INT_EN_TX_OB                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_EN_TX_OB_POS)) /**< INT_EN_TX_OB Mask */
+
+#define MXC_F_UART_REVB_INT_EN_TX_HE_POS               6 /**< INT_EN_TX_HE Position */
+#define MXC_F_UART_REVB_INT_EN_TX_HE                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_EN_TX_HE_POS)) /**< INT_EN_TX_HE Mask */
 
 /**@} end of group UART_REVB_INT_EN_Register */
 
@@ -250,23 +236,26 @@ typedef struct {
  * @brief    Interrupt status flags Control register
  * @{
  */
- #define MXC_F_UART_REVB_INT_FL_RX_FERR_POS             0 /**< INT_FL_RX_FERR Position */
- #define MXC_F_UART_REVB_INT_FL_RX_FERR                 ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_FL_RX_FERR_POS)) /**< INT_FL_RX_FERR Mask */
+#define MXC_F_UART_REVB_INT_FL_RX_FERR_POS             0 /**< INT_FL_RX_FERR Position */
+#define MXC_F_UART_REVB_INT_FL_RX_FERR                 ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_FL_RX_FERR_POS)) /**< INT_FL_RX_FERR Mask */
 
- #define MXC_F_UART_REVB_INT_FL_RX_PAR_POS              1 /**< INT_FL_RX_PAR Position */
- #define MXC_F_UART_REVB_INT_FL_RX_PAR                  ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_FL_RX_PAR_POS)) /**< INT_FL_RX_PAR Mask */
+#define MXC_F_UART_REVB_INT_FL_RX_PAR_POS              1 /**< INT_FL_RX_PAR Position */
+#define MXC_F_UART_REVB_INT_FL_RX_PAR                  ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_FL_RX_PAR_POS)) /**< INT_FL_RX_PAR Mask */
 
- #define MXC_F_UART_REVB_INT_FL_CTS_EV_POS              2 /**< INT_FL_CTS_EV Position */
- #define MXC_F_UART_REVB_INT_FL_CTS_EV                  ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_FL_CTS_EV_POS)) /**< INT_FL_CTS_EV Mask */
+#define MXC_F_UART_REVB_INT_FL_CTS_EV_POS              2 /**< INT_FL_CTS_EV Position */
+#define MXC_F_UART_REVB_INT_FL_CTS_EV                  ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_FL_CTS_EV_POS)) /**< INT_FL_CTS_EV Mask */
 
- #define MXC_F_UART_REVB_INT_FL_RX_OV_POS               3 /**< INT_FL_RX_OV Position */
- #define MXC_F_UART_REVB_INT_FL_RX_OV                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_FL_RX_OV_POS)) /**< INT_FL_RX_OV Mask */
+#define MXC_F_UART_REVB_INT_FL_RX_OV_POS               3 /**< INT_FL_RX_OV Position */
+#define MXC_F_UART_REVB_INT_FL_RX_OV                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_FL_RX_OV_POS)) /**< INT_FL_RX_OV Mask */
 
- #define MXC_F_UART_REVB_INT_FL_RX_THD_POS              4 /**< INT_FL_RX_THD Position */
- #define MXC_F_UART_REVB_INT_FL_RX_THD                  ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_FL_RX_THD_POS)) /**< INT_FL_RX_THD Mask */
+#define MXC_F_UART_REVB_INT_FL_RX_THD_POS              4 /**< INT_FL_RX_THD Position */
+#define MXC_F_UART_REVB_INT_FL_RX_THD                  ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_FL_RX_THD_POS)) /**< INT_FL_RX_THD Mask */
 
- #define MXC_F_UART_REVB_INT_FL_TX_HE_POS               6 /**< INT_FL_TX_HE Position */
- #define MXC_F_UART_REVB_INT_FL_TX_HE                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_FL_TX_HE_POS)) /**< INT_FL_TX_HE Mask */
+#define MXC_F_UART_REVB_INT_FL_TX_OB_POS               5 /**< INT_FL_TX_OB Position */
+#define MXC_F_UART_REVB_INT_FL_TX_OB                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_FL_TX_OB_POS)) /**< INT_FL_TX_OB Mask */
+
+#define MXC_F_UART_REVB_INT_FL_TX_HE_POS               6 /**< INT_FL_TX_HE Position */
+#define MXC_F_UART_REVB_INT_FL_TX_HE                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_INT_FL_TX_HE_POS)) /**< INT_FL_TX_HE Mask */
 
 /**@} end of group UART_REVB_INT_FL_Register */
 
@@ -276,8 +265,8 @@ typedef struct {
  * @brief    Clock Divider register
  * @{
  */
- #define MXC_F_UART_REVB_CLKDIV_CLKDIV_POS              0 /**< CLKDIV_CLKDIV Position */
- #define MXC_F_UART_REVB_CLKDIV_CLKDIV                  ((uint32_t)(0xFFFFFUL << MXC_F_UART_REVB_CLKDIV_CLKDIV_POS)) /**< CLKDIV_CLKDIV Mask */
+#define MXC_F_UART_REVB_CLKDIV_CLKDIV_POS              0 /**< CLKDIV_CLKDIV Position */
+#define MXC_F_UART_REVB_CLKDIV_CLKDIV                  ((uint32_t)(0xFFFFFUL << MXC_F_UART_REVB_CLKDIV_CLKDIV_POS)) /**< CLKDIV_CLKDIV Mask */
 
 /**@} end of group UART_REVB_CLKDIV_Register */
 
@@ -287,8 +276,8 @@ typedef struct {
  * @brief    Over Sampling Rate register
  * @{
  */
- #define MXC_F_UART_REVB_OSR_OSR_POS                    0 /**< OSR_OSR Position */
- #define MXC_F_UART_REVB_OSR_OSR                        ((uint32_t)(0x7UL << MXC_F_UART_REVB_OSR_OSR_POS)) /**< OSR_OSR Mask */
+#define MXC_F_UART_REVB_OSR_OSR_POS                    0 /**< OSR_OSR Position */
+#define MXC_F_UART_REVB_OSR_OSR                        ((uint32_t)(0x7UL << MXC_F_UART_REVB_OSR_OSR_POS)) /**< OSR_OSR Mask */
 
 /**@} end of group UART_REVB_OSR_Register */
 
@@ -298,8 +287,8 @@ typedef struct {
  * @brief    TX FIFO Output Peek register
  * @{
  */
- #define MXC_F_UART_REVB_TXPEEK_DATA_POS                0 /**< TXPEEK_DATA Position */
- #define MXC_F_UART_REVB_TXPEEK_DATA                    ((uint32_t)(0xFFUL << MXC_F_UART_REVB_TXPEEK_DATA_POS)) /**< TXPEEK_DATA Mask */
+#define MXC_F_UART_REVB_TXPEEK_DATA_POS                0 /**< TXPEEK_DATA Position */
+#define MXC_F_UART_REVB_TXPEEK_DATA                    ((uint32_t)(0xFFUL << MXC_F_UART_REVB_TXPEEK_DATA_POS)) /**< TXPEEK_DATA Mask */
 
 /**@} end of group UART_REVB_TXPEEK_Register */
 
@@ -309,11 +298,11 @@ typedef struct {
  * @brief     Pin register
  * @{
  */
- #define MXC_F_UART_REVB_PNR_CTS_POS                    0 /**< PNR_CTS Position */
- #define MXC_F_UART_REVB_PNR_CTS                        ((uint32_t)(0x1UL << MXC_F_UART_REVB_PNR_CTS_POS)) /**< PNR_CTS Mask */
+#define MXC_F_UART_REVB_PNR_CTS_POS                    0 /**< PNR_CTS Position */
+#define MXC_F_UART_REVB_PNR_CTS                        ((uint32_t)(0x1UL << MXC_F_UART_REVB_PNR_CTS_POS)) /**< PNR_CTS Mask */
 
- #define MXC_F_UART_REVB_PNR_RTS_POS                    1 /**< PNR_RTS Position */
- #define MXC_F_UART_REVB_PNR_RTS                        ((uint32_t)(0x1UL << MXC_F_UART_REVB_PNR_RTS_POS)) /**< PNR_RTS Mask */
+#define MXC_F_UART_REVB_PNR_RTS_POS                    1 /**< PNR_RTS Position */
+#define MXC_F_UART_REVB_PNR_RTS                        ((uint32_t)(0x1UL << MXC_F_UART_REVB_PNR_RTS_POS)) /**< PNR_RTS Mask */
 
 /**@} end of group UART_REVB_PNR_Register */
 
@@ -323,11 +312,11 @@ typedef struct {
  * @brief    FIFO Read/Write register
  * @{
  */
- #define MXC_F_UART_REVB_FIFO_DATA_POS                  0 /**< FIFO_DATA Position */
- #define MXC_F_UART_REVB_FIFO_DATA                      ((uint32_t)(0xFFUL << MXC_F_UART_REVB_FIFO_DATA_POS)) /**< FIFO_DATA Mask */
+#define MXC_F_UART_REVB_FIFO_DATA_POS                  0 /**< FIFO_DATA Position */
+#define MXC_F_UART_REVB_FIFO_DATA                      ((uint32_t)(0xFFUL << MXC_F_UART_REVB_FIFO_DATA_POS)) /**< FIFO_DATA Mask */
 
- #define MXC_F_UART_REVB_FIFO_RX_PAR_POS                8 /**< FIFO_RX_PAR Position */
- #define MXC_F_UART_REVB_FIFO_RX_PAR                    ((uint32_t)(0x1UL << MXC_F_UART_REVB_FIFO_RX_PAR_POS)) /**< FIFO_RX_PAR Mask */
+#define MXC_F_UART_REVB_FIFO_RX_PAR_POS                8 /**< FIFO_RX_PAR Position */
+#define MXC_F_UART_REVB_FIFO_RX_PAR                    ((uint32_t)(0x1UL << MXC_F_UART_REVB_FIFO_RX_PAR_POS)) /**< FIFO_RX_PAR Mask */
 
 /**@} end of group UART_REVB_FIFO_Register */
 
@@ -337,17 +326,17 @@ typedef struct {
  * @brief    DMA Configuration register
  * @{
  */
- #define MXC_F_UART_REVB_DMA_TX_THD_VAL_POS             0 /**< DMA_TX_THD_VAL Position */
- #define MXC_F_UART_REVB_DMA_TX_THD_VAL                 ((uint32_t)(0xFUL << MXC_F_UART_REVB_DMA_TX_THD_VAL_POS)) /**< DMA_TX_THD_VAL Mask */
+#define MXC_F_UART_REVB_DMA_TX_THD_VAL_POS             0 /**< DMA_TX_THD_VAL Position */
+#define MXC_F_UART_REVB_DMA_TX_THD_VAL                 ((uint32_t)(0xFUL << MXC_F_UART_REVB_DMA_TX_THD_VAL_POS)) /**< DMA_TX_THD_VAL Mask */
 
- #define MXC_F_UART_REVB_DMA_TX_EN_POS                  4 /**< DMA_TX_EN Position */
- #define MXC_F_UART_REVB_DMA_TX_EN                      ((uint32_t)(0x1UL << MXC_F_UART_REVB_DMA_TX_EN_POS)) /**< DMA_TX_EN Mask */
+#define MXC_F_UART_REVB_DMA_TX_EN_POS                  4 /**< DMA_TX_EN Position */
+#define MXC_F_UART_REVB_DMA_TX_EN                      ((uint32_t)(0x1UL << MXC_F_UART_REVB_DMA_TX_EN_POS)) /**< DMA_TX_EN Mask */
 
- #define MXC_F_UART_REVB_DMA_RX_THD_VAL_POS             5 /**< DMA_RX_THD_VAL Position */
- #define MXC_F_UART_REVB_DMA_RX_THD_VAL                 ((uint32_t)(0xFUL << MXC_F_UART_REVB_DMA_RX_THD_VAL_POS)) /**< DMA_RX_THD_VAL Mask */
+#define MXC_F_UART_REVB_DMA_RX_THD_VAL_POS             5 /**< DMA_RX_THD_VAL Position */
+#define MXC_F_UART_REVB_DMA_RX_THD_VAL                 ((uint32_t)(0xFUL << MXC_F_UART_REVB_DMA_RX_THD_VAL_POS)) /**< DMA_RX_THD_VAL Mask */
 
- #define MXC_F_UART_REVB_DMA_RX_EN_POS                  9 /**< DMA_RX_EN Position */
- #define MXC_F_UART_REVB_DMA_RX_EN                      ((uint32_t)(0x1UL << MXC_F_UART_REVB_DMA_RX_EN_POS)) /**< DMA_RX_EN Mask */
+#define MXC_F_UART_REVB_DMA_RX_EN_POS                  9 /**< DMA_RX_EN Position */
+#define MXC_F_UART_REVB_DMA_RX_EN                      ((uint32_t)(0x1UL << MXC_F_UART_REVB_DMA_RX_EN_POS)) /**< DMA_RX_EN Mask */
 
 /**@} end of group UART_REVB_DMA_Register */
 
@@ -357,14 +346,14 @@ typedef struct {
  * @brief    Wake up enable Control register
  * @{
  */
- #define MXC_F_UART_REVB_WKEN_RX_NE_POS                 0 /**< WKEN_RX_NE Position */
- #define MXC_F_UART_REVB_WKEN_RX_NE                     ((uint32_t)(0x1UL << MXC_F_UART_REVB_WKEN_RX_NE_POS)) /**< WKEN_RX_NE Mask */
+#define MXC_F_UART_REVB_WKEN_RX_NE_POS                 0 /**< WKEN_RX_NE Position */
+#define MXC_F_UART_REVB_WKEN_RX_NE                     ((uint32_t)(0x1UL << MXC_F_UART_REVB_WKEN_RX_NE_POS)) /**< WKEN_RX_NE Mask */
 
- #define MXC_F_UART_REVB_WKEN_RX_FULL_POS               1 /**< WKEN_RX_FULL Position */
- #define MXC_F_UART_REVB_WKEN_RX_FULL                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_WKEN_RX_FULL_POS)) /**< WKEN_RX_FULL Mask */
+#define MXC_F_UART_REVB_WKEN_RX_FULL_POS               1 /**< WKEN_RX_FULL Position */
+#define MXC_F_UART_REVB_WKEN_RX_FULL                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_WKEN_RX_FULL_POS)) /**< WKEN_RX_FULL Mask */
 
- #define MXC_F_UART_REVB_WKEN_RX_THD_POS                1 /**< WKEN_RX_THD Position */
- #define MXC_F_UART_REVB_WKEN_RX_THD                    ((uint32_t)(0x3UL << MXC_F_UART_REVB_WKEN_RX_THD_POS)) /**< WKEN_RX_THD Mask */
+#define MXC_F_UART_REVB_WKEN_RX_THD_POS                2 /**< WKEN_RX_THD Position */
+#define MXC_F_UART_REVB_WKEN_RX_THD                    ((uint32_t)(0x1UL << MXC_F_UART_REVB_WKEN_RX_THD_POS)) /**< WKEN_RX_THD Mask */
 
 /**@} end of group UART_REVB_WKEN_Register */
 
@@ -374,14 +363,14 @@ typedef struct {
  * @brief    Wake up Flags register
  * @{
  */
- #define MXC_F_UART_REVB_WKFL_RX_NE_POS                 0 /**< WKFL_RX_NE Position */
- #define MXC_F_UART_REVB_WKFL_RX_NE                     ((uint32_t)(0x1UL << MXC_F_UART_REVB_WKFL_RX_NE_POS)) /**< WKFL_RX_NE Mask */
+#define MXC_F_UART_REVB_WKFL_RX_NE_POS                 0 /**< WKFL_RX_NE Position */
+#define MXC_F_UART_REVB_WKFL_RX_NE                     ((uint32_t)(0x1UL << MXC_F_UART_REVB_WKFL_RX_NE_POS)) /**< WKFL_RX_NE Mask */
 
- #define MXC_F_UART_REVB_WKFL_RX_FULL_POS               1 /**< WKFL_RX_FULL Position */
- #define MXC_F_UART_REVB_WKFL_RX_FULL                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_WKFL_RX_FULL_POS)) /**< WKFL_RX_FULL Mask */
+#define MXC_F_UART_REVB_WKFL_RX_FULL_POS               1 /**< WKFL_RX_FULL Position */
+#define MXC_F_UART_REVB_WKFL_RX_FULL                   ((uint32_t)(0x1UL << MXC_F_UART_REVB_WKFL_RX_FULL_POS)) /**< WKFL_RX_FULL Mask */
 
- #define MXC_F_UART_REVB_WKFL_RX_THD_POS                2 /**< WKFL_RX_THD Position */
- #define MXC_F_UART_REVB_WKFL_RX_THD                    ((uint32_t)(0x1UL << MXC_F_UART_REVB_WKFL_RX_THD_POS)) /**< WKFL_RX_THD Mask */
+#define MXC_F_UART_REVB_WKFL_RX_THD_POS                2 /**< WKFL_RX_THD Position */
+#define MXC_F_UART_REVB_WKFL_RX_THD                    ((uint32_t)(0x1UL << MXC_F_UART_REVB_WKFL_RX_THD_POS)) /**< WKFL_RX_THD Mask */
 
 /**@} end of group UART_REVB_WKFL_Register */
 
@@ -389,4 +378,4 @@ typedef struct {
 }
 #endif
 
-#endif /* _UART_REVB_REGS_H_ */
+#endif // LIBRARIES_PERIPHDRIVERS_SOURCE_UART_UART_REVB_REGS_H_


### PR DESCRIPTION
### Description

This PR adds the missing TMR register field `TMRn_CTRL1.async[15]` which allows asynchronous reads to the TMR PWM and CNT registers. Only the parts with the TMR RevB IP are affected by this change.

Also regenerated the UART RevB register file to include the new UART one byte remaining interrupt.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.