### PR TITLE
fix(BLE): PAL Config Load BD ADDR

### DIFF
--- a/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_cfg.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_cfg.c
@@ -197,7 +197,7 @@ void palCfgLoadBdAddress(uint8_t *pDevAddr)
   pDevAddr[4] = 0x18;
   pDevAddr[3] = 0x80;
 
-  pDevAddr[2] = checksum[2];
+  pDevAddr[2] = id[6] | id[7] | id[8];
   pDevAddr[1] = checksum[1];
   pDevAddr[0] = checksum[0];
 }


### PR DESCRIPTION
### Description

The USN checksum was used to create the unique portion of the BD Address for BLE. The checksum is 16bit not 24bit. This uses the unique id to create the 3rd byte of the address, which matches other MAX32 BLE chip implementations. 

