### PR TITLE
fix(PeriphDrivers): MSDK-1287: Fix MAX32655 MXC_Delay on RISC-V shows different behavior when not compiling with -O0

### DIFF
--- a/Libraries/PeriphDrivers/Source/SYS/mxc_delay.c
+++ b/Libraries/PeriphDrivers/Source/SYS/mxc_delay.c
@@ -42,8 +42,18 @@ int MXC_Delay(uint32_t us)
     CSR_SetPCER(1); // Enable counting of cycles
     CSR_SetPCMR(3); // Turn on counter
 
+    uint32_t num_ticks_half_us = MXC_SYS_RiscVClockRate() / 1000000 / 3;
+    volatile uint32_t counter;
+
     while (CSR_GetPCCR() < ticks) {
-        // Wait for counter to reach the tick count.
+        // Wait about 1 us
+        // and re-check if the counter reaches the tick count or not.
+        // Need this waiting to prevent CPU bothers PCCR too much
+        // to avoid PCCR hardware cannot maintain the correct timing.
+        counter = 0;
+        while (counter < num_ticks_half_us) {
+            counter++;
+        }
     }
     return E_NO_ERROR;
 }


### PR DESCRIPTION

### Description

In the MSDK Dual Core Sync example for MAX32655, the LED was programed to turn on in 500ms and then turn off.
Issue: when compiling with -O0, the LED stayed on for 500ms correctly. But, when compiling with -O1, -O2, -Os and -Og, the LED stayed on for longer (around 33% longer than the expected one).
To reproduce, just compile the example changing the MXC_OPTIMIZE_CFLAGS accordingly.

Fix: Add a delay to prevent the CPU bothers PCCR too much, then the PCCR hardware can maintain the correct timing.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

_______________________________________________________________________________

