### PR TITLE
fix(PeriphDrivers): Fix UART RevB Driver not cleaning up Async Transactions

### DIFF
--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -749,9 +749,11 @@ int MXC_UART_RevB_AsyncTxCallback(mxc_uart_revb_regs_t *uart, int retVal)
 
     mxc_uart_req_t *req = (mxc_uart_req_t *)AsyncTxRequests[uart_num];
     if ((req != NULL) && (req->callback != NULL)) {
-        AsyncTxRequests[uart_num] = NULL;
         req->callback(req, retVal);
     }
+
+    // Cleanup Async Transaction
+    AsyncTxRequests[uart_num] = NULL;
 
     return E_NO_ERROR;
 }
@@ -762,9 +764,11 @@ int MXC_UART_RevB_AsyncRxCallback(mxc_uart_revb_regs_t *uart, int retVal)
 
     mxc_uart_req_t *req = (mxc_uart_req_t *)AsyncRxRequests[uart_num];
     if ((req != NULL) && (req->callback != NULL)) {
-        AsyncRxRequests[uart_num] = NULL;
         req->callback(req, retVal);
     }
+
+    // Cleanup Async Transaction
+    AsyncRxRequests[uart_num] = NULL;
 
     return E_NO_ERROR;
 }


### PR DESCRIPTION
## Description
Currently, the private AsyncTxRequests and AsyncRxRequests arrays are used to track transactions in progress for uart_revb.c. The Tx/Rx Async Callbacks check for a callback function before clearing the Requests:

```C
mxc_uart_req_t *req = (mxc_uart_req_t *)AsyncTxRequests[uart_num];
if ((req != NULL) && (req->callback != NULL)) {
    AsyncTxRequests[uart_num] = NULL;
    req->callback(req, retVal);
}
```

This means that if the user does not supply an explicit callback function, a transaction never gets cleared, causing problems after just one transaction.

This commit resolves this by moving the cleanup of this important struct outside of the conditional check for a callback function.

```C
mxc_uart_req_t *req = (mxc_uart_req_t *)AsyncTxRequests[uart_num];
if ((req != NULL) && (req->callback != NULL)) {
    req->callback(req, retVal);
}

// Cleanup Async Transaction
AsyncTxRequests[uart_num] = NULL;
```

## Testing 
This was tested as part of development for UART functionality in the CircuitPython BUSIO.UART module:
https://github.com/Brandon-Hurst/circuitpython/blob/ports/analog/add-busio/ports/analog/common-hal/busio/UART.c

I found that it was necessary to submit a callback function for the Async API to work correctly. This fix is to correct this, so the user doesn't have to supply a callback to have the Async Requests cleaned up. 

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.