### PR TITLE
feat(Other): Enable USB support for Zephyr by adding MAXUSB

### DIFF
--- a/.github/workflows/scripts/zephyr-hal.sh
+++ b/.github/workflows/scripts/zephyr-hal.sh
@@ -25,6 +25,8 @@ rm -rf ${hal_adi}/MAX/
 
 # Create parent folder
 mkdir -p ${hal_adi}/MAX/Libraries/CMSIS
+mkdir -p ${hal_adi}/MAX/Libraries/MAXUSB/include
+mkdir -p ${hal_adi}/MAX/Libraries/MAXUSB/src
 mkdir -p ${hal_adi}/MAX/Libraries/PeriphDrivers
 
 # Copy zephyr wrappers, system files and cmakefiles
@@ -38,11 +40,19 @@ cp -rf ${msdk}/Libraries/CMSIS/Include ${hal_adi}/MAX/Libraries/CMSIS/
 cp -rf ${msdk}/Libraries/PeriphDrivers/Include ${hal_adi}/MAX/Libraries/PeriphDrivers/
 cp -rf ${msdk}/Libraries/PeriphDrivers/Source  ${hal_adi}/MAX/Libraries/PeriphDrivers/
 
+# Copy MAXUSB folder
+cp -rf ${msdk}/Libraries/MAXUSB/include/core ${hal_adi}/MAX/Libraries/MAXUSB/include/
+cp -rf ${msdk}/Libraries/MAXUSB/src/core     ${hal_adi}/MAX/Libraries/MAXUSB/src/
+
 # Remove unneeded files
 rm -rf ${hal_adi}/MAX/Libraries/CMSIS/Device/Maxim/GCC
 rm -rf ${hal_adi}/MAX/Libraries/CMSIS/Device/Maxim/MAX*/Source/IAR
 rm -rf ${hal_adi}/MAX/Libraries/CMSIS/Device/Maxim/MAX*/Source/GCC
 rm -rf ${hal_adi}/MAX/Libraries/CMSIS/Device/Maxim/MAX*/Source/ARM
+rm -rf ${hal_adi}/MAX/Libraries/MAXUSB/include/core/arm
+rm -rf ${hal_adi}/MAX/Libraries/MAXUSB/include/core/maxq
+rm -rf ${hal_adi}/MAX/Libraries/MAXUSB/src/core/arm
+rm -rf ${hal_adi}/MAX/Libraries/MAXUSB/src/core/maxq
 
 # Check either dirty or clean
 cd ${hal_adi}

--- a/Libraries/MAXUSB/include/core/usb_protocol.h
+++ b/Libraries/MAXUSB/include/core/usb_protocol.h
@@ -149,7 +149,10 @@ typedef __packed struct {
 } MXC_USB_interface_descriptor_t;
 
 #define USB_EP_NUM_MASK   0x0F
+
+#ifndef USE_ZEPHYR_USB_STACK
 #define USB_EP_DIR_MASK   0x80
+#endif
 
 #if defined(__GNUC__)
 typedef struct __attribute__((packed)) {

--- a/Libraries/MAXUSB/src/core/musbhsfc/usb.c
+++ b/Libraries/MAXUSB/src/core/musbhsfc/usb.c
@@ -941,7 +941,9 @@ int MXC_USB_GetSetup(MXC_USB_SetupPkt *sud)
 
     /* Check for follow-on data and advance state machine */
     if (sud->wLength > 0) {
+#ifndef USE_ZEPHYR_USB_STACK
         MXC_USBHS->csr0 |= MXC_F_USBHS_CSR0_SERV_OUTPKTRDY;
+#endif
         /* Determine if IN or OUT data follows */
         if (sud->bmRequestType & RT_DEV_TO_HOST) {
             setup_phase = SETUP_DATA_IN;

--- a/Libraries/zephyr/MAX/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/CMakeLists.txt
@@ -47,6 +47,10 @@ zephyr_include_directories(
 )
 
 if (CONFIG_UDC_MAX32)
+    zephyr_compile_definitions(
+        -DUSE_ZEPHYR_USB_STACK=1
+    )
+
     set(MSDK_MAXUSB_DIR ${MSDK_LIBRARY_DIR}/MAXUSB)
 
     zephyr_include_directories(

--- a/Libraries/zephyr/MAX/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/CMakeLists.txt
@@ -46,6 +46,20 @@ zephyr_include_directories(
     ${MSDK_PERIPH_INC_DIR}
 )
 
+if (CONFIG_UDC_MAX32)
+    set(MSDK_MAXUSB_DIR ${MSDK_LIBRARY_DIR}/MAXUSB)
+
+    zephyr_include_directories(
+        ${MSDK_MAXUSB_DIR}/include/core
+        ${MSDK_MAXUSB_DIR}/include/core/musbhsfc
+    )
+
+    zephyr_library_sources(
+        ${MSDK_MAXUSB_DIR}/src/core/usb_event.c
+        ${MSDK_MAXUSB_DIR}/src/core/musbhsfc/usb.c
+    )
+endif()
+
 add_subdirectory_ifdef(CONFIG_SOC_MAX32520 Source/MAX32520)
 add_subdirectory_ifdef(CONFIG_SOC_MAX32570 Source/MAX32570)
 add_subdirectory_ifdef(CONFIG_SOC_MAX32572 Source/MAX32572)


### PR DESCRIPTION
### Description

The purpose of this PR is enabling USB support for MAX32 MCUs on Zephyr RTOS. 

- Added required MAXUSB files into 'hal_adi' repository by updating CI workflow.
- Added these files into Zephyr source and include directories.
- Handled differences between MSDK and Zephyr with "USE_ZEPHYR_USB_STACK" flag and solved warning problem and race condition situation.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.