### PR TITLE
feat(PeriphDrivers): Add MAX32657 non-blocking clock measurement

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32657/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/mxc_sys.h
@@ -364,12 +364,15 @@ int MXC_SYS_LockDAP_Permanent(void);
  * 
  * @details Assumes that measurement clock and ERFO are enabled. 
  * Increasing compareClockTicks will provide a more accurate measurement, 
- * but there are limits that could cause overflow.
+ * but there are limits that could cause overflow. Start and Get function
+ * are used for non-blocking implementations.
  * 
  * @param clock Enumeration for which clock to measure.
  * @param compareClockTicks Number of ticks of the comparison clock to use for measurement.
  */
 uint32_t MXC_SYS_ClockMeasure(mxc_sys_compare_clock_t clock, uint32_t compareClockTicks);
+void MXC_SYS_StartClockMeasure(mxc_sys_compare_clock_t clock, uint32_t compareClockTicks);
+uint32_t MXC_SYS_GetClockMeasure(void);
 
 #ifdef __cplusplus
 }

--- a/Libraries/PeriphDrivers/Include/MAX32657/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/mxc_sys.h
@@ -360,7 +360,7 @@ uint32_t MXC_SYS_RiscVClockRate(void);
 int MXC_SYS_LockDAP_Permanent(void);
 
 /**
- * @brief Measure the clock frequency.
+ * @brief Measure the clock frequency, blocking.
  * 
  * @details Assumes that measurement clock and ERFO are enabled. 
  * Increasing compareClockTicks will provide a more accurate measurement, 
@@ -369,9 +369,25 @@ int MXC_SYS_LockDAP_Permanent(void);
  * 
  * @param clock Enumeration for which clock to measure.
  * @param compareClockTicks Number of ticks of the comparison clock to use for measurement.
+ * @return clock frequency
  */
 uint32_t MXC_SYS_ClockMeasure(mxc_sys_compare_clock_t clock, uint32_t compareClockTicks);
+
+/**
+ * @brief Start clock frequency measurement, non blocking.
+ *
+ * @param clock Enumeration for which clock to measure.
+ * @param compareClockTicks Number of ticks of the comparison clock to use for measurement.
+ */
 void MXC_SYS_StartClockMeasure(mxc_sys_compare_clock_t clock, uint32_t compareClockTicks);
+
+/**
+ * @brief Get clock frequency measurement after calling start, non blocking.
+ *
+ * @param clock Enumeration for which clock to measure.
+ * @param compareClockTicks Number of ticks of the comparison clock to use for measurement.
+ * @return clock frequency, 0 if measurement is unfinished.
+ */
 uint32_t MXC_SYS_GetClockMeasure(void);
 
 #ifdef __cplusplus

--- a/Libraries/PeriphDrivers/Source/LP/lp_me30.c
+++ b/Libraries/PeriphDrivers/Source/LP/lp_me30.c
@@ -46,6 +46,9 @@ void MXC_LP_EnterStandbyMode(void)
 
     /* Go into Standby mode and wait for an interrupt to wake the processor */
     __WFI();
+
+    /* Clear SLEEPDEEP bit to prevent WFI from entering deep sleep */
+    CLR_SLEEPDEEP();
 }
 
 void MXC_LP_EnterBackupMode(void)

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me30.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me30.c
@@ -542,7 +542,7 @@ int MXC_SYS_LockDAP_Permanent(void)
 #endif
 
 /* ************************************************************************** */
-uint32_t MXC_SYS_ClockMeasure(mxc_sys_compare_clock_t clock, uint32_t compareClockTicks)
+void MXC_SYS_StartClockMeasure(mxc_sys_compare_clock_t clock, uint32_t compareClockTicks)
 {
     /* Assuming that both clocks are already enabled */
 
@@ -563,14 +563,32 @@ uint32_t MXC_SYS_ClockMeasure(mxc_sys_compare_clock_t clock, uint32_t compareClo
 
     /* Start the procedure */
     MXC_FCR->frqcntctrl |= MXC_F_FCR_FRQCNTCTRL_START;
+}
 
-    /* Wait for the procedure to finish */
-    while (!(MXC_FCR->intfl & MXC_F_FCR_INTFL_FRQCNT)) {}
+/* ************************************************************************** */
+uint32_t MXC_SYS_GetClockMeasure(void)
+{
+    /* Return 0 if the procedure is incomplete */
+    if(!(MXC_FCR->intfl & MXC_F_FCR_INTFL_FRQCNT)) {
+        return 0;
+    }
 
     /* Calculate the frequency */
     uint64_t freq = (uint64_t)ERFO_FREQ * (uint64_t)MXC_FCR->cmpclk / (uint64_t)MXC_FCR->refclk;
 
     return (uint32_t)freq;
+}
+
+/* ************************************************************************** */
+uint32_t MXC_SYS_ClockMeasure(mxc_sys_compare_clock_t clock, uint32_t compareClockTicks)
+{
+    /* Assuming that both clocks are already enabled */
+    MXC_SYS_StartClockMeasure(clock, compareClockTicks);
+
+    /* Wait for the procedure to finish */
+    while (!(MXC_FCR->intfl & MXC_F_FCR_INTFL_FRQCNT)) {}
+
+    return MXC_SYS_GetClockMeasure();
 }
 
 /**@} end of mxc_sys */

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me30.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me30.c
@@ -569,7 +569,7 @@ void MXC_SYS_StartClockMeasure(mxc_sys_compare_clock_t clock, uint32_t compareCl
 uint32_t MXC_SYS_GetClockMeasure(void)
 {
     /* Return 0 if the procedure is incomplete */
-    if(!(MXC_FCR->intfl & MXC_F_FCR_INTFL_FRQCNT)) {
+    if (!(MXC_FCR->intfl & MXC_F_FCR_INTFL_FRQCNT)) {
         return 0;
     }
 


### PR DESCRIPTION
### Description

Adding non-blocking functions for clock measurement. 

Clearing SLEEPDEEP bit after exiting standby mode. This will prevent the WFI instruction from causing the MCU to enter standby. 

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
