### PR TITLE
fix(PeriphDrivers, Other): Add missing parts for MAX32650

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32650/lp.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/lp.h
@@ -381,6 +381,11 @@ void MXC_LP_USBClearPONRST(void);
  */
 void MXC_LP_USBSetPONRST(void);
 
+/**
+ * @brief      clear all wake up status
+ */
+void MXC_LP_ClearWakeStatus(void);
+
 /**@} end of group lp */
 
 #ifdef __cplusplus

--- a/Libraries/zephyr/MAX/Include/wrap_max32_spi.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_spi.h
@@ -150,10 +150,13 @@ static inline int Wrap_MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int qua
 #if defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX32662)
 #define ADI_MAX32_SPI_DMA_TX_DMA_EN MXC_F_SPI_DMA_TX_EN
 #define ADI_MAX32_SPI_DMA_RX_DMA_EN MXC_F_SPI_DMA_RX_EN
+#elif defined(CONFIG_SOC_MAX32650)
+#define ADI_MAX32_SPI_DMA_TX_DMA_EN MXC_F_SPI_DMA_TX_DMA_EN
+#define ADI_MAX32_SPI_DMA_RX_DMA_EN MXC_F_SPI_DMA_RX_DMA_EN
 #else
 #define ADI_MAX32_SPI_DMA_TX_DMA_EN MXC_F_SPI_DMA_DMA_TX_EN
 #define ADI_MAX32_SPI_DMA_RX_DMA_EN MXC_F_SPI_DMA_DMA_RX_EN
-#endif /* defined(CONFIG_SOC_MAX32657) || defined(CONFIG_SOC_MAX32662) */
+#endif
 
 static inline int Wrap_MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed,
                                     int numSlaves, unsigned ssPolarity, unsigned int hz)


### PR DESCRIPTION
### Description

This PR adds `MXC_LP_ClearWakeStatus` functions descriptor to MAX32650's `lp.h` header file to avoid warnings. Also, it adds correct SPI macros to Zephyr SPI wrapper file to solve build failure.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.