### PR TITLE
fix(PeriphDrivers): Guard power mode wrapper

### DIFF
--- a/Libraries/zephyr/MAX/Include/wrap_max32_lp.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_lp.h
@@ -87,17 +87,18 @@ static inline void Wrap_MXC_LP_EnterStandbyMode(void)
     MXC_LP_EnterStandbyMode();
 }
 
+static inline void Wrap_MXC_LP_EnterPowerDownMode(void)
+{
+    MXC_LP_EnterPowerDownMode();
+}
+
+#if defined(CONFIG_SOC_MAX32657)
 static inline int Wrap_MXC_LP_EnterBackupMode(void)
 {
     MXC_LP_EnterBackupMode();
 
     /* For compatibility with Zephyr PM */
     return -1;
-}
-
-static inline void Wrap_MXC_LP_EnterPowerDownMode(void)
-{
-    MXC_LP_EnterPowerDownMode();
 }
 
 static inline void Wrap_MXC_LP_EnableSramRetention(uint32_t mask)
@@ -119,6 +120,7 @@ static inline void Wrap_MXC_LP_DisableRetentionReg(void)
 {
     MXC_LP_DisableRetentionReg();
 }
+#endif // CONFIG_SOC_MAX32657
 
 #endif // part number
 


### PR DESCRIPTION
Added ifdef guard to power modes for targets that
don't support backup or SRAM retention.

### Description

Please include a summary of the changes and related issues. Please also include relevant motivation and context.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
