### PR TITLE
fix(Examples): Add LP Lockout protection to all LP examples

### DIFF
--- a/Examples/MAX32520/LP/README.md
+++ b/Examples/MAX32520/LP/README.md
@@ -5,6 +5,46 @@ TBD<!--TBD-->
 
 ## Software
 
+### WARNING: Low-Power Mode Flash / Debug Access
+
+Microcontrollers usually shutdown SWD /JTAG debug interfaces in very low-power mode operation.
+
+This can cause an MCU to permanently lose debug access because, upon reset, the device may enter LP modes so fast that the debug probe cannot attach to and reset the target core before the debug interface is shutdown. This is true regardless of the debug probe you choose to use.
+
+To avoid this problem, please observe the 2-second delay at the beginning of the main() function. If you find that your MCU can no longer be programmed or debugged after flashing an LP example, you can attempt to recover it using the following procedure from the MSDK User Guide:
+https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+
+Another option for production builds would be to implement Lockout Protection using a free GPIO attached to a switch. Below is some example code for how this may be implemented:
+
+```C
+#ifdef LOCKOUT_PROTECT
+/**
+ * If debugger lockout protection is enabled,
+ * define a switch for enabling the protection.
+ *
+ * Note this is not a board-specific configuration;
+ * Please adapt the GPIO pin(s) to your specific hardware.
+ **/
+static const mxc_gpio_cfg_t lockoutConfig = {
+    .func = MXC_GPIO_FUNC_ALT1,
+    .port = MXC_GPIO0,
+    .mask = MXC_GPIO_PIN_0,
+    .pad = MXC_GPIO_PAD_PULL_UP
+};
+#endif
+
+int main(void) {
+#ifdef LOCKOUT_PROTECT
+    MXC_GPIO_Config(&lockoutConfig);
+
+    // If lockout switch is pulled low, prevent sleep or trigger a long delay
+    if (MXC_GPIO_InGet(lockoutConfig.port, lockoutConfig.mask)) {
+        MXC_Delay(MXC_DELAY_SEC(2));
+        allowSleep = 0;
+    }
+#endif
+```
+
 ### Project Usage
 
 Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.

--- a/Examples/MAX32520/LP/main.c
+++ b/Examples/MAX32520/LP/main.c
@@ -98,6 +98,15 @@ void setTrigger(int waitForTrigger)
 
 int main(void)
 {
+    /** PLEASE READ **/
+    // MCU shuts down SWD interface in LP modes
+    // Delay at application start to prevent debugger losing access on restarts
+    //
+    // Only remove this if you are okay with losing debug access
+    // If you can't flash/debug the device, please consult this guide:
+    // https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+    MXC_Delay(MXC_DELAY_SEC(2));
+
     PRINT("****Low Power Mode Example****\n\n");
 
     PRINT("This code cycles through the MAX32520 power modes, "

--- a/Examples/MAX32650/LP/README.md
+++ b/Examples/MAX32650/LP/README.md
@@ -7,6 +7,46 @@ The wakeup source can be configured to be either the RTC clock or the push butto
 
 ## Software
 
+### WARNING: Low-Power Mode Flash / Debug Access
+
+Microcontrollers usually shutdown SWD /JTAG debug interfaces in very low-power mode operation.
+
+This can cause an MCU to permanently lose debug access because, upon reset, the device may enter LP modes so fast that the debug probe cannot attach to and reset the target core before the debug interface is shutdown. This is true regardless of the debug probe you choose to use.
+
+To avoid this problem, please observe the 2-second delay at the beginning of the main() function. If you find that your MCU can no longer be programmed or debugged after flashing an LP example, you can attempt to recover it using the following procedure from the MSDK User Guide:
+https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+
+Another option for production builds would be to implement Lockout Protection using a free GPIO attached to a switch. Below is some example code for how this may be implemented:
+
+```C
+#ifdef LOCKOUT_PROTECT
+/**
+ * If debugger lockout protection is enabled,
+ * define a switch for enabling the protection.
+ *
+ * Note this is not a board-specific configuration;
+ * Please adapt the GPIO pin(s) to your specific hardware.
+ **/
+static const mxc_gpio_cfg_t lockoutConfig = {
+    .func = MXC_GPIO_FUNC_ALT1,
+    .port = MXC_GPIO0,
+    .mask = MXC_GPIO_PIN_0,
+    .pad = MXC_GPIO_PAD_PULL_UP
+};
+#endif
+
+int main(void) {
+#ifdef LOCKOUT_PROTECT
+    MXC_GPIO_Config(&lockoutConfig);
+
+    // If lockout switch is pulled low, prevent sleep or trigger a long delay
+    if (MXC_GPIO_InGet(lockoutConfig.port, lockoutConfig.mask)) {
+        MXC_Delay(MXC_DELAY_SEC(2));
+        allowSleep = 0;
+    }
+#endif
+```
+
 ### Project Usage
 
 Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.

--- a/Examples/MAX32650/LP/main.c
+++ b/Examples/MAX32650/LP/main.c
@@ -146,6 +146,15 @@ void setTrigger(int waitForTrigger)
 // *****************************************************************************
 int main(void)
 {
+    /** PLEASE READ **/
+    // MCU shuts down SWD interface in LP modes
+    // Delay at application start to prevent debugger losing access on restarts
+    //
+    // Only remove this if you are okay with losing debug access
+    // If you can't flash/debug the device, please consult this guide:
+    // https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+    MXC_Delay(MXC_DELAY_SEC(2));
+
     PRINT("****Low Power Mode Example****\n\n");
 
 #if USE_ALARM

--- a/Examples/MAX32650/LP/main.c
+++ b/Examples/MAX32650/LP/main.c
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by
  * Analog Devices, Inc.),
  * Copyright (C) 2023-2024 Analog Devices, Inc.
  *
@@ -49,6 +49,7 @@
 #include "rtc.h"
 #include "uart.h"
 #include "nvic_table.h"
+#include "mxc_delay.h"
 
 #define DELAY_IN_SEC 2
 #define USE_CONSOLE 1

--- a/Examples/MAX32655/LP/README.md
+++ b/Examples/MAX32655/LP/README.md
@@ -8,6 +8,46 @@ Users may also select whether they want to use a GPIO or RTC wakeup source. To u
 
 ## Software
 
+### WARNING: Low-Power Mode Flash / Debug Access
+
+Microcontrollers usually shutdown SWD /JTAG debug interfaces in very low-power mode operation.
+
+This can cause an MCU to permanently lose debug access because, upon reset, the device may enter LP modes so fast that the debug probe cannot attach to and reset the target core before the debug interface is shutdown. This is true regardless of the debug probe you choose to use.
+
+To avoid this problem, please observe the 2-second delay at the beginning of the main() function. If you find that your MCU can no longer be programmed or debugged after flashing an LP example, you can attempt to recover it using the following procedure from the MSDK User Guide:
+https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+
+Another option for production builds would be to implement Lockout Protection using a free GPIO attached to a switch. Below is some example code for how this may be implemented:
+
+```C
+#ifdef LOCKOUT_PROTECT
+/**
+ * If debugger lockout protection is enabled,
+ * define a switch for enabling the protection.
+ *
+ * Note this is not a board-specific configuration;
+ * Please adapt the GPIO pin(s) to your specific hardware.
+ **/
+static const mxc_gpio_cfg_t lockoutConfig = {
+    .func = MXC_GPIO_FUNC_ALT1,
+    .port = MXC_GPIO0,
+    .mask = MXC_GPIO_PIN_0,
+    .pad = MXC_GPIO_PAD_PULL_UP
+};
+#endif
+
+int main(void) {
+#ifdef LOCKOUT_PROTECT
+    MXC_GPIO_Config(&lockoutConfig);
+
+    // If lockout switch is pulled low, prevent sleep or trigger a long delay
+    if (MXC_GPIO_InGet(lockoutConfig.port, lockoutConfig.mask)) {
+        MXC_Delay(MXC_DELAY_SEC(2));
+        allowSleep = 0;
+    }
+#endif
+```
+
 ### Project Usage
 
 Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.

--- a/Examples/MAX32655/LP/main.c
+++ b/Examples/MAX32655/LP/main.c
@@ -162,6 +162,15 @@ void setTrigger(int waitForTrigger)
 
 int main(void)
 {
+    /** PLEASE READ **/
+    // MCU shuts down SWD interface in LP modes
+    // Delay at application start to prevent debugger losing access on restarts
+    //
+    // Only remove this if you are okay with losing debug access
+    // If you can't flash/debug the device, please consult this guide:
+    // https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+    MXC_Delay(MXC_DELAY_SEC(2));
+
     PRINT("****Low Power Mode Example****\n\n");
 
 #if USE_ALARM

--- a/Examples/MAX32655/LP/main.c
+++ b/Examples/MAX32655/LP/main.c
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by
  * Analog Devices, Inc.),
  * Copyright (C) 2023-2024 Analog Devices, Inc.
  *
@@ -49,6 +49,7 @@
 #include "rtc.h"
 #include "uart.h"
 #include "nvic_table.h"
+#include "mxc_delay.h"
 
 #define DELAY_IN_SEC 2
 #define USE_CONSOLE 1

--- a/Examples/MAX32660/LP/README.md
+++ b/Examples/MAX32660/LP/README.md
@@ -5,6 +5,46 @@ TBD<!--TBD-->
 
 ## Software
 
+### WARNING: Low-Power Mode Flash / Debug Access
+
+Microcontrollers usually shutdown SWD /JTAG debug interfaces in very low-power mode operation.
+
+This can cause an MCU to permanently lose debug access because, upon reset, the device may enter LP modes so fast that the debug probe cannot attach to and reset the target core before the debug interface is shutdown. This is true regardless of the debug probe you choose to use.
+
+To avoid this problem, please observe the 2-second delay at the beginning of the main() function. If you find that your MCU can no longer be programmed or debugged after flashing an LP example, you can attempt to recover it using the following procedure from the MSDK User Guide:
+https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+
+Another option for production builds would be to implement Lockout Protection using a free GPIO attached to a switch. Below is some example code for how this may be implemented:
+
+```C
+#ifdef LOCKOUT_PROTECT
+/**
+ * If debugger lockout protection is enabled,
+ * define a switch for enabling the protection.
+ *
+ * Note this is not a board-specific configuration;
+ * Please adapt the GPIO pin(s) to your specific hardware.
+ **/
+static const mxc_gpio_cfg_t lockoutConfig = {
+    .func = MXC_GPIO_FUNC_ALT1,
+    .port = MXC_GPIO0,
+    .mask = MXC_GPIO_PIN_0,
+    .pad = MXC_GPIO_PAD_PULL_UP
+};
+#endif
+
+int main(void) {
+#ifdef LOCKOUT_PROTECT
+    MXC_GPIO_Config(&lockoutConfig);
+
+    // If lockout switch is pulled low, prevent sleep or trigger a long delay
+    if (MXC_GPIO_InGet(lockoutConfig.port, lockoutConfig.mask)) {
+        MXC_Delay(MXC_DELAY_SEC(2));
+        allowSleep = 0;
+    }
+#endif
+```
+
 ### Project Usage
 
 Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.

--- a/Examples/MAX32660/LP/main.c
+++ b/Examples/MAX32660/LP/main.c
@@ -146,6 +146,15 @@ void setTrigger(int waitForTrigger)
 
 int main(void)
 {
+    /** PLEASE READ **/
+    // MCU shuts down SWD interface in LP modes
+    // Delay at application start to prevent debugger losing access on restarts
+    //
+    // Only remove this if you are okay with losing debug access
+    // If you can't flash/debug the device, please consult this guide:
+    // https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+    MXC_Delay(MXC_DELAY_SEC(2));
+
     PRINT("****Low Power Mode Example****\n\n");
 
 #if USE_ALARM

--- a/Examples/MAX32662/LP/README.md
+++ b/Examples/MAX32662/LP/README.md
@@ -5,6 +5,46 @@ TBD<!--TBD-->
 
 ## Software
 
+### WARNING: Low-Power Mode Flash / Debug Access
+
+Microcontrollers usually shutdown SWD /JTAG debug interfaces in very low-power mode operation.
+
+This can cause an MCU to permanently lose debug access because, upon reset, the device may enter LP modes so fast that the debug probe cannot attach to and reset the target core before the debug interface is shutdown. This is true regardless of the debug probe you choose to use.
+
+To avoid this problem, please observe the 2-second delay at the beginning of the main() function. If you find that your MCU can no longer be programmed or debugged after flashing an LP example, you can attempt to recover it using the following procedure from the MSDK User Guide:
+https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+
+Another option for production builds would be to implement Lockout Protection using a free GPIO attached to a switch. Below is some example code for how this may be implemented:
+
+```C
+#ifdef LOCKOUT_PROTECT
+/**
+ * If debugger lockout protection is enabled,
+ * define a switch for enabling the protection.
+ *
+ * Note this is not a board-specific configuration;
+ * Please adapt the GPIO pin(s) to your specific hardware.
+ **/
+static const mxc_gpio_cfg_t lockoutConfig = {
+    .func = MXC_GPIO_FUNC_ALT1,
+    .port = MXC_GPIO0,
+    .mask = MXC_GPIO_PIN_0,
+    .pad = MXC_GPIO_PAD_PULL_UP
+};
+#endif
+
+int main(void) {
+#ifdef LOCKOUT_PROTECT
+    MXC_GPIO_Config(&lockoutConfig);
+
+    // If lockout switch is pulled low, prevent sleep or trigger a long delay
+    if (MXC_GPIO_InGet(lockoutConfig.port, lockoutConfig.mask)) {
+        MXC_Delay(MXC_DELAY_SEC(2));
+        allowSleep = 0;
+    }
+#endif
+```
+
 ### Project Usage
 
 Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.

--- a/Examples/MAX32662/LP/main.c
+++ b/Examples/MAX32662/LP/main.c
@@ -154,6 +154,15 @@ void setTrigger(int waitForTrigger)
 
 int main(void)
 {
+    /** PLEASE READ **/
+    // MCU shuts down SWD interface in LP modes
+    // Delay at application start to prevent debugger losing access on restarts
+    //
+    // Only remove this if you are okay with losing debug access
+    // If you can't flash/debug the device, please consult this guide:
+    // https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+    MXC_Delay(MXC_DELAY_SEC(2));
+
     PRINT("****Low Power Mode Example****\n\n");
 
 #if USE_ALARM

--- a/Examples/MAX32665/LP/README.md
+++ b/Examples/MAX32665/LP/README.md
@@ -5,6 +5,46 @@ Example to showcase the lower power modes.
 
 ## Software
 
+### WARNING: Low-Power Mode Flash / Debug Access
+
+Microcontrollers usually shutdown SWD /JTAG debug interfaces in very low-power mode operation.
+
+This can cause an MCU to permanently lose debug access because, upon reset, the device may enter LP modes so fast that the debug probe cannot attach to and reset the target core before the debug interface is shutdown. This is true regardless of the debug probe you choose to use.
+
+To avoid this problem, please observe the 2-second delay at the beginning of the main() function. If you find that your MCU can no longer be programmed or debugged after flashing an LP example, you can attempt to recover it using the following procedure from the MSDK User Guide:
+https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+
+Another option for production builds would be to implement Lockout Protection using a free GPIO attached to a switch. Below is some example code for how this may be implemented:
+
+```C
+#ifdef LOCKOUT_PROTECT
+/**
+ * If debugger lockout protection is enabled,
+ * define a switch for enabling the protection.
+ *
+ * Note this is not a board-specific configuration;
+ * Please adapt the GPIO pin(s) to your specific hardware.
+ **/
+static const mxc_gpio_cfg_t lockoutConfig = {
+    .func = MXC_GPIO_FUNC_ALT1,
+    .port = MXC_GPIO0,
+    .mask = MXC_GPIO_PIN_0,
+    .pad = MXC_GPIO_PAD_PULL_UP
+};
+#endif
+
+int main(void) {
+#ifdef LOCKOUT_PROTECT
+    MXC_GPIO_Config(&lockoutConfig);
+
+    // If lockout switch is pulled low, prevent sleep or trigger a long delay
+    if (MXC_GPIO_InGet(lockoutConfig.port, lockoutConfig.mask)) {
+        MXC_Delay(MXC_DELAY_SEC(2));
+        allowSleep = 0;
+    }
+#endif
+```
+
 ### Project Usage
 
 Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.

--- a/Examples/MAX32665/LP/main.c
+++ b/Examples/MAX32665/LP/main.c
@@ -149,6 +149,15 @@ void setTrigger(int waitForTrigger)
 
 int main(void)
 {
+    /** PLEASE READ **/
+    // MCU shuts down SWD interface in LP modes
+    // Delay at application start to prevent debugger losing access on restarts
+    //
+    // Only remove this if you are okay with losing debug access
+    // If you can't flash/debug the device, please consult this guide:
+    // https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+    MXC_Delay(MXC_DELAY_SEC(2));
+
     PRINT("\n\n****Low Power Mode Example****\n\n");
 
 #if USE_ALARM

--- a/Examples/MAX32670/LP/README.md
+++ b/Examples/MAX32670/LP/README.md
@@ -5,6 +5,46 @@ TBD<!--TBD-->
 
 ## Software
 
+### WARNING: Low-Power Mode Flash / Debug Access
+
+Microcontrollers usually shutdown SWD /JTAG debug interfaces in very low-power mode operation.
+
+This can cause an MCU to permanently lose debug access because, upon reset, the device may enter LP modes so fast that the debug probe cannot attach to and reset the target core before the debug interface is shutdown. This is true regardless of the debug probe you choose to use.
+
+To avoid this problem, please observe the 2-second delay at the beginning of the main() function. If you find that your MCU can no longer be programmed or debugged after flashing an LP example, you can attempt to recover it using the following procedure from the MSDK User Guide:
+https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+
+Another option for production builds would be to implement Lockout Protection using a free GPIO attached to a switch. Below is some example code for how this may be implemented:
+
+```C
+#ifdef LOCKOUT_PROTECT
+/**
+ * If debugger lockout protection is enabled,
+ * define a switch for enabling the protection.
+ *
+ * Note this is not a board-specific configuration;
+ * Please adapt the GPIO pin(s) to your specific hardware.
+ **/
+static const mxc_gpio_cfg_t lockoutConfig = {
+    .func = MXC_GPIO_FUNC_ALT1,
+    .port = MXC_GPIO0,
+    .mask = MXC_GPIO_PIN_0,
+    .pad = MXC_GPIO_PAD_PULL_UP
+};
+#endif
+
+int main(void) {
+#ifdef LOCKOUT_PROTECT
+    MXC_GPIO_Config(&lockoutConfig);
+
+    // If lockout switch is pulled low, prevent sleep or trigger a long delay
+    if (MXC_GPIO_InGet(lockoutConfig.port, lockoutConfig.mask)) {
+        MXC_Delay(MXC_DELAY_SEC(2));
+        allowSleep = 0;
+    }
+#endif
+```
+
 ### Project Usage
 
 Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.

--- a/Examples/MAX32670/LP/main.c
+++ b/Examples/MAX32670/LP/main.c
@@ -185,6 +185,15 @@ void configure_gpio(void)
 
 int main(void)
 {
+    /** PLEASE READ **/
+    // MCU shuts down SWD interface in LP modes
+    // Delay at application start to prevent debugger losing access on restarts
+    //
+    // Only remove this if you are okay with losing debug access
+    // If you can't flash/debug the device, please consult this guide:
+    // https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+    MXC_Delay(MXC_DELAY_SEC(2));
+
     MXC_ECC->en = 0; // Disable ECC on Flash, ICC, and SRAM
 
     PRINT("****Low Power Mode Example****\n\n");

--- a/Examples/MAX32670/LP/main.c
+++ b/Examples/MAX32670/LP/main.c
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by
  * Analog Devices, Inc.),
  * Copyright (C) 2023-2024 Analog Devices, Inc.
  *
@@ -50,6 +50,7 @@
 #include "uart.h"
 #include "nvic_table.h"
 #include "ecc_regs.h"
+#include "mxc_delay.h"
 
 #define DELAY_IN_SEC 2
 #define USE_CONSOLE 1

--- a/Examples/MAX32672/LP/README.md
+++ b/Examples/MAX32672/LP/README.md
@@ -8,6 +8,46 @@ Either the push button or the RTC may be used as a wakeup source in this example
 
 ## Software
 
+### WARNING: Low-Power Mode Flash / Debug Access
+
+Microcontrollers usually shutdown SWD /JTAG debug interfaces in very low-power mode operation.
+
+This can cause an MCU to permanently lose debug access because, upon reset, the device may enter LP modes so fast that the debug probe cannot attach to and reset the target core before the debug interface is shutdown. This is true regardless of the debug probe you choose to use.
+
+To avoid this problem, please observe the 2-second delay at the beginning of the main() function. If you find that your MCU can no longer be programmed or debugged after flashing an LP example, you can attempt to recover it using the following procedure from the MSDK User Guide:
+https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+
+Another option for production builds would be to implement Lockout Protection using a free GPIO attached to a switch. Below is some example code for how this may be implemented:
+
+```C
+#ifdef LOCKOUT_PROTECT
+/**
+ * If debugger lockout protection is enabled,
+ * define a switch for enabling the protection.
+ *
+ * Note this is not a board-specific configuration;
+ * Please adapt the GPIO pin(s) to your specific hardware.
+ **/
+static const mxc_gpio_cfg_t lockoutConfig = {
+    .func = MXC_GPIO_FUNC_ALT1,
+    .port = MXC_GPIO0,
+    .mask = MXC_GPIO_PIN_0,
+    .pad = MXC_GPIO_PAD_PULL_UP
+};
+#endif
+
+int main(void) {
+#ifdef LOCKOUT_PROTECT
+    MXC_GPIO_Config(&lockoutConfig);
+
+    // If lockout switch is pulled low, prevent sleep or trigger a long delay
+    if (MXC_GPIO_InGet(lockoutConfig.port, lockoutConfig.mask)) {
+        MXC_Delay(MXC_DELAY_SEC(2));
+        allowSleep = 0;
+    }
+#endif
+```
+
 ### Project Usage
 
 Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.

--- a/Examples/MAX32672/LP/main.c
+++ b/Examples/MAX32672/LP/main.c
@@ -193,6 +193,15 @@ void configure_gpios(void)
 
 int main(void)
 {
+    /** PLEASE READ **/
+    // MCU shuts down SWD interface in LP modes
+    // Delay at application start to prevent debugger losing access on restarts
+    //
+    // Only remove this if you are okay with losing debug access
+    // If you can't flash/debug the device, please consult this guide:
+    // https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+    MXC_Delay(MXC_DELAY_SEC(2));
+
     // Delay to provide the debugger with a window to connect.
     // Low-power modes shut down SWD
     MXC_Delay(MXC_DELAY_SEC(2));

--- a/Examples/MAX32675/LP/README.md
+++ b/Examples/MAX32675/LP/README.md
@@ -7,6 +7,46 @@ To move to the next power state push button 0 (SW1).
 
 ## Software
 
+### WARNING: Low-Power Mode Flash / Debug Access
+
+Microcontrollers usually shutdown SWD /JTAG debug interfaces in very low-power mode operation.
+
+This can cause an MCU to permanently lose debug access because, upon reset, the device may enter LP modes so fast that the debug probe cannot attach to and reset the target core before the debug interface is shutdown. This is true regardless of the debug probe you choose to use.
+
+To avoid this problem, please observe the 2-second delay at the beginning of the main() function. If you find that your MCU can no longer be programmed or debugged after flashing an LP example, you can attempt to recover it using the following procedure from the MSDK User Guide:
+https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+
+Another option for production builds would be to implement Lockout Protection using a free GPIO attached to a switch. Below is some example code for how this may be implemented:
+
+```C
+#ifdef LOCKOUT_PROTECT
+/**
+ * If debugger lockout protection is enabled,
+ * define a switch for enabling the protection.
+ *
+ * Note this is not a board-specific configuration;
+ * Please adapt the GPIO pin(s) to your specific hardware.
+ **/
+static const mxc_gpio_cfg_t lockoutConfig = {
+    .func = MXC_GPIO_FUNC_ALT1,
+    .port = MXC_GPIO0,
+    .mask = MXC_GPIO_PIN_0,
+    .pad = MXC_GPIO_PAD_PULL_UP
+};
+#endif
+
+int main(void) {
+#ifdef LOCKOUT_PROTECT
+    MXC_GPIO_Config(&lockoutConfig);
+
+    // If lockout switch is pulled low, prevent sleep or trigger a long delay
+    if (MXC_GPIO_InGet(lockoutConfig.port, lockoutConfig.mask)) {
+        MXC_Delay(MXC_DELAY_SEC(2));
+        allowSleep = 0;
+    }
+#endif
+```
+
 ### Project Usage
 
 Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.

--- a/Examples/MAX32675/LP/main.c
+++ b/Examples/MAX32675/LP/main.c
@@ -118,6 +118,15 @@ void configure_gpio(void)
 
 int main(void)
 {
+    /** PLEASE READ **/
+    // MCU shuts down SWD interface in LP modes
+    // Delay at application start to prevent debugger losing access on restarts
+    //
+    // Only remove this if you are okay with losing debug access
+    // If you can't flash/debug the device, please consult this guide:
+    // https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+    MXC_Delay(MXC_DELAY_SEC(2));
+
     PRINT("****Low Power Mode Example****\n\n");
 
     PRINT("This code cycles through the MAX32675 power modes, using a push button 0 (SW1) to exit "

--- a/Examples/MAX32675/LP/main.c
+++ b/Examples/MAX32675/LP/main.c
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by
  * Analog Devices, Inc.),
  * Copyright (C) 2023-2024 Analog Devices, Inc.
  *
@@ -49,6 +49,7 @@
 #include "rtc.h"
 #include "uart.h"
 #include "nvic_table.h"
+#include "mxc_delay.h"
 
 #define DELAY_IN_SEC 2
 #define USE_CONSOLE 1

--- a/Examples/MAX32680/LP/README.md
+++ b/Examples/MAX32680/LP/README.md
@@ -5,6 +5,46 @@ TBD<!--TBD-->
 
 ## Software
 
+### WARNING: Low-Power Mode Flash / Debug Access
+
+Microcontrollers usually shutdown SWD /JTAG debug interfaces in very low-power mode operation.
+
+This can cause an MCU to permanently lose debug access because, upon reset, the device may enter LP modes so fast that the debug probe cannot attach to and reset the target core before the debug interface is shutdown. This is true regardless of the debug probe you choose to use.
+
+To avoid this problem, please observe the 2-second delay at the beginning of the main() function. If you find that your MCU can no longer be programmed or debugged after flashing an LP example, you can attempt to recover it using the following procedure from the MSDK User Guide:
+https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+
+Another option for production builds would be to implement Lockout Protection using a free GPIO attached to a switch. Below is some example code for how this may be implemented:
+
+```C
+#ifdef LOCKOUT_PROTECT
+/**
+ * If debugger lockout protection is enabled,
+ * define a switch for enabling the protection.
+ *
+ * Note this is not a board-specific configuration;
+ * Please adapt the GPIO pin(s) to your specific hardware.
+ **/
+static const mxc_gpio_cfg_t lockoutConfig = {
+    .func = MXC_GPIO_FUNC_ALT1,
+    .port = MXC_GPIO0,
+    .mask = MXC_GPIO_PIN_0,
+    .pad = MXC_GPIO_PAD_PULL_UP
+};
+#endif
+
+int main(void) {
+#ifdef LOCKOUT_PROTECT
+    MXC_GPIO_Config(&lockoutConfig);
+
+    // If lockout switch is pulled low, prevent sleep or trigger a long delay
+    if (MXC_GPIO_InGet(lockoutConfig.port, lockoutConfig.mask)) {
+        MXC_Delay(MXC_DELAY_SEC(2));
+        allowSleep = 0;
+    }
+#endif
+```
+
 ### Project Usage
 
 Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.

--- a/Examples/MAX32680/LP/main.c
+++ b/Examples/MAX32680/LP/main.c
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by
  * Analog Devices, Inc.),
  * Copyright (C) 2023-2024 Analog Devices, Inc.
  *
@@ -157,6 +157,15 @@ void setTrigger(int waitForTrigger)
 
 int main(void)
 {
+    /** PLEASE READ **/
+    // MCU shuts down SWD interface in LP modes
+    // Delay at application start to prevent debugger losing access on restarts
+    //
+    // Only remove this if you are okay with losing debug access
+    // If you can't flash/debug the device, please consult this guide:
+    // https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+    MXC_Delay(MXC_DELAY_SEC(2));
+
     PRINT("****Low Power Mode Example****\n\n");
 
 #if USE_ALARM

--- a/Examples/MAX32680/LP/main.c
+++ b/Examples/MAX32680/LP/main.c
@@ -50,6 +50,8 @@
 #include "uart.h"
 #include "nvic_table.h"
 
+#include "mxc_delay.h"
+
 #define DELAY_IN_SEC 2
 #define USE_CONSOLE 1
 

--- a/Examples/MAX32690/LP/README.md
+++ b/Examples/MAX32690/LP/README.md
@@ -4,6 +4,46 @@ This example demonstrates entering and exiting from the various operating modes.
 
 ## Software
 
+### WARNING: Low-Power Mode Flash / Debug Access
+
+Microcontrollers usually shutdown SWD /JTAG debug interfaces in very low-power mode operation.
+
+This can cause an MCU to permanently lose debug access because, upon reset, the device may enter LP modes so fast that the debug probe cannot attach to and reset the target core before the debug interface is shutdown. This is true regardless of the debug probe you choose to use.
+
+To avoid this problem, please observe the 2-second delay at the beginning of the main() function. If you find that your MCU can no longer be programmed or debugged after flashing an LP example, you can attempt to recover it using the following procedure from the MSDK User Guide:
+https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+
+Another option for production builds would be to implement Lockout Protection using a free GPIO attached to a switch. Below is some example code for how this may be implemented:
+
+```C
+#ifdef LOCKOUT_PROTECT
+/**
+ * If debugger lockout protection is enabled,
+ * define a switch for enabling the protection.
+ *
+ * Note this is not a board-specific configuration;
+ * Please adapt the GPIO pin(s) to your specific hardware.
+ **/
+static const mxc_gpio_cfg_t lockoutConfig = {
+    .func = MXC_GPIO_FUNC_ALT1,
+    .port = MXC_GPIO0,
+    .mask = MXC_GPIO_PIN_0,
+    .pad = MXC_GPIO_PAD_PULL_UP
+};
+#endif
+
+int main(void) {
+#ifdef LOCKOUT_PROTECT
+    MXC_GPIO_Config(&lockoutConfig);
+
+    // If lockout switch is pulled low, prevent sleep or trigger a long delay
+    if (MXC_GPIO_InGet(lockoutConfig.port, lockoutConfig.mask)) {
+        MXC_Delay(MXC_DELAY_SEC(2));
+        allowSleep = 0;
+    }
+#endif
+```
+
 ### Project Usage
 
 Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.

--- a/Examples/MAX32690/LP/main.c
+++ b/Examples/MAX32690/LP/main.c
@@ -172,6 +172,15 @@ void setTrigger(int waitForTrigger)
 
 int main(void)
 {
+    /** PLEASE READ **/
+    // MCU shuts down SWD interface in LP modes
+    // Delay at application start to prevent debugger losing access on restarts
+    //
+    // Only remove this if you are okay with losing debug access
+    // If you can't flash/debug the device, please consult this guide:
+    // https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+    MXC_Delay(MXC_DELAY_SEC(2));
+
     PRINT("****Low Power Mode Example****\n\n");
 
 #if USE_ALARM

--- a/Examples/MAX78000/LP/README.md
+++ b/Examples/MAX78000/LP/README.md
@@ -15,6 +15,46 @@ Following modes can be tested:
 
 ## Software
 
+### WARNING: Low-Power Mode Flash / Debug Access
+
+Microcontrollers usually shutdown SWD /JTAG debug interfaces in very low-power mode operation.
+
+This can cause an MCU to permanently lose debug access because, upon reset, the device may enter LP modes so fast that the debug probe cannot attach to and reset the target core before the debug interface is shutdown. This is true regardless of the debug probe you choose to use.
+
+To avoid this problem, please observe the 2-second delay at the beginning of the main() function. If you find that your MCU can no longer be programmed or debugged after flashing an LP example, you can attempt to recover it using the following procedure from the MSDK User Guide:
+https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+
+Another option for production builds would be to implement Lockout Protection using a free GPIO attached to a switch. Below is some example code for how this may be implemented:
+
+```C
+#ifdef LOCKOUT_PROTECT
+/**
+ * If debugger lockout protection is enabled,
+ * define a switch for enabling the protection.
+ *
+ * Note this is not a board-specific configuration;
+ * Please adapt the GPIO pin(s) to your specific hardware.
+ **/
+static const mxc_gpio_cfg_t lockoutConfig = {
+    .func = MXC_GPIO_FUNC_ALT1,
+    .port = MXC_GPIO0,
+    .mask = MXC_GPIO_PIN_0,
+    .pad = MXC_GPIO_PAD_PULL_UP
+};
+#endif
+
+int main(void) {
+#ifdef LOCKOUT_PROTECT
+    MXC_GPIO_Config(&lockoutConfig);
+
+    // If lockout switch is pulled low, prevent sleep or trigger a long delay
+    if (MXC_GPIO_InGet(lockoutConfig.port, lockoutConfig.mask)) {
+        MXC_Delay(MXC_DELAY_SEC(2));
+        allowSleep = 0;
+    }
+#endif
+```
+
 ### Project Usage
 
 Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.

--- a/Examples/MAX78000/LP/main.c
+++ b/Examples/MAX78000/LP/main.c
@@ -170,6 +170,15 @@ void setTrigger(int waitForTrigger)
 
 int main(void)
 {
+    /** PLEASE READ **/
+    // MCU shuts down SWD interface in LP modes
+    // Delay at application start to prevent debugger losing access on restarts
+    //
+    // Only remove this if you are okay with losing debug access
+    // If you can't flash/debug the device, please consult this guide:
+    // https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+    MXC_Delay(MXC_DELAY_SEC(2));
+
     PRINT("****Low Power Mode Example****\n\n");
 
 #if USE_ALARM

--- a/Examples/MAX78002/LP/README.md
+++ b/Examples/MAX78002/LP/README.md
@@ -15,6 +15,46 @@ Following modes can be tested:
 
 ## Software
 
+### WARNING: Low-Power Mode Flash / Debug Access
+
+Microcontrollers usually shutdown SWD /JTAG debug interfaces in very low-power mode operation.
+
+This can cause an MCU to permanently lose debug access because, upon reset, the device may enter LP modes so fast that the debug probe cannot attach to and reset the target core before the debug interface is shutdown. This is true regardless of the debug probe you choose to use.
+
+To avoid this problem, please observe the 2-second delay at the beginning of the main() function. If you find that your MCU can no longer be programmed or debugged after flashing an LP example, you can attempt to recover it using the following procedure from the MSDK User Guide:
+https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+
+Another option for production builds would be to implement Lockout Protection using a free GPIO attached to a switch. Below is some example code for how this may be implemented:
+
+```C
+#ifdef LOCKOUT_PROTECT
+/**
+ * If debugger lockout protection is enabled,
+ * define a switch for enabling the protection.
+ *
+ * Note this is not a board-specific configuration;
+ * Please adapt the GPIO pin(s) to your specific hardware.
+ **/
+static const mxc_gpio_cfg_t lockoutConfig = {
+    .func = MXC_GPIO_FUNC_ALT1,
+    .port = MXC_GPIO0,
+    .mask = MXC_GPIO_PIN_0,
+    .pad = MXC_GPIO_PAD_PULL_UP
+};
+#endif
+
+int main(void) {
+#ifdef LOCKOUT_PROTECT
+    MXC_GPIO_Config(&lockoutConfig);
+
+    // If lockout switch is pulled low, prevent sleep or trigger a long delay
+    if (MXC_GPIO_InGet(lockoutConfig.port, lockoutConfig.mask)) {
+        MXC_Delay(MXC_DELAY_SEC(2));
+        allowSleep = 0;
+    }
+#endif
+```
+
 ### Project Usage
 
 Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analogdevicesinc.github.io/msdk/USERGUIDE/)**.

--- a/Examples/MAX78002/LP/main.c
+++ b/Examples/MAX78002/LP/main.c
@@ -163,6 +163,15 @@ void setTrigger(int waitForTrigger)
 
 int main(void)
 {
+    /** PLEASE READ **/
+    // MCU shuts down SWD interface in LP modes
+    // Delay at application start to prevent debugger losing access on restarts
+    //
+    // Only remove this if you are okay with losing debug access
+    // If you can't flash/debug the device, please consult this guide:
+    // https://analogdevicesinc.github.io/msdk//USERGUIDE/#how-to-unlock-a-microcontroller-that-can-no-longer-be-programmed
+    MXC_Delay(MXC_DELAY_SEC(2));
+
     PRINT("****Low Power Mode Example****\n\n");
 
 #if USE_ALARM


### PR DESCRIPTION
### Description

Add a 2-second delay to the beginning of ALL LP examples. Also add a warning snippet to the README regarding LP debug interface issues and a small snippet for implementing lockout protection via a GPIO input. 

### Testing

Built all LP examples locally and using CI before creating PR. 
https://github.com/Brandon-Hurst/msdk/actions/runs/13186818626

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
