### PR TITLE
feat(Other): Add DMA channel number conversion for Zephyr

### DIFF
--- a/Libraries/zephyr/MAX/Include/wrap_max32_dma.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_dma.h
@@ -87,6 +87,16 @@ static inline int Wrap_MXC_DMA_AcquireChannel(mxc_dma_regs_t *dma)
 #endif
 }
 
+static inline int Wrap_MXC_DMA_GetChannelIndex(mxc_dma_regs_t *dma, uint8_t ch)
+{
+#if defined(CONFIG_SOC_MAX32657)
+    (void)dma;
+    return ch;
+#else
+    return (ch + MXC_DMA_GET_IDX(dma) * (MXC_DMA_CHANNELS / MXC_DMA_INSTANCES));
+#endif
+}
+
 static inline void Wrap_MXC_DMA_Handler(mxc_dma_regs_t *dma)
 {
 #if defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)


### PR DESCRIPTION
### Description

Add a DMA channel conversion function to convert chanel numbers between Zephyr and MSDK. For example, if an SoC has two DMA instances named DMA0 and DMA1, with 4 channels each, DMA1 channel numbers should be offset by 4 before passing to MSDK.

| Zephyr DMA0 | MSDK DMA0 |
|--------|--------|
| 0 | 0 |
| 1 | 1 |
| 2 | 2 |
| 3 | 3 |

| Zephyr DMA1 | MSDK DMA1 |
|--------|--------|
| 0 | 4 |
| 1 | 5 |
| 2 | 6 |
| 3 | 7 |

MAX32657 DMA is an exception to this.
