### PR TITLE
fix(Examples): Remove RISC-V debug configs from MAX32657 examples

### DIFF
--- a/Examples/MAX32657/Bluetooth/BLE5_ctr/.vscode/launch.json
+++ b/Examples/MAX32657/Bluetooth/BLE5_ctr/.vscode/launch.json
@@ -78,56 +78,6 @@
                 { "text":"set $pc=Reset_Handler"},
                 { "text":"b main" }
             ]
-        },
-        {
-            "name": "GDB (RISC-V)",
-            "type": "cppdbg",
-            "request": "launch",
-            "program": "${workspaceFolder}/buildrv/${config:program_file}",
-            "args": [],
-            "stopAtEntry": false,
-            "cwd": "${workspaceFolder}",
-            "environment": [],
-            "externalConsole": false,
-            "MIMode": "gdb",
-            "linux": {
-                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb",
-                "debugServerPath": "${config:OCD_path}/openocd",
-            },
-            "windows": {
-                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb.exe",
-                "debugServerPath": "${config:OCD_path}/openocd.exe",
-            },
-            "osx": {
-                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb",
-                "debugServerPath": "${config:OCD_path}/bin/openocd",
-            },
-            "logging": {
-                "exceptions": true,
-                "trace": false,
-                "traceResponse": false,
-                "engineLogging": false
-            },
-            "miDebuggerServerAddress": "localhost:3334",
-            "debugServerArgs": "-c \"gdb_port 3334\" -s ${config:OCD_path}/scripts -f interface/${config:RV_OCD_interface_file} -f target/${config:RV_OCD_target_file}",
-            "serverStarted": "Info : Listening on port 3334 for gdb connections",
-            "filterStderr": true,
-            "customLaunchSetupCommands": [
-                {"text":"-list-features"}
-            ],
-            "targetArchitecture": "arm",
-            "setupCommands": [
-                { "text":"set logging overwrite on"},
-                { "text":"set logging file debug-riscv.log"},
-                { "text":"set logging on"},
-                { "text":"cd ${workspaceFolder}" },
-                { "text": "set architecture riscv:rv32", "ignoreFailures": false },          
-                { "text":"exec-file build/${config:program_file}", "ignoreFailures": false },
-                { "text":"symbol-file buildrv/${config:symbol_file}", "ignoreFailures": false },
-                { "text":"target remote localhost:3334" },
-                { "text":"b main" },
-                { "text": "set $pc=Reset_Handler","ignoreFailures": false }
-            ]
         }
     ]
 }

--- a/Examples/MAX32657/Hello_World/.vscode/launch.json
+++ b/Examples/MAX32657/Hello_World/.vscode/launch.json
@@ -78,56 +78,6 @@
                 { "text":"set $pc=Reset_Handler"},
                 { "text":"b main" }
             ]
-        },
-        {
-            "name": "GDB (RISC-V)",
-            "type": "cppdbg",
-            "request": "launch",
-            "program": "${workspaceFolder}/buildrv/${config:program_file}",
-            "args": [],
-            "stopAtEntry": false,
-            "cwd": "${workspaceFolder}",
-            "environment": [],
-            "externalConsole": false,
-            "MIMode": "gdb",
-            "linux": {
-                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb",
-                "debugServerPath": "${config:OCD_path}/openocd",
-            },
-            "windows": {
-                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb.exe",
-                "debugServerPath": "${config:OCD_path}/openocd.exe",
-            },
-            "osx": {
-                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb",
-                "debugServerPath": "${config:OCD_path}/bin/openocd",
-            },
-            "logging": {
-                "exceptions": true,
-                "trace": false,
-                "traceResponse": false,
-                "engineLogging": false
-            },
-            "miDebuggerServerAddress": "localhost:3334",
-            "debugServerArgs": "-c \"gdb_port 3334\" -s ${config:OCD_path}/scripts -f interface/${config:RV_OCD_interface_file} -f target/${config:RV_OCD_target_file}",
-            "serverStarted": "Info : Listening on port 3334 for gdb connections",
-            "filterStderr": true,
-            "customLaunchSetupCommands": [
-                {"text":"-list-features"}
-            ],
-            "targetArchitecture": "arm",
-            "setupCommands": [
-                { "text":"set logging overwrite on"},
-                { "text":"set logging file debug-riscv.log"},
-                { "text":"set logging on"},
-                { "text":"cd ${workspaceFolder}" },
-                { "text": "set architecture riscv:rv32", "ignoreFailures": false },          
-                { "text":"exec-file build/${config:program_file}", "ignoreFailures": false },
-                { "text":"symbol-file buildrv/${config:symbol_file}", "ignoreFailures": false },
-                { "text":"target remote localhost:3334" },
-                { "text":"b main" },
-                { "text": "set $pc=Reset_Handler","ignoreFailures": false }
-            ]
         }
     ]
 }

--- a/Examples/MAX32657/Hello_World_TZ/NonSecure/.vscode/launch.json
+++ b/Examples/MAX32657/Hello_World_TZ/NonSecure/.vscode/launch.json
@@ -78,56 +78,6 @@
                 { "text":"set $pc=Reset_Handler"},
                 { "text":"b main" }
             ]
-        },
-        {
-            "name": "GDB (RISC-V)",
-            "type": "cppdbg",
-            "request": "launch",
-            "program": "${workspaceFolder}/buildrv/${config:program_file}",
-            "args": [],
-            "stopAtEntry": false,
-            "cwd": "${workspaceFolder}",
-            "environment": [],
-            "externalConsole": false,
-            "MIMode": "gdb",
-            "linux": {
-                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb",
-                "debugServerPath": "${config:OCD_path}/openocd",
-            },
-            "windows": {
-                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb.exe",
-                "debugServerPath": "${config:OCD_path}/openocd.exe",
-            },
-            "osx": {
-                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb",
-                "debugServerPath": "${config:OCD_path}/bin/openocd",
-            },
-            "logging": {
-                "exceptions": true,
-                "trace": false,
-                "traceResponse": false,
-                "engineLogging": false
-            },
-            "miDebuggerServerAddress": "localhost:3334",
-            "debugServerArgs": "-c \"gdb_port 3334\" -s ${config:OCD_path}/scripts -f interface/${config:RV_OCD_interface_file} -f target/${config:RV_OCD_target_file}",
-            "serverStarted": "Info : Listening on port 3334 for gdb connections",
-            "filterStderr": true,
-            "customLaunchSetupCommands": [
-                {"text":"-list-features"}
-            ],
-            "targetArchitecture": "arm",
-            "setupCommands": [
-                { "text":"set logging overwrite on"},
-                { "text":"set logging file debug-riscv.log"},
-                { "text":"set logging on"},
-                { "text":"cd ${workspaceFolder}" },
-                { "text": "set architecture riscv:rv32", "ignoreFailures": false },          
-                { "text":"exec-file build/${config:program_file}", "ignoreFailures": false },
-                { "text":"symbol-file buildrv/${config:symbol_file}", "ignoreFailures": false },
-                { "text":"target remote localhost:3334" },
-                { "text":"b main" },
-                { "text": "set $pc=Reset_Handler","ignoreFailures": false }
-            ]
         }
     ]
 }

--- a/Examples/MAX32657/Hello_World_TZ/Secure/.vscode/launch.json
+++ b/Examples/MAX32657/Hello_World_TZ/Secure/.vscode/launch.json
@@ -78,56 +78,6 @@
                 { "text":"set $pc=Reset_Handler"},
                 { "text":"b main" }
             ]
-        },
-        {
-            "name": "GDB (RISC-V)",
-            "type": "cppdbg",
-            "request": "launch",
-            "program": "${workspaceFolder}/buildrv/${config:program_file}",
-            "args": [],
-            "stopAtEntry": false,
-            "cwd": "${workspaceFolder}",
-            "environment": [],
-            "externalConsole": false,
-            "MIMode": "gdb",
-            "linux": {
-                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb",
-                "debugServerPath": "${config:OCD_path}/openocd",
-            },
-            "windows": {
-                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb.exe",
-                "debugServerPath": "${config:OCD_path}/openocd.exe",
-            },
-            "osx": {
-                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb",
-                "debugServerPath": "${config:OCD_path}/bin/openocd",
-            },
-            "logging": {
-                "exceptions": true,
-                "trace": false,
-                "traceResponse": false,
-                "engineLogging": false
-            },
-            "miDebuggerServerAddress": "localhost:3334",
-            "debugServerArgs": "-c \"gdb_port 3334\" -s ${config:OCD_path}/scripts -f interface/${config:RV_OCD_interface_file} -f target/${config:RV_OCD_target_file}",
-            "serverStarted": "Info : Listening on port 3334 for gdb connections",
-            "filterStderr": true,
-            "customLaunchSetupCommands": [
-                {"text":"-list-features"}
-            ],
-            "targetArchitecture": "arm",
-            "setupCommands": [
-                { "text":"set logging overwrite on"},
-                { "text":"set logging file debug-riscv.log"},
-                { "text":"set logging on"},
-                { "text":"cd ${workspaceFolder}" },
-                { "text": "set architecture riscv:rv32", "ignoreFailures": false },          
-                { "text":"exec-file build/${config:program_file}", "ignoreFailures": false },
-                { "text":"symbol-file buildrv/${config:symbol_file}", "ignoreFailures": false },
-                { "text":"target remote localhost:3334" },
-                { "text":"b main" },
-                { "text": "set $pc=Reset_Handler","ignoreFailures": false }
-            ]
         }
     ]
 }


### PR DESCRIPTION
### Description

Removed RISC-V debug configurations from MAX32657 examples since the MAX32657 part does not have a RISC-V core.
Shipping this debug configuration with these examples can be confusing to the user.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
