### PR TITLE
feat(MAXUSB): Add sending ZLP feature after data packet if it is needed

### DIFF
--- a/Libraries/MAXUSB/include/core/usb.h
+++ b/Libraries/MAXUSB/include/core/usb.h
@@ -122,6 +122,9 @@ typedef struct {
   void *cbdata;
   maxusb_req_type_t type;
   void *driver_xtra; /* driver-specific data, do not modify */
+#ifdef USE_ZEPHYR_USB_STACK
+  bool has_zlp; /* ZLP is requested by host if reqlen is equal to or multiple of MPS */
+#endif
 } MXC_USB_Req_t;
 
 


### PR DESCRIPTION
### Description

According to [USB 2.0 spec](https://www.usb.org/document-library/usb-20-specification); if data length is less than host requested and equal to or multiple of MPS, host requests ZLP to understand it is last packet.

<image src="https://github.com/user-attachments/assets/d3d4b6af-14da-4b95-8635-da79f2487fc3" width="700">

This patch adds `has_zlp` flag to `MXC_USB_Req_t `structure to understand if ZLP is needed. If `has_zlp `is set, ZLP is sent after data packet. This patch only has affects if driver used for Zephyr USB stack.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.