### PR TITLE
fix(Other): Fix MAX32650 zephyr cmake

### DIFF
--- a/Libraries/zephyr/MAX/Source/MAX32650/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32650/CMakeLists.txt
@@ -43,15 +43,11 @@ zephyr_include_directories(
     ${MSDK_PERIPH_SRC_DIR}/WDT
 )
 
-if(CONFIG_ARM)
-  zephyr_library_sources(${MSDK_CMSIS_DIR}/Source/system_max32650.c)
-  zephyr_library_sources(${MSDK_PERIPH_SRC_DIR}/SYS/mxc_lock.c)
-elseif(CONFIG_RISCV)
-  zephyr_library_sources(${MSDK_CMSIS_DIR}/Source/system_riscv_max32650.c)
-endif()
-
 zephyr_library_sources(
     ./max32xxx_system.c
+
+    ${MSDK_CMSIS_DIR}/Source/system_max32650.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_lock.c
 
     ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_assert.c
     ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_delay.c


### PR DESCRIPTION
There is no RISCV in MAX32650. So, the RISCV configuration and what it includes should be removed.

After the if else on the core configuration is removed all includes are ARM configured so the two lines can be added below for conciseness as well.