### PR TITLE
fix(PeriphDrivers, Other): Fix UART clock source selection

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32657/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/uart.h
@@ -77,14 +77,11 @@ typedef enum {
 } mxc_uart_flow_t;
 
 /**
- * @brief      Clock settings */
+ * @brief   Clock settings
+ */
 typedef enum {
-    /*Only available for UARTS 0-2*/
     MXC_UART_APB_CLK = 0,
-    /*Available for all UARTs*/
-    MXC_UART_IBRO_CLK = 2,
-    /*ERTCO clock can only be used for UART3*/
-    MXC_UART_ERTCO_CLK = 4,
+    MXC_UART_IBRO_CLK = 1,
 } mxc_uart_clock_t;
 
 /**


### PR DESCRIPTION
### Description

This PR solves UART clock source selection problems for ME18 and ME30. Problems:

- For ME18, "MXC_UART_SetFrequency" function changes clock source but it is not a good approach. There is "MXC_UART_SetClockSource" function and user should use this function to change clock source of UART.

- Removed "MXC_UART_ERTCO_CLK" enum from ME30 files because it does not used by UART.
![image](https://github.com/user-attachments/assets/e8afde81-88f6-466a-8800-5fd5086f914e)

- Fixed build error of ME30 caused by "MSDK_NO_GPIO_CLK_INIT" flag's line.
- Moved clock source enablement into "MXC_UART_SetClockSource" function for ME30.


Also, this PR adds wrapper function of "MXC_UART_SetClockSource" to Zephyr "hal_adi" to enable clock source selection feature in Zephyr. It handles clock source index differences between MSDK and Zephyr.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.