### PR TITLE
fix(PeriphDrivers): MAX32650 (ME10) Flash Address Fix

### DIFF
--- a/Libraries/PeriphDrivers/Source/FLC/flc_me10.c
+++ b/Libraries/PeriphDrivers/Source/FLC/flc_me10.c
@@ -5,9 +5,9 @@
  */
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ int MXC_FLC_ME10_GetByAddress(mxc_flc_regs_t **flc, uint32_t addr)
 int MXC_FLC_ME10_GetPhysicalAddress(uint32_t addr, uint32_t *result)
 {
     if ((addr >= MXC_FLASH_MEM_BASE) && (addr < (MXC_FLASH_MEM_BASE + MXC_FLASH_MEM_SIZE))) {
-        *result = (addr & (MXC_FLASH_MEM_SIZE - 1));
+        *result = (addr - MXC_FLASH_MEM_BASE);
     } else if ((addr >= MXC_INFO_MEM_BASE) && (addr < (MXC_INFO_MEM_BASE + MXC_INFO_MEM_SIZE))) {
         *result = (addr & (MXC_INFO_MEM_SIZE - 1)) + (MXC_INFO_MEM_BASE - MXC_FLASH_MEM_BASE);
     } else {


### PR DESCRIPTION
Corrected a bug in how the flash physical address (relative to flash base) was calculated which caused a block of pages' addresses to be incorrectly masked. This ultimately caused issues when doing single page erases whenever bit 20 of the Flash address was set.

In the original implementation, -1 was done on the FLASH_MEM_SIZE to presumably get a valid mask. This works when the memory size is a power of 2.  However, since the memory on the MAX32650 is 3MB (0x300000), subtracting 1 results in a mask of 0x2FFFFF, where Bit 20 is 0.  All pages with Bit 20 set to 1 will have an incorrect address calculated.

The solution was to just subtract the base address, since the range was already validated in the if block.  This is the same implementation that the MAX32690 (also with 3MB of Flash) does.
