### PR TITLE
fix(PeriphDrivers): Update I2C driver which causes a Double-Read (#1293)

### DIFF
--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
@@ -967,6 +967,13 @@ int MXC_I2C_RevA_MasterTransaction(mxc_i2c_reva_req_t *req)
         i2c->fifo = (req->addr << 1) | 0x1; // Load slave address with read bit.
     }
 
+    if ((req->rx_len != 0) && (req->tx_len != 0)) {
+        while (!(i2c->intfl0 & MXC_F_I2C_REVA_INTFL0_DONE)) {}
+        // Wait for Transaction to finish
+
+        i2c->intfl0 |= MXC_F_I2C_REVA_INTFL0_DONE;
+    }
+
     while (req->rx_len > read) {
         if (i2c->intfl0 & (MXC_F_I2C_REVA_INTFL0_RX_THD | MXC_F_I2C_REVA_INTFL0_DONE)) {
             read +=


### PR DESCRIPTION

### Description

Add a waiting for the Transaction to finish between writing and reading section.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

_______________________________________________________________________________

