### PR TITLE
feat(Other): Adjust built drivers for new Zephyr configs

### DIFF
--- a/Libraries/zephyr/MAX/Source/MAX32655/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32655/CMakeLists.txt
@@ -95,7 +95,7 @@ zephyr_library_sources(
 )
 endif()
 
-if (CONFIG_GPIO_MAX32)
+if (CONFIG_GPIO_MAX32 OR CONFIG_PINCTRL_MAX32)
 zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_common.c
     ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_me17.c
@@ -154,7 +154,7 @@ zephyr_library_sources(
 )
 endif()
 
-if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32) 
+if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32 OR CONFIG_MAX32_RV32_SYS_TIMER)
 zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_common.c
     ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_me17.c

--- a/Libraries/zephyr/MAX/Source/MAX32680/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32680/CMakeLists.txt
@@ -98,7 +98,7 @@ zephyr_library_sources(
 )
 endif()
 
-if (CONFIG_GPIO_MAX32)
+if (CONFIG_GPIO_MAX32 OR CONFIG_PINCTRL_MAX32)
 zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_common.c
     ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_me17.c
@@ -157,7 +157,7 @@ zephyr_library_sources(
 )
 endif()
 
-if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32) 
+if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32 OR CONFIG_MAX32_RV32_SYS_TIMER)
 zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_common.c
     ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_me17.c

--- a/Libraries/zephyr/MAX/Source/MAX32690/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32690/CMakeLists.txt
@@ -107,7 +107,7 @@ zephyr_library_sources(
 )
 endif()
 
-if (CONFIG_GPIO_MAX32)
+if (CONFIG_GPIO_MAX32 OR CONFIG_PINCTRL_MAX32)
 zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_common.c
     ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_me18.c
@@ -166,7 +166,7 @@ zephyr_library_sources(
 )
 endif()
 
-if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32) 
+if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32 OR CONFIG_MAX32_RV32_SYS_TIMER)
 zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_common.c
     ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_me18.c

--- a/Libraries/zephyr/MAX/Source/MAX78000/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX78000/CMakeLists.txt
@@ -102,7 +102,7 @@ zephyr_library_sources(
 )
 endif()
 
-if (CONFIG_GPIO_MAX32)
+if (CONFIG_GPIO_MAX32 OR CONFIG_PINCTRL_MAX32)
 zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_common.c
     ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_ai85.c
@@ -154,7 +154,7 @@ zephyr_library_sources(
 )
 endif()
 
-if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32) 
+if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32 OR CONFIG_MAX32_RV32_SYS_TIMER)
 zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_common.c
     ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_ai85.c

--- a/Libraries/zephyr/MAX/Source/MAX78002/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX78002/CMakeLists.txt
@@ -98,7 +98,7 @@ zephyr_library_sources(
 )
 endif()
 
-if (CONFIG_GPIO_MAX32)
+if (CONFIG_GPIO_MAX32 OR CONFIG_PINCTRL_MAX32)
 zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_common.c
     ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_ai87.c
@@ -150,7 +150,7 @@ zephyr_library_sources(
 )
 endif()
 
-if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32) 
+if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32 OR CONFIG_MAX32_RV32_SYS_TIMER)
 zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_common.c
     ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_ai87.c


### PR DESCRIPTION
### Description

Enable the timer and GPIO peripheral code for a few more possible Zephyr Kconfig flags.

This is a precursor to expanded RV32 core Zephyr support, which includes a new system timer using a timer peripheral.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
