### PR TITLE
fix(Other): Zephyr: MAX32650: Add missing LP wrappers

### DIFF
--- a/Libraries/zephyr/MAX/Include/wrap_max32_lp.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_lp.h
@@ -31,7 +31,7 @@ extern "C" {
  */
 #if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666) || \
     defined(CONFIG_SOC_MAX32670) || defined(CONFIG_SOC_MAX32672) || \
-    defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32675)
+    defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32675) || defined(CONFIG_SOC_MAX32650)
 
 static inline void Wrap_MXC_LP_EnterLowPowerMode(void)
 {
@@ -50,7 +50,11 @@ static inline void Wrap_MXC_LP_EnterStandbyMode(void)
 
 static inline void Wrap_MXC_LP_EnterPowerDownMode(void)
 {
+#if defined(CONFIG_SOC_MAX32650)
+    MXC_LP_EnterBackupMode();
+#else
     MXC_LP_EnterShutDownMode();
+#endif
 }
 
 /*


### PR DESCRIPTION
This commit adds the missing Low Power defines for MAX32650 for the zephyr build system.

There are generally two main groups in the wrap_max32_xx files. MAX32650 fits the first group for Low Power. However, there is no MXC_LP_EnterShutDownMode() function provided for MAX32650 so the MXC_LP_EnterBackupMode() function was chosen as best fit.