### PR TITLE
fix(Other): Update Zephyr ADC wrapper according to BM driver changes

### DIFF
--- a/Libraries/zephyr/MAX/Include/wrap_max32_adc.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_adc.h
@@ -227,7 +227,7 @@ static inline void Wrap_MXC_ADC_ChannelSelect(uint32_t *sample_channels)
     uint8_t slot_index = 0;
     int channel_id;
 
-    req.num_slots = num_of_channels - 1;
+    req.num_slots = num_of_channels;
 
     for (slot_index = 0; slot_index < num_of_channels; slot_index++) {
         channel_id = wrap_utils_find_lsb_set(*sample_channels);
@@ -242,7 +242,7 @@ static inline void Wrap_MXC_ADC_ChannelSelect(uint32_t *sample_channels)
 
     MXC_ADC_Clear_ChannelSelect();
     MXC_ADC_SlotsConfig(&req);
-    MXC_ADC_SlotConfiguration(slots, num_of_channels - 1);
+    MXC_ADC_SlotConfiguration(slots, num_of_channels);
 }
 
 static inline int Wrap_MXC_ADC_ReferenceSelect(uint8_t ref)


### PR DESCRIPTION
### Description

There are BM driver changes in PR https://github.com/analogdevicesinc/msdk/pull/1386. These changes cause problem on Zephyr side. This PR updates Zephyr ADC wrapper according to ADC revB driver changes.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.