### PR TITLE
feat(Other): Changes in preparation for Zephyr HPB support

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32650/hpb.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/hpb.h
@@ -124,7 +124,7 @@ typedef struct {
     mxc_hpb_device_t device_type;
 
     /** Pointer to array of address offset/value pairs */
-    mxc_hpb_cfg_reg_val_t *cfg_reg_val;
+    const mxc_hpb_cfg_reg_val_t *cfg_reg_val;
 
     /** number of configuration pairs */
     unsigned int cfg_reg_val_len;
@@ -174,7 +174,8 @@ void MXC_HPB_RegRead8(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, un
  * @param base_addr    Base address
  * @param index        0 or 1 to determine which configuration settings    
 */
-void MXC_HPB_RegWrite8(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, unsigned int index);
+void MXC_HPB_RegWrite8(const mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr,
+                       unsigned int index);
 
 /**
  * @brief Read a variable
@@ -190,7 +191,8 @@ void MXC_HPB_RegRead16(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, u
  * @param base_addr    Base address
  * @param index        0 or 1 to determine which configuration settings    
 */
-void MXC_HPB_RegWrite16(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, unsigned int index);
+void MXC_HPB_RegWrite16(const mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr,
+                        unsigned int index);
 
 /**
  * @brief Configure the HyperBus peripheral.
@@ -200,7 +202,7 @@ void MXC_HPB_RegWrite16(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, 
  *             this memory not used)
  * @return #E_BAD_PARAM if configuration error, #E_NO_ERROR otherwise
  */
-int MXC_HPB_Init(mxc_hpb_mem_config_t *mem0, mxc_hpb_mem_config_t *mem1);
+int MXC_HPB_Init(const mxc_hpb_mem_config_t *mem0, const mxc_hpb_mem_config_t *mem1);
 
 /**
  * @brief   Returns the contents of the status register.

--- a/Libraries/PeriphDrivers/Include/MAX32690/hpb.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/hpb.h
@@ -124,7 +124,7 @@ typedef struct {
     mxc_hpb_device_t device_type;
 
     /** Pointer to array of address offset/value pairs */
-    mxc_hpb_cfg_reg_val_t *cfg_reg_val;
+    const mxc_hpb_cfg_reg_val_t *cfg_reg_val;
 
     /** number of configuration pairs */
     unsigned int cfg_reg_val_len;
@@ -174,7 +174,8 @@ void MXC_HPB_RegRead8(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, un
  * @param base_addr    Base address
  * @param index        0 or 1 to determine which configuration settings    
 */
-void MXC_HPB_RegWrite8(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, unsigned int index);
+void MXC_HPB_RegWrite8(const mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr,
+                       unsigned int index);
 
 /**
  * @brief Read a variable
@@ -190,7 +191,8 @@ void MXC_HPB_RegRead16(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, u
  * @param base_addr    Base address
  * @param index        0 or 1 to determine which configuration settings    
 */
-void MXC_HPB_RegWrite16(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, unsigned int index);
+void MXC_HPB_RegWrite16(const mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr,
+                        unsigned int index);
 
 /**
  * @brief Configure the HyperBus peripheral.
@@ -200,7 +202,7 @@ void MXC_HPB_RegWrite16(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, 
  *             this memory not used)
  * @return #E_BAD_PARAM if configuration error, #E_NO_ERROR otherwise
  */
-int MXC_HPB_Init(mxc_hpb_mem_config_t *mem0, mxc_hpb_mem_config_t *mem1);
+int MXC_HPB_Init(const mxc_hpb_mem_config_t *mem0, const mxc_hpb_mem_config_t *mem1);
 
 /**
  * @brief   Returns the contents of the status register.

--- a/Libraries/PeriphDrivers/Source/HPB/hpb_me10.c
+++ b/Libraries/PeriphDrivers/Source/HPB/hpb_me10.c
@@ -63,9 +63,13 @@ void MXC_HPB_RegWrite16(const mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_
 /* ************************************************************************** */
 int MXC_HPB_Init(const mxc_hpb_mem_config_t *mem0, const mxc_hpb_mem_config_t *mem1)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
+
     /* Enable HyperBus Clocks */
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_HBC);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_SCACHE);
+
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     /* Select drive strength on CK pin */
     MXC_BBFC->bbfcr0 = (2 << MXC_F_BBFC_BBFCR0_CKPDRV_POS) | (MXC_S_BBFC_BBFCR0_RDSDLLEN_EN);
@@ -76,6 +80,8 @@ int MXC_HPB_Init(const mxc_hpb_mem_config_t *mem0, const mxc_hpb_mem_config_t *m
         MXC_BBFC->bbfcr0 |= (2 << MXC_F_BBFC_BBFCR0_CKNPDRV_POS);
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
+
     /* Configure HyperBus GPIO Pins */
     if (mem0) {
         MXC_GPIO_Config(&gpio_cfg_hyp_cs0);
@@ -84,6 +90,8 @@ int MXC_HPB_Init(const mxc_hpb_mem_config_t *mem0, const mxc_hpb_mem_config_t *m
         MXC_GPIO_Config(&gpio_cfg_hyp_cs1);
     }
     MXC_GPIO_Config(&gpio_cfg_hyp);
+
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     /* Reset the controller */
     MXC_SYS_Reset_Periph(MXC_SYS_RESET_HBC);

--- a/Libraries/PeriphDrivers/Source/HPB/hpb_me10.c
+++ b/Libraries/PeriphDrivers/Source/HPB/hpb_me10.c
@@ -41,7 +41,8 @@ void MXC_HPB_RegRead8(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, un
 }
 
 /* ************************************************************************** */
-void MXC_HPB_RegWrite8(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, unsigned int index)
+void MXC_HPB_RegWrite8(const mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr,
+                       unsigned int index)
 {
     MXC_HPB_RevA_RegWrite8((mxc_hpb_reva_regs_t *)MXC_HPB, cfg_reg_val, base_addr, index);
 }
@@ -53,13 +54,14 @@ void MXC_HPB_RegRead16(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, u
 }
 
 /* ************************************************************************** */
-void MXC_HPB_RegWrite16(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, unsigned int index)
+void MXC_HPB_RegWrite16(const mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr,
+                        unsigned int index)
 {
     MXC_HPB_RevA_RegWrite16((mxc_hpb_reva_regs_t *)MXC_HPB, cfg_reg_val, base_addr, index);
 }
 
 /* ************************************************************************** */
-int MXC_HPB_Init(mxc_hpb_mem_config_t *mem0, mxc_hpb_mem_config_t *mem1)
+int MXC_HPB_Init(const mxc_hpb_mem_config_t *mem0, const mxc_hpb_mem_config_t *mem1)
 {
     /* Enable HyperBus Clocks */
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_HBC);

--- a/Libraries/PeriphDrivers/Source/HPB/hpb_me18.c
+++ b/Libraries/PeriphDrivers/Source/HPB/hpb_me18.c
@@ -41,7 +41,8 @@ void MXC_HPB_RegRead8(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, un
 }
 
 /* ************************************************************************** */
-void MXC_HPB_RegWrite8(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, unsigned int index)
+void MXC_HPB_RegWrite8(const mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr,
+                       unsigned int index)
 {
     MXC_HPB_RevA_RegWrite8((mxc_hpb_reva_regs_t *)MXC_HPB, cfg_reg_val, base_addr, index);
 }
@@ -53,13 +54,14 @@ void MXC_HPB_RegRead16(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, u
 }
 
 /* ************************************************************************** */
-void MXC_HPB_RegWrite16(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, unsigned int index)
+void MXC_HPB_RegWrite16(const mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr,
+                        unsigned int index)
 {
     MXC_HPB_RevA_RegWrite16((mxc_hpb_reva_regs_t *)MXC_HPB, cfg_reg_val, base_addr, index);
 }
 
 /* ************************************************************************** */
-int MXC_HPB_Init(mxc_hpb_mem_config_t *mem0, mxc_hpb_mem_config_t *mem1)
+int MXC_HPB_Init(const mxc_hpb_mem_config_t *mem0, const mxc_hpb_mem_config_t *mem1)
 {
     /* Enable HyperBus Clocks */
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_HPB);

--- a/Libraries/PeriphDrivers/Source/HPB/hpb_me18.c
+++ b/Libraries/PeriphDrivers/Source/HPB/hpb_me18.c
@@ -63,9 +63,13 @@ void MXC_HPB_RegWrite16(const mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_
 /* ************************************************************************** */
 int MXC_HPB_Init(const mxc_hpb_mem_config_t *mem0, const mxc_hpb_mem_config_t *mem1)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
+
     /* Enable HyperBus Clocks */
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_HPB);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_SYSCACHE);
+
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     /* Select drive strength on CK pin */
     MXC_GCFR->reg0 = (2 << MXC_F_GCFR_REG0_CKPDRV_POS) | (MXC_F_GCFR_REG0_RDSDLL_EN);
@@ -76,6 +80,8 @@ int MXC_HPB_Init(const mxc_hpb_mem_config_t *mem0, const mxc_hpb_mem_config_t *m
         MXC_GCFR->reg0 |= (2 << MXC_F_GCFR_REG0_CKNDRV_POS);
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
+
     /* Configure HyperBus GPIO Pins */
     if (mem0) {
         MXC_GPIO_Config(&gpio_cfg_hpb_cs0);
@@ -84,6 +90,8 @@ int MXC_HPB_Init(const mxc_hpb_mem_config_t *mem0, const mxc_hpb_mem_config_t *m
         MXC_GPIO_Config(&gpio_cfg_hpb_cs1);
     }
     MXC_GPIO_Config(&gpio_cfg_hpb);
+
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     /* Reset the controller */
     MXC_SYS_Reset_Periph(MXC_SYS_RESET0_HPB);

--- a/Libraries/PeriphDrivers/Source/HPB/hpb_reva.c
+++ b/Libraries/PeriphDrivers/Source/HPB/hpb_reva.c
@@ -34,7 +34,7 @@
 /* **** Functions **** */
 
 /* ************************************************************************** */
-static void MXC_HPB_RevA_ConfigMem(mxc_hpb_reva_regs_t *hpb, mxc_hpb_mem_config_t *mem,
+static void MXC_HPB_RevA_ConfigMem(mxc_hpb_reva_regs_t *hpb, const mxc_hpb_mem_config_t *mem,
                                    unsigned index)
 {
     int i;
@@ -81,7 +81,7 @@ void MXC_HPB_RevA_RegRead8(mxc_hpb_reva_regs_t *hpb, mxc_hpb_cfg_reg_val_t *cfg_
 }
 
 /* ************************************************************************** */
-void MXC_HPB_RevA_RegWrite8(mxc_hpb_reva_regs_t *hpb, mxc_hpb_cfg_reg_val_t *cfg_reg_val,
+void MXC_HPB_RevA_RegWrite8(mxc_hpb_reva_regs_t *hpb, const mxc_hpb_cfg_reg_val_t *cfg_reg_val,
                             uint32_t base_addr, unsigned int index)
 {
     if (!hpb || !cfg_reg_val || index > 1) {
@@ -111,7 +111,7 @@ void MXC_HPB_RevA_RegRead16(mxc_hpb_reva_regs_t *hpb, mxc_hpb_cfg_reg_val_t *cfg
 }
 
 /* ************************************************************************** */
-void MXC_HPB_RevA_RegWrite16(mxc_hpb_reva_regs_t *hpb, mxc_hpb_cfg_reg_val_t *cfg_reg_val,
+void MXC_HPB_RevA_RegWrite16(mxc_hpb_reva_regs_t *hpb, const mxc_hpb_cfg_reg_val_t *cfg_reg_val,
                              uint32_t base_addr, unsigned int index)
 {
     if (!hpb || !cfg_reg_val || index > 1) {
@@ -126,8 +126,8 @@ void MXC_HPB_RevA_RegWrite16(mxc_hpb_reva_regs_t *hpb, mxc_hpb_cfg_reg_val_t *cf
 }
 
 /* ************************************************************************** */
-int MXC_HPB_RevA_Init(mxc_hpb_reva_regs_t *hpb, mxc_hpb_mem_config_t *mem0,
-                      mxc_hpb_mem_config_t *mem1)
+int MXC_HPB_RevA_Init(mxc_hpb_reva_regs_t *hpb, const mxc_hpb_mem_config_t *mem0,
+                      const mxc_hpb_mem_config_t *mem1)
 {
     if (mem0) {
         MXC_HPB_RevA_ConfigMem(hpb, mem0, 0);

--- a/Libraries/PeriphDrivers/Source/HPB/hpb_reva.h
+++ b/Libraries/PeriphDrivers/Source/HPB/hpb_reva.h
@@ -46,14 +46,14 @@ typedef enum {
 /* **** Function Prototypes **** */
 void MXC_HPB_RevA_RegRead8(mxc_hpb_reva_regs_t *hpb, mxc_hpb_cfg_reg_val_t *cfg_reg_val,
                            uint32_t base_addr, unsigned int index);
-void MXC_HPB_RevA_RegWrite8(mxc_hpb_reva_regs_t *hpb, mxc_hpb_cfg_reg_val_t *cfg_reg_val,
+void MXC_HPB_RevA_RegWrite8(mxc_hpb_reva_regs_t *hpb, const mxc_hpb_cfg_reg_val_t *cfg_reg_val,
                             uint32_t base_addr, unsigned int index);
 void MXC_HPB_RevA_RegRead16(mxc_hpb_reva_regs_t *hpb, mxc_hpb_cfg_reg_val_t *cfg_reg_val,
                             uint32_t base_addr, unsigned int index);
-void MXC_HPB_RevA_RegWrite16(mxc_hpb_reva_regs_t *hpb, mxc_hpb_cfg_reg_val_t *cfg_reg_val,
+void MXC_HPB_RevA_RegWrite16(mxc_hpb_reva_regs_t *hpb, const mxc_hpb_cfg_reg_val_t *cfg_reg_val,
                              uint32_t base_addr, unsigned int index);
-int MXC_HPB_RevA_Init(mxc_hpb_reva_regs_t *hpb, mxc_hpb_mem_config_t *mem0,
-                      mxc_hpb_mem_config_t *mem1);
+int MXC_HPB_RevA_Init(mxc_hpb_reva_regs_t *hpb, const mxc_hpb_mem_config_t *mem0,
+                      const mxc_hpb_mem_config_t *mem1);
 uint32_t MXC_HPB_RevA_GetStatus(mxc_hpb_reva_regs_t *hpb);
 void MXC_HPB_RevA_EnableInt(mxc_hpb_reva_regs_t *hpb, unsigned polarity);
 unsigned MXC_HPB_RevA_GetFlag(mxc_hpb_reva_regs_t *hpb);


### PR DESCRIPTION
### Description

The following two commits are prep work for the Zephyr HPB memory-controller driver. They are tested and confirmed working with that driver.

The `const` flags are a nicety, to avoid compiler warnings related to passing in our const structures that are generated from the device tree there.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
