### PR TITLE
feat(Other): Support MAX32660 in Zephyr DMA and low-power wrappers

### DIFF
--- a/Libraries/zephyr/MAX/Include/wrap_max32_dma.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_dma.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2023 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,8 @@ static inline int MXC_DMA_GetIntFlags(mxc_dma_regs_t *dma)
 {
 #if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666) || defined(CONFIG_SOC_MAX32650)
     return dma->intr;
+#elif defined(CONFIG_SOC_MAX32660)
+    return dma->int_fl;
 #else
     return dma->intfl;
 #endif

--- a/Libraries/zephyr/MAX/Include/wrap_max32_lp.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_lp.h
@@ -31,7 +31,8 @@ extern "C" {
  */
 #if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666) || \
     defined(CONFIG_SOC_MAX32670) || defined(CONFIG_SOC_MAX32672) || \
-    defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32675) || defined(CONFIG_SOC_MAX32650)
+    defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32675) || \
+    defined(CONFIG_SOC_MAX32650) || defined(CONFIG_SOC_MAX32660)
 
 static inline void Wrap_MXC_LP_EnterLowPowerMode(void)
 {


### PR DESCRIPTION
### Description

Add MAX32660 support to Zephyr DMA and low-power wrappers.

Fixes build failures in upstream CI.

- https://github.com/zephyrproject-rtos/zephyr/actions/runs/15514057490/job/43678591677#step:13:4186
- https://github.com/zephyrproject-rtos/zephyr/actions/runs/15087287187/job/42411469045#step:13:2905

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
