### PR TITLE
feat(CMSIS, Other): Initial support for SBT implementation for MAX32651

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32650/Source/sla_header_MAX32650.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32650/Source/sla_header_MAX32650.c
@@ -58,7 +58,11 @@ typedef struct {
     unsigned int AppVersionNumber; //> Version of this application
 } flash_app_header_t;
 
+#ifdef USE_ZEPHYR_SECTIONS
+__attribute__((section(".rom_start"))) __attribute__((__used__))
+#else
 __attribute__((section(".sb_sla_header"))) __attribute__((__used__))
+#endif
 const flash_app_header_t sb_header = {
     .Magic =
         {

--- a/Libraries/zephyr/MAX/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/CMakeLists.txt
@@ -32,6 +32,13 @@ zephyr_compile_definitions(
     -DMSDK_NO_LOCKING=1
 )
 
+if (CONFIG_MAX32_SECURE_SOC)
+zephyr_compile_definitions(
+    -D__SLA_FWK__
+    -DUSE_ZEPHYR_SECTIONS=1
+)
+endif()
+
 get_filename_component(MSDK_LIBRARY_DIR "./Libraries" ABSOLUTE)
 set(MSDK_CMSIS_DIR       ${MSDK_LIBRARY_DIR}/CMSIS/Device/Maxim/${TARGET_UC})
 set(MSDK_PERIPH_DIR      ${MSDK_LIBRARY_DIR}/PeriphDrivers)

--- a/Libraries/zephyr/MAX/Source/MAX32650/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32650/CMakeLists.txt
@@ -70,6 +70,10 @@ zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/DMA/dma_reva.c
 )
 
+if (CONFIG_MAX32_SECURE_SOC)
+zephyr_library_sources(${MSDK_CMSIS_DIR}/Source/sla_header_MAX32650.c)
+endif()
+
 if (CONFIG_UART_MAX32)
 zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/UART/uart_common.c


### PR DESCRIPTION
### Description

This PR adds 'sla_header_MAX32650.c' file to Zephyr source library to implement SBT to Zephyr for MAX32651 SoC. It also defines 'USE_ZEPHYR_SECTIONS' flag because Zephyr has different section names. If this flag is defined, 'sb_header' structure will be placed in the '.rom_start' section.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.