### PR TITLE
fix(PeriphDrivers): Cleanup async UART request before running the request's callback

### DIFF
--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -747,13 +747,13 @@ int MXC_UART_RevB_AsyncTxCallback(mxc_uart_revb_regs_t *uart, int retVal)
 {
     int uart_num = MXC_UART_GET_IDX((mxc_uart_regs_t *)uart);
 
+    // Store and Cleanup Async Transaction
     mxc_uart_req_t *req = (mxc_uart_req_t *)AsyncTxRequests[uart_num];
+    AsyncTxRequests[uart_num] = NULL;
+
     if ((req != NULL) && (req->callback != NULL)) {
         req->callback(req, retVal);
-    }
-
-    // Cleanup Async Transaction
-    AsyncTxRequests[uart_num] = NULL;
+    }    
 
     return E_NO_ERROR;
 }
@@ -762,13 +762,13 @@ int MXC_UART_RevB_AsyncRxCallback(mxc_uart_revb_regs_t *uart, int retVal)
 {
     int uart_num = MXC_UART_GET_IDX((mxc_uart_regs_t *)uart);
 
-    mxc_uart_req_t *req = (mxc_uart_req_t *)AsyncRxRequests[uart_num];
+    // Store and Cleanup Async Transaction
+    mxc_uart_req_t *req = (mxc_uart_req_t *)AsyncRxRequests[uart_num];    
+    AsyncRxRequests[uart_num] = NULL;
+
     if ((req != NULL) && (req->callback != NULL)) {
         req->callback(req, retVal);
     }
-
-    // Cleanup Async Transaction
-    AsyncRxRequests[uart_num] = NULL;
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -753,7 +753,7 @@ int MXC_UART_RevB_AsyncTxCallback(mxc_uart_revb_regs_t *uart, int retVal)
 
     if ((req != NULL) && (req->callback != NULL)) {
         req->callback(req, retVal);
-    }    
+    }
 
     return E_NO_ERROR;
 }
@@ -763,7 +763,7 @@ int MXC_UART_RevB_AsyncRxCallback(mxc_uart_revb_regs_t *uart, int retVal)
     int uart_num = MXC_UART_GET_IDX((mxc_uart_regs_t *)uart);
 
     // Store and Cleanup Async Transaction
-    mxc_uart_req_t *req = (mxc_uart_req_t *)AsyncRxRequests[uart_num];    
+    mxc_uart_req_t *req = (mxc_uart_req_t *)AsyncRxRequests[uart_num];
     AsyncRxRequests[uart_num] = NULL;
 
     if ((req != NULL) && (req->callback != NULL)) {


### PR DESCRIPTION
### Description

- Resolves a bug introduced in #1334 
- **Bug**:
  - As the request's callback function ran, the request was not marked as null. Thus, mistaking the UART to be busy and resulting in an assertion.
  - This affects the MAX32655. The device gets stuck when running the `BLE5_ctr` example.
- **Fix**: Move the cleanup to _before_ the callback function is called.
