### PR TITLE
fix(CMSIS): Remove AES Key Generation (unsupported) feature from MAX32657

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.svd
@@ -10318,24 +10318,6 @@
        <bitWidth>1</bitWidth>
       </field>
       <field>
-       <name>AESKG_MEU</name>
-       <description>Generate and transfer 256 bit MEU key to AES Key storage.</description>
-       <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>AESKG_MEMPROT_XIP</name>
-       <description>Generate and transfer 128 bit MEMPROT_XIP key to AES key storage.</description>
-       <bitOffset>4</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>AESKG_MEMPROT_DIP</name>
-       <description>Generate and transfer 128 bit MEMPROT_DIP key to AES key storage.</description>
-       <bitOffset>5</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
        <name>OD_ROMON</name>
        <description>Start ring oscillator monitor on demand test.</description>
        <bitOffset>6</bitOffset>
@@ -10363,12 +10345,6 @@
        <name>EBLS</name>
        <description>Entropy Bit Load Select.</description>
        <bitOffset>10</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>KEYWIPE</name>
-       <description>To wipe the Battery Backed key.</description>
-       <bitOffset>15</bitOffset>
        <bitWidth>1</bitWidth>
       </field>
       <field>
@@ -10470,12 +10446,6 @@
        <name>SRCFAIL</name>
        <description>Entropy source has failed.</description>
        <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>AES_KEYGEN</name>
-       <description>AESKGD.</description>
-       <bitOffset>4</bitOffset>
        <bitWidth>1</bitWidth>
       </field>
       <field>

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/trng_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/trng_regs.h
@@ -111,15 +111,6 @@ typedef struct {
 #define MXC_F_TRNG_CTRL_HEALTH_IE_POS                  2 /**< CTRL_HEALTH_IE Position */
 #define MXC_F_TRNG_CTRL_HEALTH_IE                      ((uint32_t)(0x1UL << MXC_F_TRNG_CTRL_HEALTH_IE_POS)) /**< CTRL_HEALTH_IE Mask */
 
-#define MXC_F_TRNG_CTRL_AESKG_MEU_POS                  3 /**< CTRL_AESKG_MEU Position */
-#define MXC_F_TRNG_CTRL_AESKG_MEU                      ((uint32_t)(0x1UL << MXC_F_TRNG_CTRL_AESKG_MEU_POS)) /**< CTRL_AESKG_MEU Mask */
-
-#define MXC_F_TRNG_CTRL_AESKG_MEMPROT_XIP_POS          4 /**< CTRL_AESKG_MEMPROT_XIP Position */
-#define MXC_F_TRNG_CTRL_AESKG_MEMPROT_XIP              ((uint32_t)(0x1UL << MXC_F_TRNG_CTRL_AESKG_MEMPROT_XIP_POS)) /**< CTRL_AESKG_MEMPROT_XIP Mask */
-
-#define MXC_F_TRNG_CTRL_AESKG_MEMPROT_DIP_POS          5 /**< CTRL_AESKG_MEMPROT_DIP Position */
-#define MXC_F_TRNG_CTRL_AESKG_MEMPROT_DIP              ((uint32_t)(0x1UL << MXC_F_TRNG_CTRL_AESKG_MEMPROT_DIP_POS)) /**< CTRL_AESKG_MEMPROT_DIP Mask */
-
 #define MXC_F_TRNG_CTRL_OD_ROMON_POS                   6 /**< CTRL_OD_ROMON Position */
 #define MXC_F_TRNG_CTRL_OD_ROMON                       ((uint32_t)(0x1UL << MXC_F_TRNG_CTRL_OD_ROMON_POS)) /**< CTRL_OD_ROMON Mask */
 
@@ -134,9 +125,6 @@ typedef struct {
 
 #define MXC_F_TRNG_CTRL_EBLS_POS                       10 /**< CTRL_EBLS Position */
 #define MXC_F_TRNG_CTRL_EBLS                           ((uint32_t)(0x1UL << MXC_F_TRNG_CTRL_EBLS_POS)) /**< CTRL_EBLS Mask */
-
-#define MXC_F_TRNG_CTRL_KEYWIPE_POS                    15 /**< CTRL_KEYWIPE Position */
-#define MXC_F_TRNG_CTRL_KEYWIPE                        ((uint32_t)(0x1UL << MXC_F_TRNG_CTRL_KEYWIPE_POS)) /**< CTRL_KEYWIPE Mask */
 
 #define MXC_F_TRNG_CTRL_GET_TERO_CNT_POS               16 /**< CTRL_GET_TERO_CNT Position */
 #define MXC_F_TRNG_CTRL_GET_TERO_CNT                   ((uint32_t)(0x1UL << MXC_F_TRNG_CTRL_GET_TERO_CNT_POS)) /**< CTRL_GET_TERO_CNT Mask */
@@ -182,9 +170,6 @@ typedef struct {
 
 #define MXC_F_TRNG_STATUS_SRCFAIL_POS                  3 /**< STATUS_SRCFAIL Position */
 #define MXC_F_TRNG_STATUS_SRCFAIL                      ((uint32_t)(0x1UL << MXC_F_TRNG_STATUS_SRCFAIL_POS)) /**< STATUS_SRCFAIL Mask */
-
-#define MXC_F_TRNG_STATUS_AES_KEYGEN_POS               4 /**< STATUS_AES_KEYGEN Position */
-#define MXC_F_TRNG_STATUS_AES_KEYGEN                   ((uint32_t)(0x1UL << MXC_F_TRNG_STATUS_AES_KEYGEN_POS)) /**< STATUS_AES_KEYGEN Mask */
 
 #define MXC_F_TRNG_STATUS_OD_ROMON_POS                 6 /**< STATUS_OD_ROMON Position */
 #define MXC_F_TRNG_STATUS_OD_ROMON                     ((uint32_t)(0x1UL << MXC_F_TRNG_STATUS_OD_ROMON_POS)) /**< STATUS_OD_ROMON Mask */

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_revc_me30.svd
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_revc_me30.svd
@@ -52,24 +52,6 @@
             <bitWidth>1</bitWidth>
           </field>
           <field>
-            <name>AESKG_MEU</name>
-            <description>Generate and transfer 256 bit MEU key to AES Key storage.</description>
-            <bitOffset>3</bitOffset>
-            <bitWidth>1</bitWidth>
-          </field>
-          <field>
-            <name>AESKG_MEMPROT_XIP</name>
-            <description>Generate and transfer 128 bit MEMPROT_XIP key to AES key storage.</description>
-            <bitOffset>4</bitOffset>
-            <bitWidth>1</bitWidth>
-          </field>
-          <field>
-            <name>AESKG_MEMPROT_DIP</name>
-            <description>Generate and transfer 128 bit MEMPROT_DIP key to AES key storage.</description>
-            <bitOffset>5</bitOffset>
-            <bitWidth>1</bitWidth>
-          </field>
-          <field>
             <name>OD_ROMON</name>
             <description>Start ring oscillator monitor on demand test.</description>
             <bitOffset>6</bitOffset>
@@ -97,12 +79,6 @@
             <name>EBLS</name>
             <description>Entropy Bit Load Select.</description>
             <bitOffset>10</bitOffset>
-            <bitWidth>1</bitWidth>
-          </field>
-          <field>
-            <name>KEYWIPE</name>
-            <description>To wipe the Battery Backed key.</description>
-            <bitOffset>15</bitOffset>
             <bitWidth>1</bitWidth>
           </field>
           <field>
@@ -204,12 +180,6 @@
             <name>SRCFAIL</name>
             <description>Entropy source has failed.</description>
             <bitOffset>3</bitOffset>
-            <bitWidth>1</bitWidth>
-          </field>
-          <field>
-            <name>AES_KEYGEN</name>
-            <description>AESKGD.</description>
-            <bitOffset>4</bitOffset>
             <bitWidth>1</bitWidth>
           </field>
           <field>


### PR DESCRIPTION
### Description

The TRNG block for the MAX32657 does not support AES key generation. This PR removes all registers related to it.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.