### PR TITLE
fix(Examples,PeriphDrivers): Use correct number of slots when configuring ADC RevB

### DIFF
--- a/Examples/MAX32662/ADC/main.c
+++ b/Examples/MAX32662/ADC/main.c
@@ -186,16 +186,16 @@ void adc_example1_configuration(void)
     adc_conv.avg_number = MXC_ADC_AVG_16;
     adc_conv.fifo_format = MXC_ADC_DATA_STATUS;
 #ifdef DMA
-    adc_conv.fifo_threshold = 0;
+    adc_conv.fifo_threshold = 1;
 #else
     adc_conv.fifo_threshold = MAX_ADC_FIFO_LEN >> 1;
 #endif
     adc_conv.lpmode_divder = MXC_ADC_DIV_2_5K_50K_ENABLE;
-    adc_conv.num_slots = 0;
+    adc_conv.num_slots = 1;
 
     MXC_ADC_Configuration(&adc_conv);
 
-    MXC_ADC_SlotConfiguration(&single_slot, 0);
+    MXC_ADC_SlotConfiguration(&single_slot, 1);
 }
 
 /* Multi Channel Example */
@@ -211,7 +211,7 @@ void adc_example2_configuration(void)
     adc_conv.fifo_threshold = MAX_ADC_FIFO_LEN >> 1;
 #endif
     adc_conv.lpmode_divder = MXC_ADC_DIV_2_5K_50K_ENABLE;
-    adc_conv.num_slots = 1; // Match number of channels - 1
+    adc_conv.num_slots = 1; // Match number of channels
 
     MXC_ADC_Configuration(&adc_conv);
 

--- a/Examples/MAX32672/ADC/main.c
+++ b/Examples/MAX32672/ADC/main.c
@@ -168,16 +168,16 @@ void adc_example1_configuration(void)
     adc_conv.avg_number = MXC_ADC_AVG_16;
     adc_conv.fifo_format = MXC_ADC_DATA_STATUS;
     adc_conv.lpmode_divder = MXC_ADC_DIV_2_5K_50K_ENABLE;
-    adc_conv.num_slots = 0;
+    adc_conv.num_slots = 1;
 #ifdef DMA
-    adc_conv.fifo_threshold = 0;
+    adc_conv.fifo_threshold = 1;
 #else
     adc_conv.fifo_threshold = MAX_ADC_FIFO_LEN >> 1;
 #endif
 
     MXC_ADC_Configuration(&adc_conv);
 
-    MXC_ADC_SlotConfiguration(&single_slot, 0);
+    MXC_ADC_SlotConfiguration(&single_slot, 1);
 }
 
 /* Temperature Sensor Example Function(s) */
@@ -189,16 +189,16 @@ void adc_example2_configuration(void)
     adc_conv.avg_number = MXC_ADC_AVG_8;
     adc_conv.fifo_format = MXC_ADC_DATA_STATUS;
     adc_conv.lpmode_divder = MXC_ADC_DIV_2_5K_50K_ENABLE;
-    adc_conv.num_slots = 2;
+    adc_conv.num_slots = 3;
 #ifdef DMA
-    adc_conv.fifo_threshold = 2;
+    adc_conv.fifo_threshold = 3;
 #else
     adc_conv.fifo_threshold = MAX_ADC_FIFO_LEN >> 1;
 #endif
 
     MXC_ADC_Configuration(&adc_conv);
 
-    MXC_ADC_SlotConfiguration(three_slots, 2);
+    MXC_ADC_SlotConfiguration(three_slots, 3);
 }
 
 void temperature_average(float temperature)
@@ -236,16 +236,16 @@ void adc_example3_configuration(void)
     adc_conv.avg_number = MXC_ADC_AVG_1;
     adc_conv.fifo_format = MXC_ADC_DATA_STATUS;
     adc_conv.lpmode_divder = MXC_ADC_DIV_2_5K_50K_ENABLE;
-    adc_conv.num_slots = 7;
+    adc_conv.num_slots = 8;
 #ifdef DMA
-    adc_conv.fifo_threshold = 7;
+    adc_conv.fifo_threshold = 8;
 #else
     adc_conv.fifo_threshold = MAX_ADC_FIFO_LEN >> 1;
 #endif
 
     MXC_ADC_Configuration(&adc_conv);
 
-    MXC_ADC_SlotConfiguration(multi_slots, 7);
+    MXC_ADC_SlotConfiguration(multi_slots, 8);
 }
 
 void WaitforConversionComplete(void)

--- a/Examples/MAX32672/ADC_DMA_RMS/InternalADC.c
+++ b/Examples/MAX32672/ADC_DMA_RMS/InternalADC.c
@@ -103,10 +103,10 @@ void InternalADC_StartSampling(ADC_Callback callback)
     adcConv.avg_number = MXC_ADC_AVG_1; //No averaging
     adcConv.fifo_format = MXC_ADC_DATA; //Data only.
     adcConv.lpmode_divder = MXC_ADC_DIV_2_5K_50K_DISABLE;
-    adcConv.num_slots = 0; //1 slot/single channel
-    adcConv.fifo_threshold = 0;
+    adcConv.num_slots = 1; //1 slot/single channel
+    adcConv.fifo_threshold = 1;
     MXC_ADC_Configuration(&adcConv);
-    MXC_ADC_SlotConfiguration(&adcSingleSlot, 0);
+    MXC_ADC_SlotConfiguration(&adcSingleSlot, 1);
 
     //Default the buffer indexes
     activeIndex = 0;

--- a/Examples/MAX32690/ADC/main.c
+++ b/Examples/MAX32690/ADC/main.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -404,16 +404,16 @@ void adc_example1_configuration(void)
     adc_conv.avg_number = MXC_ADC_AVG_16;
     adc_conv.fifo_format = MXC_ADC_DATA_STATUS;
 #ifdef DMA
-    adc_conv.fifo_threshold = 0;
+    adc_conv.fifo_threshold = 1;
 #else
     adc_conv.fifo_threshold = MAX_ADC_FIFO_LEN >> 1;
 #endif
     adc_conv.lpmode_divder = MXC_ADC_DIV_2_5K_50K_ENABLE;
-    adc_conv.num_slots = 0;
+    adc_conv.num_slots = 1;
 
     MXC_ADC_Configuration(&adc_conv);
 
-    MXC_ADC_SlotConfiguration(&single_slot, 0);
+    MXC_ADC_SlotConfiguration(&single_slot, 1);
 }
 
 /* Temperature Sensor */
@@ -426,16 +426,16 @@ void adc_example2_configuration(void)
     adc_conv.avg_number = MXC_ADC_AVG_8;
     adc_conv.fifo_format = MXC_ADC_DATA_STATUS;
 #ifdef DMA
-    adc_conv.fifo_threshold = 2;
+    adc_conv.fifo_threshold = 3;
 #else
     adc_conv.fifo_threshold = MAX_ADC_FIFO_LEN >> 1;
 #endif
     adc_conv.lpmode_divder = MXC_ADC_DIV_2_5K_50K_ENABLE;
-    adc_conv.num_slots = 2;
+    adc_conv.num_slots = 3;
 
     MXC_ADC_Configuration(&adc_conv);
 
-    MXC_ADC_SlotConfiguration(three_slots, 2);
+    MXC_ADC_SlotConfiguration(three_slots, 3);
 }
 
 /* Multi Channel Example */
@@ -448,17 +448,17 @@ void adc_example3_configuration(void)
     adc_conv.avg_number = MXC_ADC_AVG_1;
     adc_conv.fifo_format = MXC_ADC_DATA_STATUS;
 #ifdef DMA
-    adc_conv.fifo_threshold = 7;
+    adc_conv.fifo_threshold = 8;
 #else
     adc_conv.fifo_threshold = MAX_ADC_FIFO_LEN >> 1;
 #endif
     //    adc_conv.fifo_threshold = 8;
     adc_conv.lpmode_divder = MXC_ADC_DIV_2_5K_50K_ENABLE;
-    adc_conv.num_slots = 7;
+    adc_conv.num_slots = 8;
 
     MXC_ADC_Configuration(&adc_conv);
 
-    MXC_ADC_SlotConfiguration(multi_slots, 7);
+    MXC_ADC_SlotConfiguration(multi_slots, 8);
 }
 
 void temperature_average(float temperature)

--- a/Examples/MAX78002/ADC/main.c
+++ b/Examples/MAX78002/ADC/main.c
@@ -166,16 +166,16 @@ void adc_example1_configuration(void)
     adc_conv.avg_number = MXC_ADC_AVG_16;
     adc_conv.fifo_format = MXC_ADC_DATA_STATUS;
 #ifdef DMA
-    adc_conv.fifo_threshold = 0;
+    adc_conv.fifo_threshold = 1;
 #else
     adc_conv.fifo_threshold = MAX_ADC_FIFO_LEN >> 1;
 #endif
     adc_conv.lpmode_divder = MXC_ADC_DIV_2_5K_50K_ENABLE;
-    adc_conv.num_slots = 0;
+    adc_conv.num_slots = 1;
 
     MXC_ADC_Configuration(&adc_conv);
 
-    MXC_ADC_SlotConfiguration(&single_slot, 0);
+    MXC_ADC_SlotConfiguration(&single_slot, 1);
 }
 
 /* Temperature Sensor */
@@ -188,16 +188,16 @@ void adc_example2_configuration(void)
     adc_conv.avg_number = MXC_ADC_AVG_8;
     adc_conv.fifo_format = MXC_ADC_DATA_STATUS;
 #ifdef DMA
-    adc_conv.fifo_threshold = 2;
+    adc_conv.fifo_threshold = 3;
 #else
     adc_conv.fifo_threshold = MAX_ADC_FIFO_LEN >> 1;
 #endif
     adc_conv.lpmode_divder = MXC_ADC_DIV_2_5K_50K_ENABLE;
-    adc_conv.num_slots = 2;
+    adc_conv.num_slots = 3;
 
     MXC_ADC_Configuration(&adc_conv);
 
-    MXC_ADC_SlotConfiguration(three_slots, 2);
+    MXC_ADC_SlotConfiguration(three_slots, 3);
 }
 
 /* Multi Channel Example */
@@ -210,17 +210,17 @@ void adc_example3_configuration(void)
     adc_conv.avg_number = MXC_ADC_AVG_1;
     adc_conv.fifo_format = MXC_ADC_DATA_STATUS;
 #ifdef DMA
-    adc_conv.fifo_threshold = 7;
+    adc_conv.fifo_threshold = 8;
 #else
     adc_conv.fifo_threshold = MAX_ADC_FIFO_LEN >> 1;
 #endif
     //    adc_conv.fifo_threshold = 8;
     adc_conv.lpmode_divder = MXC_ADC_DIV_2_5K_50K_ENABLE;
-    adc_conv.num_slots = 7;
+    adc_conv.num_slots = 8;
 
     MXC_ADC_Configuration(&adc_conv);
 
-    MXC_ADC_SlotConfiguration(multi_slots, 7);
+    MXC_ADC_SlotConfiguration(multi_slots, 8);
 }
 
 void temperature_average(float temperature)

--- a/Libraries/PeriphDrivers/Include/MAX32662/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/adc.h
@@ -44,7 +44,8 @@ extern "C" {
  */
 
 /* MAX32662 Specific */
-#define MAX_ADC_SLOT_NUM 29
+#define MAX_ADC_SLOT_NUM 19 ///< Channels 4-11, 13, 16-17 are reserved
+                            ///< This definition is used to check max slot ID limit
 #define MAX_ADC_FIFO_LEN 16
 #define MAX_ADC_RES_DIV_CH 12
 
@@ -64,6 +65,7 @@ typedef enum {
     MXC_ADC_CH_VDDA_DIV2 = 12, ///< Select Channel 12
     MXC_ADC_CH_VCOREA = 14, ///< Select Channel 14
     MXC_ADC_CH_VSS = 15, ///< Select Channel 15
+    MXC_ADC_CH_VDDIO_DIV4 = 18 ///< Select Channel 18
 } mxc_adc_chsel_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32672/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/adc.h
@@ -57,7 +57,7 @@ extern "C" {
   *
   */
 typedef enum {
-    MXC_ADC_CH_0, ///< Select Channel 0
+    MXC_ADC_CH_0 = 0, ///< Select Channel 0
     MXC_ADC_CH_1, ///< Select Channel 1
     MXC_ADC_CH_2, ///< Select Channel 2
     MXC_ADC_CH_3, ///< Select Channel 3
@@ -69,10 +69,15 @@ typedef enum {
     MXC_ADC_CH_9, ///< Select Channel 9
     MXC_ADC_CH_10, ///< Select Channel 10
     MXC_ADC_CH_11, ///< Select Channel 11
-    MXC_ADC_CH_12, ///< Select Channel 12
-    MXC_ADC_CH_13, ///< Select Channel 13
-    MXC_ADC_CH_14, ///< Select Channel 14
-    MXC_ADC_CH_15 ///< Select Channel 15
+    MXC_ADC_CH_VDDA = 12, ///< Select Channel 12
+    MXC_ADC_CH_TEMP_SENS, ///< Select Channel 13
+    MXC_ADC_CH_VCORE, ///< Select Channel 14
+    MXC_ADC_CH_VSS, ///< Select Channel 15
+
+    MXC_ADC_CH_12 = MXC_ADC_CH_VDDA, ///< Legacy Name: Select Channel 12
+    MXC_ADC_CH_13 = MXC_ADC_CH_TEMP_SENS, ///< Legacy Name: Select Channel 13
+    MXC_ADC_CH_14 = MXC_ADC_CH_VCORE, ///< Legacy Name: Select Channel 14
+    MXC_ADC_CH_15 = MXC_ADC_CH_VSS ///< Legacy Name: Select Channel 15
 } mxc_adc_chsel_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32690/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/adc.h
@@ -44,10 +44,12 @@ extern "C" {
  * @{
  */
 
-/* MAX32672 Specific */
-#define MAX_ADC_SLOT_NUM 29
+/* MAX32690 Specific */
+#define MAX_ADC_SLOT_NUM 21 ///< Channels 8-11 and 16-17 are reserved
+                            ///< This definition is used to check max slot ID limit
 #define MAX_ADC_FIFO_LEN 16
 #define MAX_ADC_RES_DIV_CH 12
+
 /***************************************************************************************************************
                                     DATA STRUCTURES FOR ADC INITIALIZATION
 ***************************************************************************************************************/
@@ -69,6 +71,9 @@ typedef enum {
     MXC_ADC_CH_TEMP_SENS = 13, ///< Select Channel 13
     MXC_ADC_CH_VCOREA = 14, ///< Select Channel 14
     MXC_ADC_CH_VSS = 15, ///< Select Channel 15
+    MXC_ADC_CH_VDBB3A_DIV4 = 18, ///< Select Channel 18
+    MXC_ADC_CH_VDBB_DIV4 = 19, ///< Select Channel 19
+    MXC_ADC_CH_VSSA = 20, ///< Select Channel 20
 } mxc_adc_chsel_t;
 
 /**

--- a/Libraries/PeriphDrivers/Source/ADC/adc_revb.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_revb.c
@@ -234,7 +234,7 @@ int MXC_ADC_RevB_StartConversionDMA(mxc_adc_revb_regs_t *adc, mxc_adc_conversion
 
     adc->fifodmactrl |= MXC_F_ADC_REVB_FIFODMACTRL_DMA_EN; //Enable ADC DMA
 
-    num_bytes = (req->num_slots + 1) * 4; //Support 8 slots (32 bytes) only. (TODO)
+    num_bytes = (req->num_slots) * 4; //Support 8 slots (32 bytes) only. (TODO)
 
     channel = req->dma_channel;
 


### PR DESCRIPTION
### Description

The slot configurations were not handled correctly. For example, when using x3 ADC slots, the examples and drivers required you to pass in `2` (num of slots - 1) instead of `3` (num of slots). PR #1380 corrected this, so it's now more intuitive.

This PR accounts for the side effects that came from that fix.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.