### PR TITLE
fix(PeriphDrivers): Make TRNG clock shutdown optional for all parts

### DIFF
--- a/Libraries/PeriphDrivers/Source/TRNG/trng_ai85.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_ai85.c
@@ -61,7 +61,9 @@ int MXC_TRNG_Shutdown(void)
 {
     int error = MXC_TRNG_RevB_Shutdown();
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     return error;
 }

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_ai87.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_ai87.c
@@ -61,7 +61,9 @@ int MXC_TRNG_Shutdown(void)
 {
     int error = MXC_TRNG_RevB_Shutdown();
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     return error;
 }

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me10.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me10.c
@@ -58,7 +58,9 @@ void MXC_TRNG_DisableInt(void)
 // *********************************************************************
 int MXC_TRNG_Shutdown(void)
 {
-    MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#ifndef MSDK_NO_GPIO_CLK_INIT
+    MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     return MXC_TRNG_RevA_Shutdown();
 }

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me12.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me12.c
@@ -61,7 +61,9 @@ int MXC_TRNG_Shutdown(void)
 {
     int error = MXC_TRNG_RevB_Shutdown();
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     return error;
 }

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me14.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me14.c
@@ -61,7 +61,9 @@ int MXC_TRNG_Shutdown(void)
 {
     int error = MXC_TRNG_RevB_Shutdown();
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     return error;
 }

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me15.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me15.c
@@ -56,7 +56,9 @@ int MXC_TRNG_Shutdown(void)
 {
     int error = MXC_TRNG_RevB_Shutdown();
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     return error;
 }

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me16.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me16.c
@@ -56,7 +56,9 @@ int MXC_TRNG_Shutdown(void)
 {
     int error = MXC_TRNG_RevB_Shutdown();
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     return error;
 }

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me17.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me17.c
@@ -61,7 +61,9 @@ int MXC_TRNG_Shutdown(void)
 {
     int error = MXC_TRNG_RevB_Shutdown();
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     return error;
 }

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me18.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me18.c
@@ -61,7 +61,9 @@ int MXC_TRNG_Shutdown(void)
 {
     int error = MXC_TRNG_RevB_Shutdown();
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     return error;
 }

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me20.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me20.c
@@ -61,7 +61,9 @@ int MXC_TRNG_Shutdown(void)
 {
     int error = MXC_TRNG_RevB_Shutdown();
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     return error;
 }

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me21.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me21.c
@@ -56,7 +56,9 @@ int MXC_TRNG_Shutdown(void)
 {
     int error = MXC_TRNG_RevB_Shutdown();
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     return error;
 }

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me30.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me30.c
@@ -54,7 +54,9 @@ int MXC_TRNG_Shutdown(void)
 {
     int error = MXC_TRNG_RevB_Shutdown();
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     return error;
 }


### PR DESCRIPTION
TRNG clock setup depends on MSDK_NO_GPIO_CLK_INIT on initialization however it is disabled unconditionally on shutdown. Add the same dependency on shutdown too.

### Description

Please include a summary of the changes and related issues. Please also include relevant motivation and context.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
