### PR TITLE
refactor(PeriphDrivers): Make HPB clock/gpio setup conditional

### DIFF
--- a/Libraries/PeriphDrivers/Source/HPB/hpb_me10.c
+++ b/Libraries/PeriphDrivers/Source/HPB/hpb_me10.c
@@ -61,9 +61,13 @@ void MXC_HPB_RegWrite16(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, 
 /* ************************************************************************** */
 int MXC_HPB_Init(mxc_hpb_mem_config_t *mem0, mxc_hpb_mem_config_t *mem1)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
+
     /* Enable HyperBus Clocks */
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_HBC);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_SCACHE);
+
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     /* Select drive strength on CK pin */
     MXC_BBFC->bbfcr0 = (2 << MXC_F_BBFC_BBFCR0_CKPDRV_POS) | (MXC_S_BBFC_BBFCR0_RDSDLLEN_EN);
@@ -74,6 +78,8 @@ int MXC_HPB_Init(mxc_hpb_mem_config_t *mem0, mxc_hpb_mem_config_t *mem1)
         MXC_BBFC->bbfcr0 |= (2 << MXC_F_BBFC_BBFCR0_CKNPDRV_POS);
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
+
     /* Configure HyperBus GPIO Pins */
     if (mem0) {
         MXC_GPIO_Config(&gpio_cfg_hyp_cs0);
@@ -82,6 +88,8 @@ int MXC_HPB_Init(mxc_hpb_mem_config_t *mem0, mxc_hpb_mem_config_t *mem1)
         MXC_GPIO_Config(&gpio_cfg_hyp_cs1);
     }
     MXC_GPIO_Config(&gpio_cfg_hyp);
+
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     /* Reset the controller */
     MXC_SYS_Reset_Periph(MXC_SYS_RESET_HBC);

--- a/Libraries/PeriphDrivers/Source/HPB/hpb_me18.c
+++ b/Libraries/PeriphDrivers/Source/HPB/hpb_me18.c
@@ -61,9 +61,13 @@ void MXC_HPB_RegWrite16(mxc_hpb_cfg_reg_val_t *cfg_reg_val, uint32_t base_addr, 
 /* ************************************************************************** */
 int MXC_HPB_Init(mxc_hpb_mem_config_t *mem0, mxc_hpb_mem_config_t *mem1)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
+
     /* Enable HyperBus Clocks */
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_HPB);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_SYSCACHE);
+
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     /* Select drive strength on CK pin */
     MXC_GCFR->reg0 = (2 << MXC_F_GCFR_REG0_CKPDRV_POS) | (MXC_F_GCFR_REG0_RDSDLL_EN);
@@ -74,6 +78,8 @@ int MXC_HPB_Init(mxc_hpb_mem_config_t *mem0, mxc_hpb_mem_config_t *mem1)
         MXC_GCFR->reg0 |= (2 << MXC_F_GCFR_REG0_CKNDRV_POS);
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
+
     /* Configure HyperBus GPIO Pins */
     if (mem0) {
         MXC_GPIO_Config(&gpio_cfg_hpb_cs0);
@@ -82,6 +88,8 @@ int MXC_HPB_Init(mxc_hpb_mem_config_t *mem0, mxc_hpb_mem_config_t *mem1)
         MXC_GPIO_Config(&gpio_cfg_hpb_cs1);
     }
     MXC_GPIO_Config(&gpio_cfg_hpb);
+
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     /* Reset the controller */
     MXC_SYS_Reset_Periph(MXC_SYS_RESET0_HPB);


### PR DESCRIPTION
### Description

Matching other peripheral drivers, this makes clock and GPIO configuration optional if `MSDK_NO_GPIO_CLK_INIT` is defined, to be used by the HPB Zephyr driver which does it's own clock and pinctrl setup.

Second of two PRs to split up #1361

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

_______________________________________________________________________________
