### PR TITLE
fix(PeriphDrivers): Fix SPIv2 TS1 GPIO init issue for MAX32690

### DIFF
--- a/Libraries/PeriphDrivers/Source/SPI/spi_me18_v2.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me18_v2.c
@@ -130,7 +130,7 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, mxc_spi_type_t controller_target, mxc_spi_
 
             // Target Select 1 - TS1 (L. SS1 pin)
             if (pins.ss1 == true) {
-                temp_ts_cfg = gpio_cfg_spi0_ts0;
+                temp_ts_cfg = gpio_cfg_spi0_ts1;
                 temp_ts_cfg.vssel = vssel;
                 temp_ts_cfg.drvstr = pins.drvstr;
 


### PR DESCRIPTION
### Description
For MAX32690 there is a little mistake in the SPI_v2 configuration function. When Target Select for the SS1 is enabled SS0 gets  enabled instead.
This PR fixes this.