### PR TITLE
fix(PeriphDrivers): Fix Uart SVD register field names for MAX32650 and MAX32660

### DIFF
--- a/Libraries/PeriphDrivers/Source/UART/uart_reva_me10.svd
+++ b/Libraries/PeriphDrivers/Source/UART/uart_reva_me10.svd
@@ -944,13 +944,13 @@
             </enumeratedValues>
           </field>
           <field>
-            <name>TXDMA_LVL</name>
+            <name>TXDMA_LEVEL</name>
             <description>TX threshold for DMA transmission.</description>
             <bitOffset>8</bitOffset>
             <bitWidth>6</bitWidth>
           </field>
           <field>
-            <name>RXDMA_LVL</name>
+            <name>RXDMA_LEVEL</name>
             <description>RX threshold for DMA transmission.</description>
             <bitOffset>16</bitOffset>
             <bitWidth>6</bitWidth>

--- a/Libraries/PeriphDrivers/Source/UART/uart_reva_me11.svd
+++ b/Libraries/PeriphDrivers/Source/UART/uart_reva_me11.svd
@@ -646,13 +646,13 @@
             </enumeratedValues>
           </field>
           <field>
-            <name>TXDMA_LVL</name>
+            <name>TXDMA_LEVEL</name>
             <description>TX threshold for DMA transmission.</description>
             <bitOffset>8</bitOffset>
             <bitWidth>6</bitWidth>
           </field>
           <field>
-            <name>RXDMA_LVL</name>
+            <name>RXDMA_LEVEL</name>
             <description>RX threshold for DMA transmission.</description>
             <bitOffset>16</bitOffset>
             <bitWidth>6</bitWidth>


### PR DESCRIPTION
This PR  fixes svd register names of
uart_reva_me10 and uart_reva_me11.

The names were changed because to add MAX32660 and
MAX32650 boards to the zephyr.

### Description

Please include a summary of the changes and related issues. Please also include relevant motivation and context.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
