### PR TITLE
feat(CMSIS,PeriphDrivers): Enable external clock selection on MAX32657

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/system_max32657.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/system_max32657.h
@@ -38,7 +38,7 @@ extern "C" {
          Update if use of this oscillator requires precise timing.*/
 /* NOTE: INRO was previously named NANORING */
 #ifndef INRO_FREQ
-#define INRO_FREQ 100000
+#define INRO_FREQ 131000
 #endif
 
 #ifndef IPO_FREQ

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Source/system_max32657.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Source/system_max32657.c
@@ -80,10 +80,9 @@ __weak void SystemCoreClockUpdate(void)
     case MXC_S_GCR_CLKCTRL_SYSCLK_SEL_ERTCO:
         base_freq = ERTCO_FREQ;
         break;
-    // case MXC_S_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK:
-    //     base_freq = EXTCLK_FREQ;
-    //     break;
-    // TODO(JC): ^^^ Uncomment when EXTCLK register definition is added
+    case MXC_S_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK:
+        base_freq = EXTCLK_FREQ;
+        break;
     default:
         // Codes 001 and 111 are reserved.
         // This code should never execute, however, initialize to safe value.

--- a/Libraries/PeriphDrivers/Include/MAX32657/mxc_pins.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/mxc_pins.h
@@ -28,6 +28,7 @@
 
 /***** Global Variables *****/
 // Predefined GPIO Configurations
+extern const mxc_gpio_cfg_t gpio_cfg_extclk;
 extern const mxc_gpio_cfg_t gpio_cfg_i3c;
 
 extern const mxc_gpio_cfg_t gpio_cfg_uart;

--- a/Libraries/PeriphDrivers/Include/MAX32657/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/mxc_sys.h
@@ -99,9 +99,8 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_INRO, /**< Select the Internal Nanoring Oscillator (INRO) */
     MXC_SYS_CLOCK_ERTCO =
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_ERTCO, /**< Select the External RTC Crystal Oscillator */
-    // MXC_SYS_CLOCK_EXTCLK =
-    //     MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Use the external system clock input */
-    // TODO(JC): ^^^ EXTCLK select is missing from gcr_regs.h (should be 0x7)
+    MXC_SYS_CLOCK_EXTCLK =
+        MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Use the external system clock input */
 } mxc_sys_system_clock_t;
 
 /** @brief Enumeration to set the System Clock divider */

--- a/Libraries/PeriphDrivers/Source/SYS/pins_me30.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_me30.c
@@ -24,6 +24,9 @@
 /***** Global Variables *****/
 
 // clang-format off
+const mxc_gpio_cfg_t gpio_cfg_extclk = { MXC_GPIO0, (MXC_GPIO_PIN_7), MXC_GPIO_FUNC_IN,
+                                         MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+
 // P0.0 - I3C SCL
 // P0.1 - I3C SDA
 const mxc_gpio_cfg_t gpio_cfg_i3c = { MXC_GPIO0, (MXC_GPIO_PIN_0 | MXC_GPIO_PIN_1), MXC_GPIO_FUNC_ALT1,

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me30.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me30.c
@@ -301,7 +301,7 @@ int MXC_SYS_ClockSourceDisable(mxc_sys_system_clock_t clock)
         break;
 
     case MXC_SYS_CLOCK_INRO:
-        // The 80k clock is always enabled
+        // The 131k clock is always enabled
         break;
 
     case MXC_SYS_CLOCK_ERFO:

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me30.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me30.c
@@ -226,11 +226,10 @@ int MXC_SYS_ClockSourceEnable(mxc_sys_system_clock_t clock)
         return MXC_SYS_Clock_Timeout(MXC_F_GCR_CLKCTRL_IBRO_RDY);
         break;
 
-        // TODO(ME30): EXTCLK is missing from register definitions
-        // case MXC_SYS_CLOCK_EXTCLK:
-        //     // No "RDY" bit to monitor, so just configure the GPIO
-        //     return MXC_GPIO_Config(&gpio_cfg_extclk);
-        //     break;
+    case MXC_SYS_CLOCK_EXTCLK:
+        // No "RDY" bit to monitor, so just configure the GPIO
+        return MXC_GPIO_Config(&gpio_cfg_extclk);
+        break;
 
     case MXC_SYS_CLOCK_INRO:
         // The 80k clock is always enabled
@@ -291,16 +290,15 @@ int MXC_SYS_ClockSourceDisable(mxc_sys_system_clock_t clock)
         MXC_GCR->clkctrl &= ~MXC_F_GCR_CLKCTRL_IBRO_EN;
         break;
 
-        // TODO(ME30): Missing EXTCLK register definition
-        // case MXC_SYS_CLOCK_EXTCLK:
-        //     /*
-        //     There's not a great way to disable the external clock.
-        //     Deinitializing the GPIO here may have unintended consequences
-        //     for application code.
-        //     Selecting a different system clock source is sufficient
-        //     to "disable" the EXT_CLK source.
-        //     */
-        //     break;
+    case MXC_SYS_CLOCK_EXTCLK:
+        /*
+        There's not a great way to disable the external clock.
+        Deinitializing the GPIO here may have unintended consequences
+        for application code.
+        Selecting a different system clock source is sufficient
+        to "disable" the EXT_CLK source.
+        */
+        break;
 
     case MXC_SYS_CLOCK_INRO:
         // The 80k clock is always enabled
@@ -353,6 +351,7 @@ int MXC_SYS_Clock_Timeout(uint32_t ready)
 int MXC_SYS_Clock_Select(mxc_sys_system_clock_t clock)
 {
     uint32_t current_clock;
+    int err = E_NO_ERROR;
 
     // Save the current system clock
     current_clock = MXC_GCR->clkctrl & MXC_F_GCR_CLKCTRL_SYSCLK_SEL;
@@ -394,21 +393,20 @@ int MXC_SYS_Clock_Select(mxc_sys_system_clock_t clock)
 
         break;
 
-        // TODO(ME30): Missing EXTCLK register definition
-        // case MXC_SYS_CLOCK_EXTCLK:
-        //     /*
-        //     There's not "EXT_CLK RDY" bit for the ME17, so we'll
-        //     blindly enable (configure GPIO) the external clock every time.
-        //     */
-        //     err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_EXTCLK);
-        //     if (err)
-        //         return err;
+    case MXC_SYS_CLOCK_EXTCLK:
+        /*
+        There's not "EXT_CLK RDY" bit for the ME17, so we'll
+        blindly enable (configure GPIO) the external clock every time.
+        */
+        err = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_EXTCLK);
+        if (err)
+            return err;
 
-        //     // Set EXT clock as System Clock
-        //     MXC_SETFIELD(MXC_GCR->clkctrl, MXC_F_GCR_CLKCTRL_SYSCLK_SEL,
-        //                  MXC_S_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK);
+        // Set EXT clock as System Clock
+        MXC_SETFIELD(MXC_GCR->clkctrl, MXC_F_GCR_CLKCTRL_SYSCLK_SEL,
+                     MXC_S_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK);
 
-        //     break;
+        break;
 
     case MXC_SYS_CLOCK_ERFO:
 


### PR DESCRIPTION
### Description

Uncomment clock selection code to allow external clock input to be used as system clock since external clock pin and system clock selection bits are now known.

Set INRO clock frequency to 131kHz.
