### PR TITLE
fix(PeriphDrivers): MAX32657 Cache Access

### DIFF
--- a/Libraries/PeriphDrivers/Source/ICC/icc_me30.c
+++ b/Libraries/PeriphDrivers/Source/ICC/icc_me30.c
@@ -37,20 +37,31 @@ Maxim Internal Use
 
 int MXC_ICC_ID(mxc_icc_info_t cid)
 {
+#if CONFIG_TRUSTED_EXECUTION_SECURE
     return MXC_ICC_RevA_ID((mxc_icc_reva_regs_t *)MXC_ICC, cid);
+#else
+    return E_NOT_SUPPORTED;
+#endif
 }
 
 void MXC_ICC_Enable(void)
 {
+    /* Cache controller only accessible in secure world. */
+#if CONFIG_TRUSTED_EXECUTION_SECURE
     MXC_ICC_RevA_Enable((mxc_icc_reva_regs_t *)MXC_ICC);
+#endif
 }
 
 void MXC_ICC_Disable(void)
 {
+#if CONFIG_TRUSTED_EXECUTION_SECURE
     MXC_ICC_RevA_Disable((mxc_icc_reva_regs_t *)MXC_ICC);
+#endif
 }
 
 void MXC_ICC_Flush(void)
 {
+#if CONFIG_TRUSTED_EXECUTION_SECURE
     MXC_ICC_Com_Flush();
+#endif
 }


### PR DESCRIPTION
MAX32657 cache controller only accessibly by secure world. 
This PR add guard to invalid access from non-secure world

### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [X] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
