### PR TITLE
feat(PeriphDrivers): Implement low power modes for MAX32657

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/gcr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/gcr_regs.h
@@ -7,7 +7,7 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2024-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -312,7 +312,7 @@ typedef struct {
 #define MXC_F_GCR_PM_RTC_WE_POS                        5 /**< PM_RTC_WE Position */
 #define MXC_F_GCR_PM_RTC_WE                            ((uint32_t)(0x1UL << MXC_F_GCR_PM_RTC_WE_POS)) /**< PM_RTC_WE Mask */
 
-#define MXC_F_GCR_PM_WUT_WE_POS                        7 /**< PM_WUT_WE Position */
+#define MXC_F_GCR_PM_WUT_WE_POS                        6 /**< PM_WUT_WE Position */
 #define MXC_F_GCR_PM_WUT_WE                            ((uint32_t)(0x1UL << MXC_F_GCR_PM_WUT_WE_POS)) /**< PM_WUT_WE Mask */
 
 #define MXC_F_GCR_PM_ERFO_BP_POS                       20 /**< PM_ERFO_BP Position */

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.svd
@@ -2334,7 +2334,7 @@
       <field derivedFrom="GPIO_WE">
        <name>WUT_WE</name>
        <description>Enable Wakeup Timer as wakeup source.</description>
-       <bitOffset>7</bitOffset>
+       <bitOffset>6</bitOffset>
        <bitWidth>1</bitWidth>
       </field>
       <field>

--- a/Libraries/PeriphDrivers/Include/MAX32657/lp.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/lp.h
@@ -91,12 +91,12 @@ void MXC_LP_SetOVR(mxc_lp_ovr_t ovr);
 /**
  * @brief      Enable retention regulator
  */
-void MXC_LP_RetentionRegEnable(void);
+void MXC_LP_EnableRetentionReg(void);
 
 /**
  * @brief      Disable retention regulator
  */
-void MXC_LP_RetentionRegDisable(void);
+void MXC_LP_DisableRetentionReg(void);
 
 /**
  * @brief      Is the retention regulator enabled

--- a/Libraries/PeriphDrivers/Include/MAX32657/lp.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/lp.h
@@ -5,7 +5,7 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2024-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,6 +89,39 @@ void MXC_LP_EnterPowerDownMode(void);
 void MXC_LP_SetOVR(mxc_lp_ovr_t ovr);
 
 /**
+ * @brief      Enable retention regulator
+ */
+void MXC_LP_RetentionRegEnable(void);
+
+/**
+ * @brief      Disable retention regulator
+ */
+void MXC_LP_RetentionRegDisable(void);
+
+/**
+ * @brief      Is the retention regulator enabled
+ *
+ * @return     1 = enabled 0 =  disabled
+ */
+int MXC_LP_RetentionRegIsEnabled(void);
+
+/**
+ * @brief      Enables data retention to RAM blocks 0-4 in BACKUP mode.
+ * 
+ * @param[in]  mask  The mask of the RAM blocks to enable data retention. Bit 0 enables 
+ *                   block 0, bit 1 enables block 1, etc.
+ */
+void MXC_LP_EnableSramRetention(uint32_t mask);
+
+/**
+ * @brief      Disables data retention to RAM blocks 0-4 in BACKUP mode.
+ * 
+ * @param[in]  mask  The mask of the RAM blocks to disable data retention. Bit 0 disables 
+ *                   block 0, bit 1 disables block 1, etc.
+ */
+void MXC_LP_DisableSramRetention(uint32_t mask);
+
+/**
  * @brief      Turn bandgap on
  */
 void MXC_LP_BandgapOn(void);
@@ -153,16 +186,6 @@ void MXC_LP_EnableTimerWakeup(mxc_tmr_regs_t *tmr);
 void MXC_LP_DisableTimerWakeup(mxc_tmr_regs_t *tmr);
 
 /**
- * @brief      Enables the USB to wake up the device from any low power mode.
- */
-void MXC_LP_EnableUSBWakeup(void);
-
-/**
- * @brief      Disables the USB from waking up the device.
- */
-void MXC_LP_DisableUSBWakeup(void);
-
-/**
  * @brief      Enables the WUT alarm to wake up the device from any low power mode.
  */
 void MXC_LP_EnableWUTAlarmWakeup(void);
@@ -173,52 +196,17 @@ void MXC_LP_EnableWUTAlarmWakeup(void);
 void MXC_LP_DisableWUTAlarmWakeup(void);
 
 /**
- * @brief      Enables the HA0 to wake up the device from any low power mode.
- */
-void MXC_LP_EnableHA0Wakeup(void);
-
-/**
- * @brief      Disables the HA)0 from waking up the device.
- */
-void MXC_LP_DisableHA0Wakeup(void);
-/**
- * @brief      Enables the HA1 to wake up the device from any low power mode.
- */
-void MXC_LP_EnableHA1Wakeup(void);
-
-/**
- * @brief      Disables the HA1 from waking up the device.
- */
-void MXC_LP_DisableHA1Wakeup(void);
-
-/**
  * @brief      Configure which clocks are powered down at deep sleep and which are not affected.
  *
- * @note       Need to configure all clocks at once any clock not passed in the mask will be unaffected by Deepsleep.  This will
- *             always overwrite the previous settings of ALL clocks.
+ * @note       Need to configure all clocks at once any clock not passed in the mask will be 
+ *             unaffected by Deepsleep.
  *
- * @param[in]  mask  The mask of the clocks to power down when part goes into deepsleep
+ * @param[in]  mask         The mask of the clocks to power down when part goes into deepsleep.
+ *                          Only ERTCO can be switched off.
  *
  * @return     #E_NO_ERROR or error based on /ref MXC_Error_Codes
  */
 int MXC_LP_ConfigDeepSleepClocks(uint32_t mask);
-
-/**
- * @brief      Enable NFC Oscilator Bypass
- */
-void MXC_LP_NFCOscBypassEnable(void);
-
-/**
- * @brief      Disable NFC Oscilator Bypass
- */
-void MXC_LP_NFCOscBypassDisable(void);
-
-/**
- * @brief      Is NFC Oscilator Bypass Enabled
- *
- * @return     1 = enabled, 0 = disabled
- */
-int MXC_LP_NFCOscBypassIsEnabled(void);
 
 /**@} end of group pwrseq */
 

--- a/Libraries/PeriphDrivers/Include/MAX32657/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/mxc_sys.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2024-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@
 #include "mxc_device.h"
 #include "gcr_regs.h"
 #include "fcr_regs.h"
+#include "mcr_regs.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -88,7 +89,6 @@ typedef enum {
 } mxc_sys_periph_clock_t;
 
 /** @brief Enumeration to select System Clock source */
-// TODO(ME30): CLKCTRL sysclk_sel values seem incorrect.
 typedef enum {
     MXC_SYS_CLOCK_IPO =
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_IPO, /**< Select the Internal Primary Oscillator (IPO) */
@@ -115,6 +115,17 @@ typedef enum {
     MXC_SYS_CLOCK_DIV_64 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV64,
     MXC_SYS_CLOCK_DIV_128 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV128
 } mxc_sys_system_clock_div_t;
+
+/** @brief Enumeration to select 32KHz Clock source used by the RTC, the timers, the wakeup timers, 
+ * and the system clock */
+typedef enum {
+    MXC_SYS_32K_CLOCK_ERTCO =
+        MXC_V_MCR_CTRL_CLKSEL_ERTCO, /**< Select the External Real-Time Clock Oscillator (ERTCO) */
+    MXC_SYS_32K_CLOCK_INRO =
+        MXC_V_MCR_CTRL_CLKSEL_INRO_DIV4, /**< Select the Internal Baud Rate Oscillator (INRO) */
+    MXC_SYS_32K_CLOCK_RTC_IN =
+        MXC_V_MCR_CTRL_CLKSEL_RTC_IN_DIV8, /**< Select the External clock input (RTC_CLK_IN) */
+} mxc_sys_32k_clock_t;
 
 /** @brief Compare clock enumeration. Used in MXC_SYS_ClockMeasure function. */
 typedef enum {
@@ -270,22 +281,14 @@ void MXC_SYS_RTCClockEnable(void);
 int MXC_SYS_RTCClockDisable(void);
 
 /**
- * @brief Enables the 32kHz oscillator to be powered down when not in use.
- *        Only available for ME17 Rev. B and older chips. This has no effect on ME17
- *        Rev. A chips.
+ * @brief Selects the 32KHz clock source used by the RTC, the timers, the wakeup timers, 
+ * and the system clock.
  * 
- * @returns  E_NO_ERROR if everything is successful
+ * @param       clock Clock source to use. See @ref mxc_sys_32k_clock_t for options.
+ * @return      E_NO_ERROR if everything is successful
+ *              E_BAD_PARAM if the clock is not valid 
  */
-void MXC_SYS_RTCClockPowerDownEn(void);
-
-/**
- * @brief Disables the 32kHz oscillator from being powered down when not in use.
- *        Only available for ME17 Rev. B and older chips. This has no effect on ME17
- *        Rev. A chips.
- * 
- * @returns  E_NO_ERROR if everything is successful
- */
-void MXC_SYS_RTCClockPowerDownDis(void);
+int MXC_SYS_Select32KClockSource(mxc_sys_32k_clock_t clock);
 
 /**
  * @brief Enable System Clock Source without switching to it

--- a/Libraries/PeriphDrivers/Include/MAX32657/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/rtc.h
@@ -5,7 +5,7 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2024-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,15 +76,6 @@ typedef enum {
 } mxc_rtc_int_fl_t;
 
 /**
- * @brief     Clock settings
- */
-typedef enum {
-    MXC_RTC_ERTCO_CLK = 0,
-    MXC_RTC_INRO_CLK = 1,
-    MXC_RTC_EXT_CLK = 2,
-} mxc_rtc_clock_t;
-
-/**
  * @brief     Set Time-of-Day alarm value and enable Interrupt
  * @param     ras    20-bit value 0-0xFFFFF
  * @retval    returns Success or Fail, see \ref MXC_ERROR_CODES
@@ -98,13 +89,6 @@ int MXC_RTC_SetTimeofdayAlarm(uint32_t ras);
  * @retval    returns Success or Fail, see \ref MXC_ERROR_CODES
  */
 int MXC_RTC_SetSubsecondAlarm(uint32_t rssa);
-
-/**
- * @brief     Set the RTC clock source
- * @param     clk_src   Clock source to use
- * @retval    returns Success or Fail, see \ref MXC_ERROR_CODES
- */
-int MXC_RTC_SetClockSource(mxc_rtc_clock_t clk_src);
 
 /**
  * @brief     Start the Real Time Clock (Blocking function)

--- a/Libraries/PeriphDrivers/Source/LP/lp_me30.c
+++ b/Libraries/PeriphDrivers/Source/LP/lp_me30.c
@@ -73,12 +73,12 @@ void MXC_LP_SetOVR(mxc_lp_ovr_t ovr)
     //not supported yet
 }
 
-void MXC_LP_RetentionRegEnable(void)
+void MXC_LP_EnableRetentionReg(void)
 {
     MXC_PWRSEQ->lpctrl |= MXC_F_PWRSEQ_LPCTRL_RETLDO_EN;
 }
 
-void MXC_LP_RetentionRegDisable(void)
+void MXC_LP_DisableRetentionReg(void)
 {
     MXC_PWRSEQ->lpctrl &= ~MXC_F_PWRSEQ_LPCTRL_RETLDO_EN;
 }

--- a/Libraries/PeriphDrivers/Source/LP/lp_me30.c
+++ b/Libraries/PeriphDrivers/Source/LP/lp_me30.c
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2024-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,6 @@
 #define SET_SLEEPDEEP(X) (SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk)
 #define CLR_SLEEPDEEP(X) (SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk)
 
-// TODO(SW): Update this.
-
 void MXC_LP_EnterSleepMode(void)
 {
     MXC_LP_ClearWakeStatus();
@@ -39,19 +37,15 @@ void MXC_LP_EnterSleepMode(void)
     __WFI();
 }
 
-void MXC_LP_EnterLowPowerMode(void)
-{
-    return;
-}
-
-void MXC_LP_EnterMicroPowerMode(void)
-{
-    return;
-}
-
 void MXC_LP_EnterStandbyMode(void)
 {
-    return;
+    MXC_LP_ClearWakeStatus();
+
+    /* Clear SLEEPDEEP bit */
+    SET_SLEEPDEEP();
+
+    /* Go into Standby mode and wait for an interrupt to wake the processor */
+    __WFI();
 }
 
 void MXC_LP_EnterBackupMode(void)
@@ -77,6 +71,31 @@ void MXC_LP_EnterPowerDownMode(void)
 void MXC_LP_SetOVR(mxc_lp_ovr_t ovr)
 {
     //not supported yet
+}
+
+void MXC_LP_RetentionRegEnable(void)
+{
+    MXC_PWRSEQ->lpctrl |= MXC_F_PWRSEQ_LPCTRL_RETLDO_EN;
+}
+
+void MXC_LP_RetentionRegDisable(void)
+{
+    MXC_PWRSEQ->lpctrl &= ~MXC_F_PWRSEQ_LPCTRL_RETLDO_EN;
+}
+
+int MXC_LP_RetentionRegIsEnabled(void)
+{
+    return (MXC_PWRSEQ->lpctrl & MXC_F_PWRSEQ_LPCTRL_RETLDO_EN);
+}
+
+void MXC_LP_EnableSramRetention(uint32_t mask)
+{
+    MXC_PWRSEQ->lpctrl |= (mask & 0x1F) << MXC_F_PWRSEQ_LPCTRL_SRAMRET_EN_POS;
+}
+
+void MXC_LP_DisableSramRetention(uint32_t mask)
+{
+    MXC_PWRSEQ->lpctrl &= ~((mask & 0x1F) << MXC_F_PWRSEQ_LPCTRL_SRAMRET_EN_POS);
 }
 
 void MXC_LP_BandgapOn(void)
@@ -135,16 +154,6 @@ void MXC_LP_DisableRTCAlarmWakeup(void)
     MXC_GCR->pm &= ~MXC_F_GCR_PM_RTC_WE;
 }
 
-void MXC_LP_EnableTimerWakeup(mxc_tmr_regs_t *tmr)
-{
-    return;
-}
-
-void MXC_LP_DisableTimerWakeup(mxc_tmr_regs_t *tmr)
-{
-    return;
-}
-
 void MXC_LP_EnableWUTAlarmWakeup(void)
 {
     MXC_GCR->pm |= MXC_F_GCR_PM_WUT_WE;
@@ -157,6 +166,11 @@ void MXC_LP_DisableWUTAlarmWakeup(void)
 
 int MXC_LP_ConfigDeepSleepClocks(uint32_t mask)
 {
-    MXC_GCR->pm |= mask;
+    if (!(mask & MXC_F_MCR_CTRL_ERTCO_EN)) {
+        return E_BAD_PARAM;
+    }
+
+    MXC_MCR->ctrl &= ~mask;
+
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me30.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me30.c
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2024-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,33 +63,6 @@ int MXC_RTC_SetTimeofdayAlarm(uint32_t ras)
 int MXC_RTC_SetSubsecondAlarm(uint32_t rssa)
 {
     return MXC_RTC_RevA_SetSubsecondAlarm((mxc_rtc_reva_regs_t *)MXC_RTC, rssa);
-}
-
-int MXC_RTC_SetClockSource(mxc_rtc_clock_t clk_src)
-{
-    uint8_t retval = E_NO_ERROR;
-
-    switch (clk_src) {
-    case MXC_RTC_ERTCO_CLK:
-#ifndef MSDK_NO_GPIO_CLK_INIT
-        retval = MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
-#endif // MSDK_NO_GPIO_CLK_INIT
-        MXC_SETFIELD(MXC_MCR->ctrl, MXC_F_MCR_CTRL_CLKSEL, MXC_S_MCR_CTRL_CLKSEL_ERTCO);
-        break;
-
-    case MXC_RTC_INRO_CLK:
-        MXC_SETFIELD(MXC_MCR->ctrl, MXC_F_MCR_CTRL_CLKSEL, MXC_S_MCR_CTRL_CLKSEL_INRO_DIV4);
-        break;
-
-    case MXC_RTC_EXT_CLK:
-        return E_NOT_SUPPORTED;
-
-    default:
-        // Invalid clock source
-        return E_BAD_PARAM;
-    }
-
-    return retval;
 }
 
 int MXC_RTC_Start(void)

--- a/Libraries/PeriphDrivers/Source/SYS/SVD/gcr_me30.svd
+++ b/Libraries/PeriphDrivers/Source/SYS/SVD/gcr_me30.svd
@@ -434,7 +434,7 @@
           <field derivedFrom="GPIO_WE">
             <name>WUT_WE</name>
             <description>Enable Wakeup Timer as wakeup source.</description>
-            <bitOffset>7</bitOffset>
+            <bitOffset>6</bitOffset>
             <bitWidth>1</bitWidth>
           </field>
           <field>

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me30.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me30.c
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2024-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -198,19 +198,17 @@ int MXC_SYS_RTCClockDisable(void)
     }
 }
 
-#if TARGET_NUM == 32655
-/******************************************************************************/
-void MXC_SYS_RTCClockPowerDownEn(void)
+int MXC_SYS_Select32KClockSource(mxc_sys_32k_clock_t clock)
 {
-    MXC_MCR->ctrl |= MXC_F_MCR_CTRL_32KOSC_EN;
-}
+    if (clock > MXC_SYS_32K_CLOCK_RTC_IN) {
+        return E_BAD_PARAM;
+    }
 
-/******************************************************************************/
-void MXC_SYS_RTCClockPowerDownDis(void)
-{
-    MXC_MCR->ctrl &= ~MXC_F_MCR_CTRL_32KOSC_EN;
+    MXC_MCR->ctrl &= ~MXC_F_MCR_CTRL_CLKSEL;
+    MXC_MCR->ctrl |= (clock << MXC_F_MCR_CTRL_CLKSEL_POS);
+
+    return E_NO_ERROR;
 }
-#endif //TARGET_NUM == 32655
 
 /******************************************************************************/
 int MXC_SYS_ClockSourceEnable(mxc_sys_system_clock_t clock)
@@ -232,7 +230,7 @@ int MXC_SYS_ClockSourceEnable(mxc_sys_system_clock_t clock)
         break;
 
     case MXC_SYS_CLOCK_INRO:
-        // The 80k clock is always enabled
+        // The 131k clock is always enabled
         return MXC_SYS_Clock_Timeout(MXC_F_GCR_CLKCTRL_INRO_RDY);
         break;
 

--- a/Libraries/zephyr/MAX/Include/wrap_max32_lp.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_lp.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2023 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,12 +61,20 @@ static inline void Wrap_MXC_LP_EnterPowerDownMode(void)
 
 static inline void Wrap_MXC_LP_EnterLowPowerMode(void)
 {
+#if defined(CONFIG_SOC_MAX32657)
+    MXC_LP_EnterSleepMode();
+#else
     MXC_LP_EnterLowPowerMode();
+#endif
 }
 
 static inline void Wrap_MXC_LP_EnterMicroPowerMode(void)
 {
+#if defined(CONFIG_SOC_MAX32657)
+    MXC_LP_EnterSleepMode();
+#else
     MXC_LP_EnterMicroPowerMode();
+#endif
 }
 
 static inline void Wrap_MXC_LP_EnterStandbyMode(void)

--- a/Libraries/zephyr/MAX/Include/wrap_max32_rtc.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_rtc.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2024-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@
 
 /***** Includes *****/
 #include <rtc.h>
+#include <mxc_sys.h>
+#include "wrap_max32_sys.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,32 +30,11 @@ extern "C" {
 
 #if defined(CONFIG_SOC_MAX32657)
 
-static inline mxc_rtc_clock_t wrap_get_clock_source_instance(uint8_t clock_source)
-{
-    mxc_rtc_clock_t clk_src;
-
-    switch (clock_source) {
-    case 4: // ADI_MAX32_PRPH_CLK_SRC_ERTCO
-        clk_src = MXC_RTC_ERTCO_CLK;
-        break;
-    case 5: // ADI_MAX32_PRPH_CLK_SRC_INRO
-        clk_src = MXC_RTC_INRO_CLK;
-        break;
-    default:
-        return -1;
-    }
-
-    return clk_src;
-}
-
 static inline int Wrap_MXC_RTC_Init(uint32_t sec, uint16_t ssec, uint8_t clock_source)
 {
     int ret;
-    mxc_rtc_clock_t clk_src;
 
-    clk_src = wrap_get_clock_source_instance(clock_source);
-
-    if (MXC_RTC_SetClockSource(clk_src) == E_NO_ERROR) {
+    if (Wrap_MXC_SYS_Select32KClockSource(clock_source) == E_NO_ERROR) {
         ret = MXC_RTC_Init(sec, ssec);
     } else {
         ret = E_BAD_PARAM;

--- a/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2023 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,11 @@ static inline void Wrap_MXC_SYS_SetClockDiv(int div)
     MXC_SYS_Clock_Div((mxc_sys_system_div_t)div);
 }
 
+static inline int Wrap_MXC_SYS_Select32KClockSource(int clock)
+{
+    return 0;
+}
+
 /*
  *  MAX32690, MAX32655 related mapping
  */
@@ -82,6 +87,36 @@ static inline void Wrap_MXC_SYS_SetClockDiv(int div)
 {
     MXC_SYS_SetClockDiv((mxc_sys_system_clock_div_t)div);
 }
+
+#if defined(CONFIG_SOC_MAX32657)
+static inline mxc_sys_32k_clock_t wrap_get_32k_clock_source_instance(uint8_t clock_source)
+{
+    mxc_sys_32k_clock_t clk_src;
+
+    switch (clock_source) {
+    case 4: // ADI_MAX32_PRPH_CLK_SRC_ERTCO
+        clk_src = MXC_SYS_32K_CLOCK_ERTCO;
+        break;
+    case 5: // ADI_MAX32_PRPH_CLK_SRC_INRO
+        clk_src = MXC_SYS_32K_CLOCK_INRO;
+        break;
+    default:
+        return -1;
+    }
+
+    return clk_src;
+}
+
+static inline int Wrap_MXC_SYS_Select32KClockSource(int clock)
+{
+    return MXC_SYS_Select32KClockSource(wrap_get_32k_clock_source_instance(clock));
+}
+#else
+static inline int Wrap_MXC_SYS_Select32KClockSource(int clock)
+{
+    return 0;
+}
+#endif
 
 #endif // part number
 


### PR DESCRIPTION
### Description

This PR updates MAX32657 low power API as listed below.
1. Implement standby mode. 
2. Implement SRAM retention.
3. Remove unsupported API functions.
4. Update _wrap_max32_lp.h_ to map wrapper functions to MAX32657 low power modes.
5. Fixed position of Wake-up Timer wake enable bit.
6. Moved 32K system clock source selection into sys_me30.c.

