### PR TITLE
ci(workflow): Update Zephyr-HAL workflow

### DIFF
--- a/.github/workflows/scripts/zephyr-hal.sh
+++ b/.github/workflows/scripts/zephyr-hal.sh
@@ -19,6 +19,10 @@ cd ${msdk}
 msdk_head=$(git rev-parse HEAD)
 cd ${root_dir}
 
+# Store msdk_sha file if exist
+if [ -e "${hal_adi}/MAX/msdk_sha" ]; then
+    mv ${hal_adi}/MAX/msdk_sha ${root_dir}
+fi
 
 # Cleanup hal_adi
 rm -rf ${hal_adi}/MAX/
@@ -31,6 +35,11 @@ mkdir -p ${hal_adi}/MAX/Libraries/PeriphDrivers
 
 # Copy zephyr wrappers, system files and cmakefiles
 cp -rf ${msdk}/Libraries/zephyr/MAX/*  ${hal_adi}/MAX/
+
+# Move "msdk_sha" file again to not create a difference.
+if [ -e "${root_dir}/msdk_sha" ]; then
+    mv ${root_dir}/msdk_sha ${hal_adi}/MAX
+fi
 
 # Copy CMSIS folder
 cp -rf ${msdk}/Libraries/CMSIS/Device  ${hal_adi}/MAX/Libraries/CMSIS/

--- a/.github/workflows/zephyr-hal.yml
+++ b/.github/workflows/zephyr-hal.yml
@@ -69,10 +69,19 @@ jobs:
 
       - name: Push changes to hal_adi repository
         run: |
-          echo "$(pwd) - $(ls)"
+          echo -e "$(pwd)\n\n$(ls)\n"
           cd ./hal_adi
-          git config --global user.email "actions@github.com"
-          git config --global user.name "GitHub Actions"
-          git add *
-          git commit -m "Update Zephyr MSDK Hal based on MSDK PR: https://github.com/analogdevicesinc/msdk/pull/${PR_NUM}"
-          git push 
+          if [[ -n $(git status -s) ]]; then
+            echo "Starting to commit changes to hal_adi repository"
+            cd ${msdk}
+            msdk_head=$(git rev-parse HEAD)
+            commit_author=$(git show --no-patch --format="%an <%ae>" ${msdk_head})
+            commit_msg=$(git show --no-patch --format="%B" ${msdk_head})
+
+            cd ${hal_adi}
+            git add *
+            git commit --author="${commit_author}" -m "${commit_msg}"
+            git push
+          else
+            echo "No changes to commit"
+          fi


### PR DESCRIPTION
### Description

Current workflow sends some commits which has only "msdk_sha" file change. To avoid these commits, I implemented a solution which protects "msdk_sha" file from remove operation.

Also, I updated workflow to send commits to "hal_adi" with same description and author information as MSDK commits.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.