### PR TITLE
fix(PeriphDrivers, Other): Fix RTC clock source selection

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32657/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/rtc.h
@@ -76,6 +76,15 @@ typedef enum {
 } mxc_rtc_int_fl_t;
 
 /**
+ * @brief     Clock settings
+ */
+typedef enum {
+    MXC_RTC_ERTCO_CLK = 0,
+    MXC_RTC_INRO_CLK = 1,
+    MXC_RTC_EXT_CLK = 2,
+} mxc_rtc_clock_t;
+
+/**
  * @brief     Set Time-of-Day alarm value and enable Interrupt
  * @param     ras    20-bit value 0-0xFFFFF
  * @retval    returns Success or Fail, see \ref MXC_ERROR_CODES
@@ -91,10 +100,18 @@ int MXC_RTC_SetTimeofdayAlarm(uint32_t ras);
 int MXC_RTC_SetSubsecondAlarm(uint32_t rssa);
 
 /**
+ * @brief     Set the RTC clock source
+ * @param     clk_src   Clock source to use
+ * @retval    returns Success or Fail, see \ref MXC_ERROR_CODES
+ */
+int MXC_RTC_SetClockSource(mxc_rtc_clock_t clk_src);
+
+/**
  * @brief     Start the Real Time Clock (Blocking function)
  * @retval    returns Success or Fail, see \ref MXC_ERROR_CODES
  */
 int MXC_RTC_Start(void);
+
 /**
  * @brief     Stop the Real Time Clock (Blocking function)
  * @retval    returns Success or Fail, see \ref MXC_ERROR_CODES

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me30.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me30.c
@@ -65,6 +65,33 @@ int MXC_RTC_SetSubsecondAlarm(uint32_t rssa)
     return MXC_RTC_RevA_SetSubsecondAlarm((mxc_rtc_reva_regs_t *)MXC_RTC, rssa);
 }
 
+int MXC_RTC_SetClockSource(mxc_rtc_clock_t clk_src)
+{
+    uint8_t retval = E_NO_ERROR;
+
+    switch (clk_src) {
+    case MXC_RTC_ERTCO_CLK:
+#ifndef MSDK_NO_GPIO_CLK_INIT
+        retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+#endif // MSDK_NO_GPIO_CLK_INIT
+        MXC_SETFIELD(MXC_MCR->ctrl, MXC_F_MCR_CTRL_CLKSEL, MXC_S_MCR_CTRL_CLKSEL_ERTCO);
+        break;
+
+    case MXC_RTC_INRO_CLK:
+        MXC_SETFIELD(MXC_MCR->ctrl, MXC_F_MCR_CTRL_CLKSEL, MXC_S_MCR_CTRL_CLKSEL_INRO_DIV4);
+        break;
+
+    case MXC_RTC_EXT_CLK:
+        return E_NOT_SUPPORTED;
+
+    default:
+        // Invalid clock source
+        return E_BAD_PARAM;
+    }
+
+    return retval;
+}
+
 int MXC_RTC_Start(void)
 {
     return MXC_RTC_RevA_Start((mxc_rtc_reva_regs_t *)MXC_RTC);
@@ -77,8 +104,6 @@ int MXC_RTC_Stop(void)
 
 int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 {
-    MXC_GCR->clkctrl |= MXC_F_GCR_CLKCTRL_ERTCO_EN;
-
     return MXC_RTC_RevA_Init((mxc_rtc_reva_regs_t *)MXC_RTC, sec, (ssec & MXC_F_RTC_SSEC_SSEC));
 }
 

--- a/Libraries/zephyr/MAX/Include/wrap_max32_rtc.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_rtc.h
@@ -1,0 +1,86 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2024 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#ifndef LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_RTC_H_
+#define LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_RTC_H_
+
+/***** Includes *****/
+#include <rtc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(CONFIG_SOC_MAX32657)
+
+static inline mxc_rtc_clock_t wrap_get_clock_source_instance(uint8_t clock_source)
+{
+    mxc_rtc_clock_t clk_src;
+
+    switch (clock_source) {
+    case 4: // ADI_MAX32_PRPH_CLK_SRC_ERTCO
+        clk_src = MXC_RTC_ERTCO_CLK;
+        break;
+    case 5: // ADI_MAX32_PRPH_CLK_SRC_INRO
+        clk_src = MXC_RTC_INRO_CLK;
+        break;
+    default:
+        return -1;
+    }
+
+    return clk_src;
+}
+
+static inline int Wrap_MXC_RTC_Init(uint32_t sec, uint16_t ssec, uint8_t clock_source)
+{
+    int ret;
+    mxc_rtc_clock_t clk_src;
+
+    clk_src = wrap_get_clock_source_instance(clock_source);
+
+    if (MXC_RTC_SetClockSource(clk_src) == E_NO_ERROR) {
+        ret = MXC_RTC_Init(sec, ssec);
+    } else {
+        ret = E_BAD_PARAM;
+    }
+
+    return ret;
+}
+
+#else
+
+static inline int Wrap_MXC_RTC_Init(uint32_t sec, uint16_t ssec, uint8_t clock_source)
+{
+    int ret;
+
+    // Return -1 if clock source not equal to ADI_MAX32_PRPH_CLK_SRC_ERTCO
+    if (clock_source != 4) {
+        return -1;
+    }
+
+    ret = MXC_RTC_Init(sec, ssec);
+
+    return ret;
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_RTC_H_


### PR DESCRIPTION
### Description

This PR solves RTC clock source selection problem for ME30. It adds a function to set clock source and creates wrapper function for MXC_RTC_Init to select clock source for ME30.