### PR TITLE
fix(Other): Fix MAX32650 zephyr cmake

### DIFF
--- a/Libraries/zephyr/MAX/Source/MAX32650/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32650/CMakeLists.txt
@@ -60,7 +60,8 @@ zephyr_library_sources(
      
     ${MSDK_PERIPH_SRC_DIR}/ICC/icc_me10.c
     ${MSDK_PERIPH_SRC_DIR}/ICC/icc_reva.c
-    
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_common.c
+
     ${MSDK_PERIPH_SRC_DIR}/LP/lp_me10.c
     
     ${MSDK_PERIPH_SRC_DIR}/PT/pt_me10.c


### PR DESCRIPTION
### Description

This PR adds icc_common.c source file to the MAX32650 Cmake.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

