### PR TITLE
feat(Examples): Expand MAX32650 SPI example to select SPI instance

### DIFF
--- a/Examples/MAX32650/SPI/README.md
+++ b/Examples/MAX32650/SPI/README.md
@@ -1,10 +1,22 @@
 ## Description
 
-This example configures the SPI to send data between the MISO (1.28) and MOSI (P1.29) pins.  Connect these two pins together.
+This example configures the SPI to send data between the MISO and MOSI pins of
+the specified SPI instance.  If no SPI instance is specified, the default instance
+is SPI1.  Connect the MISO and MOSI lines together per the table below:
+
+| SPI Inst | MISO | MOSI |
+| -------- | ---- | ---- |
+| SPI0     | 3.1  | 3.2  |
+| SPI1     | 1.28 | 1.29 |
+| SPI2     | 2.3  | 2.4  |
+| SPI3     | 0.20 | 0.21 |
 
 Multiple word sizes (2 through 16 bits) are demonstrated.
 
-By default, the example performs blocking SPI transactions.  To switch to non-blocking (asynchronous) transactions, reset the MASTERSYNC macro to 0 and set the MASTERASYNC macro to 1.  To use DMA transactions, set the MASTERDMA macro to 1 instead.
+By default, the example performs blocking SPI transactions.  To switch to
+non-blocking (asynchronous) transactions, reset the MASTERSYNC macro to 0 and set
+the MASTERASYNC macro to 1.  To use DMA transactions, set the MASTERDMA macro to
+1 instead.
 
 
 ## Software
@@ -15,13 +27,16 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+Update the project.mk file to specify the desired SPI instance via the TEST_SPI_NUM
+definition. Valid values for TEST_SPI_NUM are 0-3:
+
+`PROJ_CFLAGS += -DTEST_SPI_NUM=1`
 
 ## Required Connections
 
 -   Connect a USB cable between the PC and the CN2 (USB/PWR) connector.
 -   Open an terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
--   You must connect P1.29 (MOSI) to P1.28 (MISO).
+-   You must connect MOSI to MISO per the desired SPI instance.
 
 ## Expected Output
 

--- a/Examples/MAX32650/SPI/main.c
+++ b/Examples/MAX32650/SPI/main.c
@@ -1,15 +1,15 @@
 /**
  * @file    main.c
  * @brief   SPI Master Demo
- * @details Shows Master loopback demo for QSPI1
+ * @details Shows Master loopback demo for MAX32650
  *          Read the printf() for instructions
  */
 
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,8 +56,34 @@
 #define VALUE 0xFFFF
 #define SPI_SPEED 100000 // Bit Rate
 
+/* Default to SPI1 if not specified */
+#ifndef TEST_SPI_NUM
+#define TEST_SPI_NUM 1
+#endif
+
+#if TEST_SPI_NUM == 0
+#define SPI MXC_SPI0
+#define SPI_IRQ SPI0_IRQn
+#define SPI_MISO_STR "P3.1"
+#define SPI_MOSI_STR "P3.2"
+#elif TEST_SPI_NUM == 1
 #define SPI MXC_SPI1
 #define SPI_IRQ SPI1_IRQn
+#define SPI_MISO_STR "P1.28"
+#define SPI_MOSI_STR "P1.29"
+#elif TEST_SPI_NUM == 2
+#define SPI MXC_SPI2
+#define SPI_IRQ SPI2_IRQn
+#define SPI_MISO_STR "P2.3"
+#define SPI_MOSI_STR "P2.4"
+#elif TEST_SPI_NUM == 3
+#define SPI MXC_SPI3
+#define SPI_IRQ SPI3_IRQn
+#define SPI_MISO_STR "P0.20"
+#define SPI_MOSI_STR "P0.21"
+#else
+#error "Invalid SPI Instance specified!"
+#endif
 
 /***** Globals *****/
 uint16_t rx_data[DATA_LEN];
@@ -66,7 +92,7 @@ volatile int SPI_FLAG;
 volatile uint8_t DMA_FLAG = 0;
 
 /***** Functions *****/
-void SPI0_IRQHandler(void)
+void SPI_IRQHandler(void)
 {
     MXC_SPI_AsyncHandler(SPI);
 }
@@ -94,11 +120,11 @@ int main(void)
     mxc_spi_req_t req;
 
     printf("\n************** SPI Loopback Demo ****************\n");
-    printf("This example configures the SPI to send data between the MISO (P1.28) and\n");
-    printf("MOSI (P1.29) pins.  Connect these two pins together.  This demo shows SPI\n");
-    printf("sending different bit sizes each run through. If successful, the green LED will\n");
-    printf("illuminate.\n");
-
+    printf("This example configures the SPI to send data between the MISO (" SPI_MISO_STR
+           ") and\n");
+    printf("MOSI (" SPI_MOSI_STR ") pins.  Connect these two pins together.\n");
+    printf("This demo shows SPI sending different bit sizes each run through.\n"
+           "If successful, the green LED will illuminate.\n");
     printf("\nThis demo shows Asynchronous, Synchronous and DMA transaction for SPI1\n");
 
     for (i = 1; i < 17; i++) {
@@ -149,7 +175,7 @@ int main(void)
 #endif
 
 #if MASTERASYNC
-        MXC_NVIC_SetVector(SPI_IRQ, SPI0_IRQHandler);
+        MXC_NVIC_SetVector(SPI_IRQ, SPI_IRQHandler);
         NVIC_EnableIRQ(SPI_IRQ);
         MXC_SPI_MasterTransactionAsync(&req);
 

--- a/Examples/MAX32650/SPI/project.mk
+++ b/Examples/MAX32650/SPI/project.mk
@@ -16,19 +16,20 @@
  #
  ##############################################################################
 # This file can be used to set build configuration
-# variables.  These variables are defined in a file called 
+# variables.  These variables are defined in a file called
 # "Makefile" that is located next to this one.
 
 # For instructions on how to use this system, see
 # https://analogdevicesinc.github.io/msdk/USERGUIDE/#build-system
 
 #BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
+# ^ For example, you can uncomment this line to make the
 # project build for the "FTHR_RevA" board.
 
 # **********************************************************
 
-# Add your config here!
+# Set the TEST_SPI_NUM here [0-3] to specify the SPI instance to test
+PROJ_CFLAGS += -DTEST_SPI_NUM=1
 
 # If you have secure version of MCU (MAX32651), set SBT=1 to generate signed binary
 # For more information on how sing process works, see


### PR DESCRIPTION
Updated the MAX32650 SPI example project to allow the user to select the SPI instance to test. All of the driver logic remained the same, the additions updated the instance and IRQ constants and loopback instructions during startup, as well as documentation.

This was based on a customer request regarding confusion on the SPI drivers, as well as identifying the MISO and MOSI lines when leveraging SPI3.

