### PR TITLE
fix(PeriphDrivers): Wait for flash op done flag after write or erase

### DIFF
--- a/Libraries/PeriphDrivers/Source/FLC/flc_reva.c
+++ b/Libraries/PeriphDrivers/Source/FLC/flc_reva.c
@@ -134,6 +134,8 @@ int MXC_FLC_RevA_MassErase(mxc_flc_reva_regs_t *flc)
 
     /* Wait until flash operation is complete */
     while (MXC_busy_flc(flc)) {}
+    while ((flc->intr & MXC_F_FLC_REVA_INTR_DONE) == 0) {}
+    flc->intr &= ~MXC_F_FLC_REVA_INTR_DONE;
 
     /* Lock flash */
     flc->ctrl &= ~MXC_F_FLC_REVA_CTRL_UNLOCK;
@@ -170,6 +172,8 @@ int MXC_FLC_RevA_PageErase(mxc_flc_reva_regs_t *flc, uint32_t addr)
 
     /* Wait until flash operation is complete */
     while (MXC_busy_flc(flc)) {}
+    while ((flc->intr & MXC_F_FLC_REVA_INTR_DONE) == 0) {}
+    flc->intr &= ~MXC_F_FLC_REVA_INTR_DONE;
 
     /* Lock flash */
     flc->ctrl &= ~MXC_F_FLC_REVA_CTRL_UNLOCK;
@@ -223,6 +227,8 @@ int MXC_FLC_RevA_Write32(mxc_flc_reva_regs_t *flc, uint32_t logicAddr, uint32_t 
     /* Wait until flash operation is complete */
     while ((flc->ctrl & MXC_F_FLC_REVA_CTRL_PEND) != 0) {}
     while (MXC_busy_flc(flc)) {}
+    while ((flc->intr & MXC_F_FLC_REVA_INTR_DONE) == 0) {}
+    flc->intr &= ~MXC_F_FLC_REVA_INTR_DONE;
 
     /* Lock flash */
     flc->ctrl &= ~MXC_F_FLC_REVA_CTRL_UNLOCK;
@@ -325,6 +331,8 @@ int MXC_FLC_RevA_Write128(mxc_flc_reva_regs_t *flc, uint32_t addr, uint32_t *dat
     /* Wait until flash operation is complete */
     while ((flc->ctrl & MXC_F_FLC_REVA_CTRL_PEND) != 0) {}
     while (MXC_busy_flc(flc)) {}
+    while ((flc->intr & MXC_F_FLC_REVA_INTR_DONE) == 0) {}
+    flc->intr &= ~MXC_F_FLC_REVA_INTR_DONE;
 
     /* Lock flash */
     flc->ctrl &= ~MXC_F_FLC_REVA_CTRL_UNLOCK;


### PR DESCRIPTION
### Description

Zephyr flash tests on MAX32690 sometimes fail with an error code of `-7` which corresponds to `E_BAD_STATE`. This error code is returned either when `FLC_INTR.af` (flash access fail) flag is set or `MXC_FLC_Com_VerifyData` detects a data mismatch. I have tracked this to `MXC_FLC_RevA_Write128` (`flc_reva.c:335`) by changing the error code returned in that line. `FLC_INTR.af` reads `0` if a breakpoint is put so it looks like the hardware is clearing that bit itself though I am not completely certain on that either.

I have added an extra guard that waits for `done` flag after write/erase operations and it seems to solve the `E_BAD_STATE` errors. However, I am not sure if this is the correct solution to this problem and the real cause lies elsewhere.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
