### PR TITLE
fix(BLE): WSF Assertion Checking for callback when not enabled. 

### DIFF
--- a/Libraries/Cordio/wsf/sources/targets/baremetal/wsf_trace.c
+++ b/Libraries/Cordio/wsf/sources/targets/baremetal/wsf_trace.c
@@ -266,7 +266,10 @@ void WsfTraceVerbose(const char *pStr, ...)
 /*************************************************************************************************/
 void WsfTraceEnable(bool_t enable)
 {
+  #if WSF_TRACE_ENABLED == TRUE
   WSF_ASSERT(wsfTraceCb.sendMsgCback);
+  #endif
+  
   wsfTraceCb.enabled = enable;
 
 /*


### PR DESCRIPTION
### Description

Conditionally check for trace being enabled to assert a trace callback. If there is no trace, we don't need a callback. This issue must have been introduced recently because we have not had this issue in the past. 

Address #1301 