### PR TITLE
fix(PeriphDrivers): Correct slot configuration loop in ADC SAR12

### DIFF
--- a/Libraries/PeriphDrivers/Source/ADC/adc_ai87.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_ai87.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -347,7 +347,7 @@ int MXC_ADC_SlotConfiguration(mxc_adc_slot_req_t *req, uint32_t slot_length)
 {
     uint32_t loop_counter = 0;
 
-    for (loop_counter = 0; loop_counter <= slot_length; loop_counter++) {
+    for (loop_counter = 0; loop_counter < slot_length; loop_counter++) {
         initGPIOForChannel(req->channel);
 
         if (req->channel <= MAX_ADC_RES_DIV_CH) {

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me12.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me12.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -266,7 +266,7 @@ int MXC_ADC_SlotConfiguration(mxc_adc_slot_req_t *req, uint32_t slot_length)
 {
     uint32_t loop_counter = 0;
 
-    for (loop_counter = 0; loop_counter <= slot_length; loop_counter++) {
+    for (loop_counter = 0; loop_counter < slot_length; loop_counter++) {
         initGPIOForChannel(req->channel);
 #if 0
          if (req->channel <= MAX_ADC_RES_DIV_CH) {

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me18.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me18.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -314,7 +314,7 @@ int MXC_ADC_SlotConfiguration(mxc_adc_slot_req_t *req, uint32_t slot_length)
 {
     uint32_t loop_counter = 0;
 
-    for (loop_counter = 0; loop_counter <= slot_length; loop_counter++) {
+    for (loop_counter = 0; loop_counter < slot_length; loop_counter++) {
         initGPIOForChannel(req->channel);
 #if 0
         if (req->channel <= MAX_ADC_RES_DIV_CH) {

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me21.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me21.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -387,7 +387,7 @@ int MXC_ADC_SlotConfiguration(mxc_adc_slot_req_t *req, uint32_t slot_length)
 {
     uint32_t loop_counter = 0;
 
-    for (loop_counter = 0; loop_counter <= slot_length; loop_counter++) {
+    for (loop_counter = 0; loop_counter < slot_length; loop_counter++) {
         initGPIOForChannel(req->channel);
 
         if (req->channel <= MAX_ADC_RES_DIV_CH) {


### PR DESCRIPTION

### Description

The loop in MXC_ADC_SlotConfiguration iterated one more than the number of slots passed in.
I can't think of any obvious reason why this is not incorrect.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
