### PR TITLE
fix(CMSIS): Remove UART PIN register from MAX32657

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.svd
@@ -10929,26 +10929,6 @@
      </fields>
     </register>
     <register>
-     <name>PIN</name>
-     <description> Pin register</description>
-     <addressOffset>0x001C</addressOffset>
-     <fields>
-      <field>
-       <name>CTS</name>
-       <description>Current sampled value of CTS IO</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-only</access>
-      </field>
-      <field>
-       <name>RTS</name>
-       <description>This bit controls the value to apply on the RTS IO. If set to 1, the RTS IO is set to high level. If set to 0, the RTS IO is set to low level.</description>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-     </fields>
-    </register>
-    <register>
      <name>FIFO</name>
      <description>FIFO Read/Write register</description>
      <addressOffset>0x0020</addressOffset>

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/uart_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/uart_regs.h
@@ -83,7 +83,7 @@ typedef struct {
     __IO uint32_t clkdiv;               /**< <tt>\b 0x0010:</tt> UART CLKDIV Register */
     __IO uint32_t osr;                  /**< <tt>\b 0x0014:</tt> UART OSR Register */
     __IO uint32_t txpeek;               /**< <tt>\b 0x0018:</tt> UART TXPEEK Register */
-    __IO uint32_t pin;                  /**< <tt>\b 0x001C:</tt> UART PIN Register */
+    __R  uint32_t rsv_0x1c;
     __IO uint32_t fifo;                 /**< <tt>\b 0x0020:</tt> UART FIFO Register */
     __R  uint32_t rsv_0x24_0x2f[3];
     __IO uint32_t dma;                  /**< <tt>\b 0x0030:</tt> UART DMA Register */
@@ -105,7 +105,6 @@ typedef struct {
 #define MXC_R_UART_CLKDIV                  ((uint32_t)0x00000010UL) /**< Offset from UART Base Address: <tt> 0x0010</tt> */
 #define MXC_R_UART_OSR                     ((uint32_t)0x00000014UL) /**< Offset from UART Base Address: <tt> 0x0014</tt> */
 #define MXC_R_UART_TXPEEK                  ((uint32_t)0x00000018UL) /**< Offset from UART Base Address: <tt> 0x0018</tt> */
-#define MXC_R_UART_PIN                     ((uint32_t)0x0000001CUL) /**< Offset from UART Base Address: <tt> 0x001C</tt> */
 #define MXC_R_UART_FIFO                    ((uint32_t)0x00000020UL) /**< Offset from UART Base Address: <tt> 0x0020</tt> */
 #define MXC_R_UART_DMA                     ((uint32_t)0x00000030UL) /**< Offset from UART Base Address: <tt> 0x0030</tt> */
 #define MXC_R_UART_WKEN                    ((uint32_t)0x00000034UL) /**< Offset from UART Base Address: <tt> 0x0034</tt> */
@@ -305,20 +304,6 @@ typedef struct {
 #define MXC_F_UART_TXPEEK_DATA                         ((uint32_t)(0xFFUL << MXC_F_UART_TXPEEK_DATA_POS)) /**< TXPEEK_DATA Mask */
 
 /**@} end of group UART_TXPEEK_Register */
-
-/**
- * @ingroup  uart_registers
- * @defgroup UART_PIN UART_PIN
- * @brief     Pin register
- * @{
- */
-#define MXC_F_UART_PIN_CTS_POS                         0 /**< PIN_CTS Position */
-#define MXC_F_UART_PIN_CTS                             ((uint32_t)(0x1UL << MXC_F_UART_PIN_CTS_POS)) /**< PIN_CTS Mask */
-
-#define MXC_F_UART_PIN_RTS_POS                         1 /**< PIN_RTS Position */
-#define MXC_F_UART_PIN_RTS                             ((uint32_t)(0x1UL << MXC_F_UART_PIN_RTS_POS)) /**< PIN_RTS Mask */
-
-/**@} end of group UART_PIN_Register */
 
 /**
  * @ingroup  uart_registers

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb_me30.svd
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb_me30.svd
@@ -347,26 +347,6 @@
         </fields>
       </register>
       <register>
-        <name>PIN</name>
-        <description> Pin register</description>
-        <addressOffset>0x001C</addressOffset>
-        <fields>
-          <field>
-            <name>CTS</name>
-            <description>Current sampled value of CTS IO</description>
-            <bitOffset>0</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-only</access>
-          </field>
-          <field>
-            <name>RTS</name>
-            <description>This bit controls the value to apply on the RTS IO. If set to 1, the RTS IO is set to high level. If set to 0, the RTS IO is set to low level.</description>
-            <bitOffset>1</bitOffset>
-            <bitWidth>1</bitWidth>
-          </field>
-        </fields>
-      </register>
-      <register>
         <name>FIFO</name>
         <description>FIFO Read/Write register</description>
         <addressOffset>0x0020</addressOffset>


### PR DESCRIPTION
### Description

The UART PIN register is not supported for the MAX32657.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.