### PR TITLE
refactor(Build): Check if MAXIM_PATH is empty before including board.mk

### DIFF
--- a/Libraries/libs.mk
+++ b/Libraries/libs.mk
@@ -45,7 +45,12 @@ PROJ_CFLAGS += -DLIB_BOARD
 # in this case we want to avoid building with mismatched BSPs.
 export BOARD
 export BSP_SEARCH_DIR
+ifeq "$(MAXIM_PATH)" ""
+$(warning Warning:  MAXIM_PATH is not set!  Unable to find the MiscDrivers directory.)
+else
 include $(BOARD_DIR)/board.mk
+endif
+
 endif
 # ************************
 


### PR DESCRIPTION
### Description

Running `make clean.cordio` may fail to include `fonts.mk`, which is included in `board.mk`.

Check if `MAXIM_PATH` is empty before including board.mk -- which contains `MISC_DRIVERS_DIR`, a variable dependent on `MAXIM_PATH`.
