### PR TITLE
feat(Other): Update Zephyr wrappers to enable MAX32650 support

### DIFF
--- a/Libraries/PeriphDrivers/Source/SPI/spi_me10.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me10.c
@@ -165,7 +165,10 @@ int MXC_SPI_SetSlave(mxc_spi_regs_t *spi, int ssIdx)
 int MXC_SPI_GetSlave(mxc_spi_regs_t *spi)
 {
     int spi_num = MXC_SPI_GET_IDX((mxc_spi_regs_t *)spi);
-    MXC_ASSERT(spi_num >= 0);
+
+    if (spi_num < 0 || spi_num >= MXC_SPI_INSTANCES) {
+        return E_BAD_PARAM;
+    }
 
     int slvSel = (spi->ctrl0 & MXC_F_SPI_CTRL0_SS_SEL) >> MXC_F_SPI_CTRL0_SS_SEL_POS;
 

--- a/Libraries/zephyr/MAX/Include/wrap_max32_dma.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_dma.h
@@ -26,7 +26,7 @@
 extern "C" {
 #endif
 
-#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666) || defined(CONFIG_SOC_MAX32650)
 #define ADI_MAX32_DMA_CTRL_DIS_IE MXC_F_DMA_CFG_CHDIEN
 #define ADI_MAX32_DMA_CTRL_CTZIEN MXC_F_DMA_CFG_CTZIEN
 
@@ -50,7 +50,7 @@ extern "C" {
 
 static inline int MXC_DMA_GetIntFlags(mxc_dma_regs_t *dma)
 {
-#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666) || defined(CONFIG_SOC_MAX32650)
     return dma->intr;
 #else
     return dma->intfl;

--- a/Libraries/zephyr/MAX/Include/wrap_max32_i2c.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_i2c.h
@@ -29,7 +29,7 @@ extern "C" {
 /*
  *  MAX32665, MAX32666 related mapping
  */
-#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666) || defined(CONFIG_SOC_MAX32650)
 
 /*
  *  Control register bits
@@ -39,6 +39,21 @@ extern "C" {
 /*
  *  Interrupt enable bits
  */
+#if defined(CONFIG_SOC_MAX32650)
+#define ADI_MAX32_I2C_INT_EN0_RX_THD MXC_F_I2C_INT_EN0_RXTHIE
+#define ADI_MAX32_I2C_INT_EN0_TX_LOCK_OUT MXC_F_I2C_INT_EN0_TXLOIE
+#define ADI_MAX32_I2C_INT_EN0_TX_THD MXC_F_I2C_INT_EN0_TXTHIE
+#define ADI_MAX32_I2C_INT_EN0_DONE MXC_F_I2C_INT_EN0_DONEIE
+#define ADI_MAX32_I2C_INT_EN0_STOP MXC_F_I2C_INT_EN0_STOPIE
+#define ADI_MAX32_I2C_INT_EN0_ADDR_MATCH MXC_F_I2C_INT_EN0_AMIE
+#define ADI_MAX32_I2C_INT_EN0_ADDR_ACK MXC_F_I2C_INT_EN0_ADRACKIE
+#define ADI_MAX32_I2C_INT_EN1_RX_OVERFLOW MXC_F_I2C_INT_EN1_RXOFIE
+#define ADI_MAX32_I2C_INT_EN1_TX_UNDERFLOW MXC_F_I2C_INT_EN1_TXUFIE
+#define ADI_MAX32_I2C_INT_EN0_ERR                                                          \
+    (MXC_F_I2C_INT_EN0_ARBERIE | MXC_F_I2C_INT_EN0_TOERIE | MXC_F_I2C_INT_EN0_ADRERIE |    \
+     MXC_F_I2C_INT_EN0_DATAERIE | MXC_F_I2C_INT_EN0_DNRERIE | MXC_F_I2C_INT_EN0_STRTERIE | \
+     MXC_F_I2C_INT_EN0_STOPERIE)
+#else
 #define ADI_MAX32_I2C_INT_EN0_RX_THD MXC_F_I2C_INT_EN0_RX_THRESH
 #define ADI_MAX32_I2C_INT_EN0_TX_LOCK_OUT MXC_F_I2C_INT_EN0_TX_LOCK_OUT
 #define ADI_MAX32_I2C_INT_EN0_TX_THD MXC_F_I2C_INT_EN0_TX_THRESH
@@ -48,15 +63,29 @@ extern "C" {
 #define ADI_MAX32_I2C_INT_EN0_ADDR_ACK MXC_F_I2C_INT_EN0_ADDR_ACK
 #define ADI_MAX32_I2C_INT_EN1_RX_OVERFLOW MXC_F_I2C_INT_EN1_RX_OVERFLOW
 #define ADI_MAX32_I2C_INT_EN1_TX_UNDERFLOW MXC_F_I2C_INT_EN1_TX_UNDERFLOW
-
 #define ADI_MAX32_I2C_INT_EN0_ERR                                                                \
     (MXC_F_I2C_INT_EN0_ARB_ER | MXC_F_I2C_INT_EN0_TO_ER | MXC_F_I2C_INT_EN0_ADDR_NACK_ER |       \
      MXC_F_I2C_INT_EN0_DATA_ER | MXC_F_I2C_INT_EN0_DO_NOT_RESP_ER | MXC_F_I2C_INT_EN0_START_ER | \
      MXC_F_I2C_INT_EN0_STOP_ER)
+#endif
 
 /*
  *  Interrupt flags
  */
+#if defined(CONFIG_SOC_MAX32650)
+#define ADI_MAX32_I2C_INT_FL0_RX_THD MXC_F_I2C_INT_FL0_RXTHI
+#define ADI_MAX32_I2C_INT_FL0_TX_LOCK_OUT MXC_F_I2C_INT_FL0_TXLOI
+#define ADI_MAX32_I2C_INT_FL0_TX_THD MXC_F_I2C_INT_FL0_TXTHI
+#define ADI_MAX32_I2C_INT_FL0_ADDR_MATCH MXC_F_I2C_INT_FL0_AMI
+#define ADI_MAX32_I2C_INT_FL0_ADDR_ACK MXC_F_I2C_INT_FL0_ADRACKI
+#define ADI_MAX32_I2C_INT_FL0_STOP MXC_F_I2C_INT_FL0_STOPI
+#define ADI_MAX32_I2C_INT_FL0_DONE MXC_F_I2C_INT_FL0_DONEI
+#define ADI_MAX32_I2C_INT_FL1_RX_OVERFLOW MXC_F_I2C_INT_FL1_RXOFI
+#define ADI_MAX32_I2C_INT_FL0_ERR                                                       \
+    (MXC_F_I2C_INT_FL0_ARBERI | MXC_F_I2C_INT_FL0_TOERI | MXC_F_I2C_INT_FL0_ADRERI |    \
+     MXC_F_I2C_INT_FL0_DATAERI | MXC_F_I2C_INT_FL0_DNRERI | MXC_F_I2C_INT_FL0_STRTERI | \
+     MXC_F_I2C_INT_FL0_STOPERI)
+#else
 #define ADI_MAX32_I2C_INT_FL0_RX_THD MXC_F_I2C_INT_FL0_RX_THRESH
 #define ADI_MAX32_I2C_INT_FL0_TX_LOCK_OUT MXC_F_I2C_INT_FL0_TX_LOCK_OUT
 #define ADI_MAX32_I2C_INT_FL0_TX_THD MXC_F_I2C_INT_FL0_TX_THRESH
@@ -65,11 +94,11 @@ extern "C" {
 #define ADI_MAX32_I2C_INT_FL0_STOP MXC_F_I2C_INT_FL0_STOP
 #define ADI_MAX32_I2C_INT_FL0_DONE MXC_F_I2C_INT_FL0_DONE
 #define ADI_MAX32_I2C_INT_FL1_RX_OVERFLOW MXC_F_I2C_INT_FL1_RX_OVERFLOW
-
 #define ADI_MAX32_I2C_INT_FL0_ERR                                                                \
     (MXC_F_I2C_INT_FL0_ARB_ER | MXC_F_I2C_INT_FL0_TO_ER | MXC_F_I2C_INT_FL0_ADDR_NACK_ER |       \
      MXC_F_I2C_INT_FL0_DATA_ER | MXC_F_I2C_INT_FL0_DO_NOT_RESP_ER | MXC_F_I2C_INT_FL0_START_ER | \
      MXC_F_I2C_INT_FL0_STOP_ER)
+#endif
 
 /*
  *  DMA enable bits
@@ -107,22 +136,65 @@ static inline void Wrap_MXC_I2C_SetRxCount(mxc_i2c_regs_t *i2c, unsigned int len
 
 static inline void Wrap_MXC_I2C_WaitForRestart(mxc_i2c_regs_t *i2c)
 {
+#if defined(CONFIG_SOC_MAX32650)
+    while (i2c->mstr_mode & MXC_F_I2C_MSTR_MODE_RESTART) {}
+#else
     while (i2c->master_ctrl & MXC_F_I2C_MASTER_CTRL_RESTART) {}
+#endif
 }
 
 static inline void Wrap_MXC_I2C_Start(mxc_i2c_regs_t *i2c)
 {
+#if defined(CONFIG_SOC_MAX32650)
+    i2c->mstr_mode |= MXC_F_I2C_MSTR_MODE_START;
+#else
     i2c->master_ctrl |= MXC_F_I2C_MASTER_CTRL_START;
+#endif
 }
 
 static inline void Wrap_MXC_I2C_Restart(mxc_i2c_regs_t *i2c)
 {
+#if defined(CONFIG_SOC_MAX32650)
+    i2c->mstr_mode |= MXC_F_I2C_MSTR_MODE_RESTART;
+#else
     i2c->master_ctrl |= MXC_F_I2C_MASTER_CTRL_RESTART;
+#endif
 }
 
 static inline void Wrap_MXC_I2C_Stop(mxc_i2c_regs_t *i2c)
 {
+#if defined(CONFIG_SOC_MAX32650)
+    i2c->mstr_mode |= MXC_F_I2C_MSTR_MODE_STOP;
+#else
     i2c->master_ctrl |= MXC_F_I2C_MASTER_CTRL_STOP;
+#endif
+}
+
+static inline void Wrap_MXC_I2C_WaitForBusyClear(mxc_i2c_regs_t *i2c)
+{
+#if defined(CONFIG_SOC_MAX32650)
+    while (i2c->stat & MXC_F_I2C_STAT_CKMD) {}
+#else
+    while (i2c->status & MXC_F_I2C_STATUS_CLK_MODE) {}
+#endif
+}
+
+static inline void Wrap_MXC_I2C_GetCtrl(mxc_i2c_regs_t *i2c, unsigned int *ctrl)
+{
+#if defined(CONFIG_SOC_MAX32650)
+    *ctrl = i2c->ctrl0;
+#else
+    *ctrl = i2c->ctrl;
+#endif
+}
+
+static inline uint32_t Wrap_MXC_I2C_GetReadWriteBitStatus(mxc_i2c_regs_t *i2c)
+{
+#if defined(CONFIG_SOC_MAX32650)
+    return i2c->ctrl0 & MXC_F_I2C_CTRL0_READ;
+#else
+    return i2c->ctrl & MXC_F_I2C_CTRL_READ;
+#endif
 }
 
 /*
@@ -225,6 +297,21 @@ static inline void Wrap_MXC_I2C_Restart(mxc_i2c_regs_t *i2c)
 static inline void Wrap_MXC_I2C_Stop(mxc_i2c_regs_t *i2c)
 {
     i2c->mstctrl |= MXC_F_I2C_MSTCTRL_STOP;
+}
+
+static inline void Wrap_MXC_I2C_WaitForBusyClear(mxc_i2c_regs_t *i2c)
+{
+    while (i2c->status & MXC_F_I2C_STATUS_MST_BUSY) {}
+}
+
+static inline void Wrap_MXC_I2C_GetCtrl(mxc_i2c_regs_t *i2c, unsigned int *ctrl)
+{
+    *ctrl = i2c->ctrl;
+}
+
+static inline uint32_t Wrap_MXC_I2C_GetReadWriteBitStatus(mxc_i2c_regs_t *i2c)
+{
+    return i2c->ctrl & MXC_F_I2C_CTRL_READ;
 }
 
 #endif

--- a/Libraries/zephyr/MAX/Include/wrap_max32_spi.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_spi.h
@@ -77,10 +77,17 @@ static inline int Wrap_MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int qua
     defined(CONFIG_SOC_MAX32670) || defined(CONFIG_SOC_MAX32672) ||   \
     defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32675) ||   \
     defined(CONFIG_SOC_MAX32680) || defined(CONFIG_SOC_MAX32657) ||   \
-    defined(CONFIG_SOC_MAX78002) || defined(CONFIG_SOC_MAX78000)
+    defined(CONFIG_SOC_MAX78002) || defined(CONFIG_SOC_MAX78000) || defined(CONFIG_SOC_MAX32650)
 
+#if defined(CONFIG_SOC_MAX32650)
+#define ADI_MAX32_SPI_CTRL_EN MXC_F_SPI_CTRL0_SPI_EN
+#else
+#define ADI_MAX32_SPI_CTRL_EN MXC_F_SPI_CTRL0_EN
+#endif
 #if defined(CONFIG_SOC_MAX32657)
 #define ADI_MAX32_SPI_CTRL_MASTER_MODE MXC_F_SPI_CTRL0_CONT_MODE
+#elif defined(CONFIG_SOC_MAX32650)
+#define ADI_MAX32_SPI_CTRL_MASTER_MODE MXC_F_SPI_CTRL0_MM_EN
 #else
 #define ADI_MAX32_SPI_CTRL_MASTER_MODE MXC_F_SPI_CTRL0_MST_MODE
 #endif
@@ -90,6 +97,8 @@ static inline int Wrap_MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int qua
 #define ADI_MAX32_SPI_INT_FL_TX_OV MXC_F_SPI_INTFL_TX_OV
 #if defined(CONFIG_SOC_MAX32657)
 #define ADI_MAX32_SPI_INT_FL_MST_DONE MXC_F_SPI_INTFL_CONT_DONE
+#elif defined(CONFIG_SOC_MAX32650)
+#define ADI_MAX32_SPI_INT_FL_MST_DONE MXC_F_SPI_INT_FL_M_DONE
 #else
 #define ADI_MAX32_SPI_INT_FL_MST_DONE MXC_F_SPI_INTFL_MST_DONE
 #endif
@@ -97,9 +106,14 @@ static inline int Wrap_MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int qua
 #define ADI_MAX32_SPI_INT_FL_FAULT MXC_F_SPI_INTFL_FAULT
 #define ADI_MAX32_SPI_INT_FL_SSD MXC_F_SPI_INTFL_SSD
 #define ADI_MAX32_SPI_INT_FL_SSA MXC_F_SPI_INTFL_SSA
+#if defined(CONFIG_SOC_MAX32650)
+#define ADI_MAX32_SPI_INT_FL_RX_THD MXC_F_SPI_INT_FL_RX_LEVEL
+#define ADI_MAX32_SPI_INT_FL_TX_THD MXC_F_SPI_INT_FL_TX_LEVEL
+#else
 #define ADI_MAX32_SPI_INT_FL_RX_THD MXC_F_SPI_INTFL_RX_THD
-#define ADI_MAX32_SPI_INT_FL_TX_EMPTY MXC_F_SPI_INTFL_TX_EMPTY
 #define ADI_MAX32_SPI_INT_FL_TX_THD MXC_F_SPI_INTFL_TX_THD
+#endif
+#define ADI_MAX32_SPI_INT_FL_TX_EMPTY MXC_F_SPI_INTFL_TX_EMPTY
 
 #define ADI_MAX32_SPI_INT_EN_RX_UN MXC_F_SPI_INTEN_RX_UN
 #define ADI_MAX32_SPI_INT_EN_RX_OV MXC_F_SPI_INTEN_RX_OV
@@ -107,6 +121,8 @@ static inline int Wrap_MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int qua
 #define ADI_MAX32_SPI_INT_EN_TX_OV MXC_F_SPI_INTEN_TX_OV
 #if defined(CONFIG_SOC_MAX32657)
 #define ADI_MAX32_SPI_INT_EN_MST_DONE MXC_F_SPI_INTEN_CONT_DONE
+#elif defined(CONFIG_SOC_MAX32650)
+#define ADI_MAX32_SPI_INT_EN_MST_DONE MXC_F_SPI_INT_EN_M_DONE
 #else
 #define ADI_MAX32_SPI_INT_EN_MST_DONE MXC_F_SPI_INTEN_MST_DONE
 #endif
@@ -114,12 +130,22 @@ static inline int Wrap_MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int qua
 #define ADI_MAX32_SPI_INT_EN_FAULT MXC_F_SPI_INTEN_FAULT
 #define ADI_MAX32_SPI_INT_EN_SSD MXC_F_SPI_INTEN_SSD
 #define ADI_MAX32_SPI_INT_EN_SSA MXC_F_SPI_INTEN_SSA
+#if defined(CONFIG_SOC_MAX32650)
+#define ADI_MAX32_SPI_INT_EN_RX_THD MXC_F_SPI_INT_EN_RX_LEVEL
+#define ADI_MAX32_SPI_INT_EN_TX_THD MXC_F_SPI_INT_EN_TX_LEVEL
+#else
 #define ADI_MAX32_SPI_INT_EN_RX_THD MXC_F_SPI_INTEN_RX_THD
-#define ADI_MAX32_SPI_INT_EN_TX_EMPTY MXC_F_SPI_INTEN_TX_EMPTY
 #define ADI_MAX32_SPI_INT_EN_TX_THD MXC_F_SPI_INTEN_TX_THD
+#endif
+#define ADI_MAX32_SPI_INT_EN_TX_EMPTY MXC_F_SPI_INTEN_TX_EMPTY
 
+#if defined(CONFIG_SOC_MAX32650)
+#define ADI_MAX32_SPI_DMA_TX_FIFO_CLEAR MXC_F_SPI_DMA_TX_FIFO_CLEAR
+#define ADI_MAX32_SPI_DMA_RX_FIFO_CLEAR MXC_F_SPI_DMA_RX_FIFO_CLEAR
+#else
 #define ADI_MAX32_SPI_DMA_TX_FIFO_CLEAR MXC_F_SPI_DMA_TX_FLUSH
 #define ADI_MAX32_SPI_DMA_RX_FIFO_CLEAR MXC_F_SPI_DMA_RX_FLUSH
+#endif
 #if defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX32662)
 #define ADI_MAX32_SPI_DMA_TX_DMA_EN MXC_F_SPI_DMA_TX_EN
 #define ADI_MAX32_SPI_DMA_RX_DMA_EN MXC_F_SPI_DMA_RX_EN
@@ -131,7 +157,8 @@ static inline int Wrap_MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int qua
 static inline int Wrap_MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed,
                                     int numSlaves, unsigned ssPolarity, unsigned int hz)
 {
-#if defined(CONFIG_SOC_MAX32670) || defined(CONFIG_SOC_MAX32672) || defined(CONFIG_SOC_MAX32675)
+#if defined(CONFIG_SOC_MAX32670) || defined(CONFIG_SOC_MAX32672) || \
+    defined(CONFIG_SOC_MAX32675) || defined(CONFIG_SOC_MAX32650)
     return MXC_SPI_Init(spi, masterMode, quadModeUsed, numSlaves, ssPolarity, hz);
 #else
     mxc_spi_pins_t tmp; // not used

--- a/Libraries/zephyr/MAX/Include/wrap_max32_tmr.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_tmr.h
@@ -39,7 +39,7 @@ typedef struct {
 /*
  *  MAX32665, MAX32666 related mapping
  */
-#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666) || defined(CONFIG_SOC_MAX32650)
 
 /* All timers are 32bits */
 #define WRAP_MXC_IS_32B_TIMER(idx) (1)

--- a/Libraries/zephyr/MAX/Include/wrap_max32_wdt.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_wdt.h
@@ -37,7 +37,7 @@ typedef struct {
 /*
  *  MAX32665, MAX32666 related mapping
  */
-#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666) || defined(CONFIG_SOC_MAX32650)
 
 #define WRAP_MXC_F_WDT_CTRL_EN MXC_F_WDT_CTRL_WDT_EN
 


### PR DESCRIPTION
### Description

This PR enables Zephyr support for MAX32650 for DMA, SPI, I2C, TMR and WDT peripherals by updating Zephyr wrapper files of these peripherals.

`spi_num` parameter causes "unused variable" warning. Because of that, I changed assert with an if condition which also checks instance limit.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.