### PR TITLE
fix(Other): Add FLC wrap file to fix Zephyr flash problems for MAX32690

### DIFF
--- a/Libraries/zephyr/MAX/Include/wrap_max32_flc.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_flc.h
@@ -1,0 +1,56 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2025 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#ifndef LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_FLC_H_
+#define LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_FLC_H_
+
+/***** Includes *****/
+#include <flc.h>
+#include <icc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(CONFIG_SOC_MAX32690)
+
+static inline int Wrap_MXC_FLC_Write(uint32_t address, uint32_t length, uint32_t *buffer)
+{
+    int ret = 0;
+
+    MXC_ICC_Disable(MXC_ICC);
+    ret = MXC_FLC_Write(address, length, buffer);
+    MXC_ICC_Enable(MXC_ICC);
+
+    return ret;
+}
+
+#else
+
+static inline int Wrap_MXC_FLC_Write(uint32_t address, uint32_t length, uint32_t *buffer)
+{
+    return MXC_FLC_Write(address, length, buffer);
+}
+
+#endif // part number
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // LIBRARIES_ZEPHYR_MAX_INCLUDE_WRAP_MAX32_FLC_H_


### PR DESCRIPTION
### Description

FLC write functions require disabling ICC first. I added this operation to fix problems of Zephyr flash tests for MAX32690 boards.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.