### PR TITLE
feat(PeriphDrivers): Add backup power mode wrappers

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/mcr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/mcr_regs.h
@@ -7,7 +7,7 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2024-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,6 +149,17 @@ typedef struct {
 #define MXC_F_MCR_CTRL_ERTCO_EN                        ((uint32_t)(0x1UL << MXC_F_MCR_CTRL_ERTCO_EN_POS)) /**< CTRL_ERTCO_EN Mask */
 
 /**@} end of group MCR_CTRL_Register */
+
+/**
+ * @ingroup  mcr_registers
+ * @defgroup MCR_BYPASS0 MCR_BYPASS0
+ * @brief    Flash Signature Check Bypass Register
+ * @{
+ */
+#define MXC_V_MCR_BYPASS0                              ((uint32_t)0xB0CCF487UL) /**< MCR_BYPASS0 Flash Signature Check Bypass Value */
+#define MXC_S_MCR_BYPASS0                              MXC_V_MCR_BYPASS0 /**< MCR_BYPASS0 Flash Signature Check Bypass Setting */
+
+/**@} end of group MCR_BYPASS0_Register */
 
 #ifdef __cplusplus
 }

--- a/Libraries/PeriphDrivers/Source/LP/lp_me30.c
+++ b/Libraries/PeriphDrivers/Source/LP/lp_me30.c
@@ -55,11 +55,12 @@ void MXC_LP_EnterBackupMode(void)
 {
     MXC_LP_ClearWakeStatus();
 
+    /* Enable backup mode */
     MXC_GCR->pm &= ~MXC_F_GCR_PM_MODE;
     MXC_GCR->pm |= MXC_S_GCR_PM_MODE_BACKUP;
 
     while (1) {}
-    // Should never reach this line - device will jump to backup vector on exit from background mode.
+    // Should never reach this line - device will jump to backup vector on exit from backup mode.
 }
 
 void MXC_LP_EnterPowerDownMode(void)

--- a/Libraries/zephyr/MAX/Include/wrap_max32_lp.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_lp.h
@@ -87,9 +87,37 @@ static inline void Wrap_MXC_LP_EnterStandbyMode(void)
     MXC_LP_EnterStandbyMode();
 }
 
+static inline int Wrap_MXC_LP_EnterBackupMode(void)
+{
+    MXC_LP_EnterBackupMode();
+
+    /* For compatibility with Zephyr PM */
+    return -1;
+}
+
 static inline void Wrap_MXC_LP_EnterPowerDownMode(void)
 {
     MXC_LP_EnterPowerDownMode();
+}
+
+static inline void Wrap_MXC_LP_EnableSramRetention(uint32_t mask)
+{
+    MXC_LP_EnableSramRetention(mask);
+}
+
+static inline void Wrap_MXC_LP_DisableSramRetention()
+{
+    MXC_LP_DisableSramRetention(0x1F);
+}
+
+static inline void Wrap_MXC_LP_EnableRetentionReg(void)
+{
+    MXC_LP_EnableRetentionReg();
+}
+
+static inline void Wrap_MXC_LP_DisableRetentionReg(void)
+{
+    MXC_LP_DisableRetentionReg();
 }
 
 #endif // part number


### PR DESCRIPTION
Added wrapper functions for Zephyr use of Backup mode for MAX32657.

### Description

Part of enabling low-power mode integration in Zephyr

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
