### PR TITLE
fix(Cordio/Wsf,FreeRTOS): Fix Issue #699 which results in hung Cordio/Wsf/FreeRTOS app

### DIFF
--- a/Libraries/Cordio/wsf/sources/targets/freertos/wsf_cs.c
+++ b/Libraries/Cordio/wsf/sources/targets/freertos/wsf_cs.c
@@ -34,9 +34,6 @@
   Global Variables
 **************************************************************************************************/
 
-/*! \brief  Critical section nesting level. */
-uint8_t wsfCsNesting = 0;
-
 /*************************************************************************************************/
 /*!
  *  \brief  Enter a critical section.
@@ -46,7 +43,7 @@ void WsfCsEnter(void)
 {
     portDISABLE_INTERRUPTS();
 
-    wsfCsNesting++;
+    portINC_CRITICAL_NESTING();
 }
 
 /*************************************************************************************************/
@@ -56,9 +53,9 @@ void WsfCsEnter(void)
 /*************************************************************************************************/
 void WsfCsExit(void)
 {
-    wsfCsNesting--;
+    UBaseType_t uxCriticalNesting = portDEC_CRITICAL_NESTING();
 
-    if (wsfCsNesting == 0) {
+    if (uxCriticalNesting == 0) {
         portENABLE_INTERRUPTS();
     }
 }

--- a/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F/port.c
+++ b/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F/port.c
@@ -410,6 +410,16 @@ void vPortEndScheduler( void )
 }
 /*-----------------------------------------------------------*/
 
+UBaseType_t vPortIncCriticalNesting( void ) {
+    uxCriticalNesting++;
+    return uxCriticalNesting;
+}
+
+UBaseType_t vPortDecCriticalNesting( void ) {
+    uxCriticalNesting--;
+    return uxCriticalNesting;
+}
+
 void vPortEnterCritical( void )
 {
     portDISABLE_INTERRUPTS();

--- a/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F/portmacro.h
+++ b/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F/portmacro.h
@@ -96,12 +96,17 @@
 /*-----------------------------------------------------------*/
 
 /* Critical section management. */
+/* enable nesting with outside libs */
+    extern UBaseType_t vPortIncCriticalNesting( void );
+    extern UBaseType_t vPortDecCriticalNesting( void );
     extern void vPortEnterCritical( void );
     extern void vPortExitCritical( void );
     #define portSET_INTERRUPT_MASK_FROM_ISR()         ulPortRaiseBASEPRI()
     #define portCLEAR_INTERRUPT_MASK_FROM_ISR( x )    vPortSetBASEPRI( x )
     #define portDISABLE_INTERRUPTS()                  vPortRaiseBASEPRI()
     #define portENABLE_INTERRUPTS()                   vPortSetBASEPRI( 0 )
+    #define portINC_CRITICAL_NESTING()                vPortIncCriticalNesting()
+    #define portDEC_CRITICAL_NESTING()                vPortDecCriticalNesting()
     #define portENTER_CRITICAL()                      vPortEnterCritical()
     #define portEXIT_CRITICAL()                       vPortExitCritical()
 


### PR DESCRIPTION
See Issue #699 for details.

Bottom line, Wsf critical sections are not enforced because the critical nesting count is not shared between the port of Wsf to FreeRTOS and native FreeRTOS.  The result is unexpected behavior, and in the case of Issue #699, an early/unexpected yield from within a Wsf critical section eventually leads to corrupted CordioM task state and a hung application.
