### PR TITLE
fix(Other): Fix Wrap_MXC_CAN_Init signature

### DIFF
--- a/Libraries/zephyr/MAX/Include/wrap_max32_can.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_can.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2024-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,9 @@
 extern "C" {
 #endif
 
-static inline void Wrap_MXC_CAN_Init(uint32_t can_idx, mxc_can_obj_cfg_t cfg,
-                                     mxc_can_unit_event_cb_t unit_cb,
-                                     mxc_can_object_event_cb_t obj_cb)
+static inline int Wrap_MXC_CAN_Init(uint32_t can_idx, mxc_can_obj_cfg_t cfg,
+                                    mxc_can_unit_event_cb_t unit_cb,
+                                    mxc_can_object_event_cb_t obj_cb)
 {
     /* The only API difference between the MAX32662 and MAX32690 relevant to
      * implementing the max32 CAN driver in Zephyr is that the former requires a
@@ -40,11 +40,11 @@ static inline void Wrap_MXC_CAN_Init(uint32_t can_idx, mxc_can_obj_cfg_t cfg,
     /* A value of -1 is invalid, will configure no GPIOs, but still pass through
      * to MXC_CAN_RevA_Init, even in case MSDK_NO_GPIO_CLK_INIT wasn't set.
      */
-    MXC_CAN_Init(can_idx, cfg, unit_cb, obj_cb, -1);
+    return MXC_CAN_Init(can_idx, cfg, unit_cb, obj_cb, -1);
 
     /* MAX32690 related mapping */
 #elif defined(CONFIG_SOC_MAX32690)
-    MXC_CAN_Init(can_idx, cfg, unit_cb, obj_cb);
+    return MXC_CAN_Init(can_idx, cfg, unit_cb, obj_cb);
 
 #endif // part number
 }


### PR DESCRIPTION
### Description

Fixes a bug introduced by #1306, which added a Zephyr wrapper for `MXC_CAN_Init`, whose signature differs between the MAX32662 and MAX32690.

The previous implementation declared `Wrap_MXC_CAN_Init` as `void` and discarded the return value of the underlying `MXC_CAN_Init` calls. This is incompatible with the can_max32 driver which does error checking and expects an `int` return value.

While this is a "breaking" change, no code currently depends on this wrapper, because its signature is invalid and could not be properly used in the can_max32 driver.

#### How did this happen?

This is entirely my fault, as I was rushing to get some zephyr can_max32 changes in, on the last Friday before the winter holiday break. (I am now well aware of how stupid that is...)

While working on this wrapper, I used the following forks: [trupples/msdk](https://github.com/trupples/msdk), [trupples/hal_adi](https://github.com/trupples/hal_adi). I *did* catch this error and [fixed it in hal_adi](https://github.com/trupples/hal_adi/commit/55ebe41bc769ab4532e3e2cf7a7676cd73f5c5ea), but **didn't push the same changes to msdk**. 

At that point, trupples/hal_adi had the correct implementation (int return), but trupples/msdk did not (void return).

I was able to build and test an application using the driver, because in zephyr I only referenced my hal_adi repo. In PR #1306 **I claimed the wrapper is correct and tested**, and the PR got accepted, but with the wrong code. The wrong code was then automatically copied to [analogdevicesinc/hal_adi](https://github.com/analogdevicesinc/hal_adi).

NB: should have listened to [shouldideploy.today](https://shouldideploy.today/)

#### Validation

A minimal example to test this on both MAX32662 and MAX32690 can be found at [trupples/max32-can-validate](https://github.com/trupples/max32-can-validate/). It unfortunately requires some fiddling around to get the WIP driver from innersource. Most importantly, the entire process is automated by [`validate.sh`](https://github.com/trupples/max32-can-validate/blob/main/validate.sh), which:

1. Clones hal_adi (develop branch), msdk (the branch in this PR)
2. Uses zephyr-hal.sh to properly copy files to hal_adi
3. Prepares the west workspace
4. Overwrites hal_adi with modified variant (this is the step I'm most doubtful of, because it intentionally bypasses `west update` to more easily apply the changes)
5. Builds example for MAX32690 and MAX32662

Usage:
```sh
cd /path/to/west_workspace
git clone https://github.com/trupples/max32-can-validate/ validate
cd validate
./validate.sh
```

I have successfully run this, and I am quite confident that I am not wasting your time with a second bad PR, but I'd like a sanity check.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.