### PR TITLE
fix(CMSIS, PeriphDrivers): Fix MAX32670 OVR & SystemCoreClock Update settings for LP operation

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Source/system_max32670.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Source/system_max32670.c
@@ -65,13 +65,12 @@ __weak void SystemCoreClockUpdate(void)
         break;
     case MXC_S_GCR_CLKCTRL_SYSCLK_SEL_IPO:
         base_freq = IPO_FREQ;
-		
-		// Use output voltage range (OVR / VCORE) to adjust maximum IPO frequency
-		ovr = (MXC_PWRSEQ->lpcn & MXC_F_PWRSEQ_LPCN_OVR) >> MXC_F_PWRSEQ_LPCN_OVR_POS;
+
+        // Use output voltage range (OVR / VCORE) to adjust maximum IPO frequency
+        ovr = (MXC_PWRSEQ->lpcn & MXC_F_PWRSEQ_LPCN_OVR) >> MXC_F_PWRSEQ_LPCN_OVR_POS;
         if (ovr == 0) { // 0.9 V
             base_freq = 12000000;
-        }
-        else if (ovr == 1) { // 1.0 V
+        } else if (ovr == 1) { // 1.0 V
             base_freq = 50000000;
         }
         break;

--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Source/system_max32670.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Source/system_max32670.c
@@ -49,7 +49,7 @@ __weak int _kill(void)
 
 __weak void SystemCoreClockUpdate(void)
 {
-    uint32_t base_freq, div, clk_src;
+    uint32_t base_freq, div, clk_src, ovr;
 
     // Get the clock source and frequency
     clk_src = (MXC_GCR->clkctrl & MXC_F_GCR_CLKCTRL_SYSCLK_SEL);
@@ -65,6 +65,15 @@ __weak void SystemCoreClockUpdate(void)
         break;
     case MXC_S_GCR_CLKCTRL_SYSCLK_SEL_IPO:
         base_freq = IPO_FREQ;
+		
+		// Use output voltage range (OVR / VCORE) to adjust maximum IPO frequency
+		ovr = (MXC_PWRSEQ->lpcn & MXC_F_PWRSEQ_LPCN_OVR) >> MXC_F_PWRSEQ_LPCN_OVR_POS;
+        if (ovr == 0) { // 0.9 V
+            base_freq = 12000000;
+        }
+        else if (ovr == 1) { // 1.0 V
+            base_freq = 50000000;
+        }
         break;
     case MXC_S_GCR_CLKCTRL_SYSCLK_SEL_IBRO:
         base_freq = IBRO_FREQ;

--- a/Libraries/PeriphDrivers/Source/LP/lp_me15.c
+++ b/Libraries/PeriphDrivers/Source/LP/lp_me15.c
@@ -119,7 +119,7 @@ int MXC_LP_SetOVR(mxc_lp_ovr_t ovr)
     MXC_SETFIELD(MXC_PWRSEQ->lpcn, MXC_F_PWRSEQ_LPCN_OVR, ovr);
 
     // Set LVE bit
-    if (ovr == MXC_LP_OVR_0_9) {
+    if ((ovr == MXC_LP_OVR_0_9) || (ovr == MXC_LP_OVR_1_0)) {
         MXC_FLC0->ctrl |= MXC_F_FLC_CTRL_LVE;
 
     } else {


### PR DESCRIPTION
### Description
The Max32670 LP and SYS driver functions currently have a couple small inaccuracies that are both capable of significantly mis-configuring the system under Low-Power use-cases. This was found by attempting to set Vcore in software using the SetOVR function in the LP driver, and also by trying to rely on its SystemClockUpdate call to automatically update the IPO when Vcore cannot drive a high-frequency clock. 

- Flash Controller LVE Bit set in lp_me15.c SetOVR function needs to be set when Vcore <= 1.0V. Currently checks only 0.9V.
- SystemClockUpdate function currently does not set IPO frequency properly accounting for the current Vcore / OVR setting. Added this change.

I validated this on the EV Kit Rev B with the attached code. This was able to set Vcore to 0.9V and correctly throttle the IPO. Below were my jumper settings:
- VCORE_EN open
- VDD_EN shorted (via ammeter)
- RX_SEL --> RX0
- TX_SEL --> TX0
- LED1_EN/LED2_EN open
- VCORE_SEL --> 1.0V

The EVKit User Guide mentions to remove RX/TX but I had no problem measuring reasonable current values with these jumpers on, and found some issue executing with them off that I will pursue internally. These driver updates are unrelated to the HW issues in any case, and they are necessary regardless. 

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
[LP_optimized_vcore&ipo.zip](https://github.com/user-attachments/files/19197914/LP_optimized_vcore.ipo.zip)
