### PR TITLE
fix(PeriphDrivers): SPI RevA1 DMA Handler Fix

### DIFF
--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
@@ -1,8 +1,8 @@
 /******************************************************************************
  *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
+ * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1309,6 +1309,9 @@ void MXC_SPI_RevA1_DMACallback(int ch, int error)
                 if (MXC_SPI_GetDataSize((mxc_spi_regs_t *)temp_req->spi) > 8) {
                     MXC_SPI_RevA1_SwapByte(temp_req->rxData, temp_req->rxLen);
                 }
+            } else {
+                //No channel match, continue searching.
+                continue;
             }
 
             if (!states[i].txrx_req || (states[i].txrx_req && states[i].req_done == 2)) {


### PR DESCRIPTION
Fixes multiple potential issues with the SPI DMA handler which could cause SPI transactions to falsely get callbacks and terminated, or some transactions to never get callbacks or terminate under various conditions.

### Failure Condition 1:
If there are 2 active SPI peripherals using DMA (for the example say SPI0 and SPI1).  If SPI0 is currently being configured via `MXC_SPI_RevA1_MasterTransactionDMA` and the DMA interrupt occurs for SPI1, it is possible for the interrupt to be handled as if SPI0 was the source, causing SPI1 to never complete.

This only occurs when the DMA interrupt happens between reassigning the state's req, and before clearing req_done https://github.com/analogdevicesinc/msdk/blob/2ec3f4ed1ecc5fafe1c687e61d1a38dc98220e76/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c#L709

```
states[spi_num].req = req;
states[spi_num].started = 0;
states[spi_num].req_done = 0;
```

The since .req is not NULL the DMA handler will look at the channels for that req. None of the channels match, but since the req_done is still 2 from a previous transaction (not yet cleared) the callback will happen (erroneously) and the loop breaks, never actually touching the real SPI peripheral causing the interrupt, resulting in the SPI transaction going stale and never getting a callback.

### Failure Condition 2:
Similar to the above, if the SPI instance passes the NULL check for req, but its channels don't match, the if statement still hits.  If that transaction is Tx or Rx only (i.e. txrx_req == 0), the if statement will pass, once again falsely sending a callback, and causing the real cause of the interrupt to go stale.

### Solution
There probably should be some critical section code for working with the states array. However a simple work around is to just continue processing the loop if there is not a DMA channel match.   For applications which leverage the MSDK without this fix, disabling interrupts in the user code while the MasterTransactionDMA is being called also mitigates the issue.