### PR TITLE
fix(Other): Skip USN checksum checking for Zephyr wrapper

### DIFF
--- a/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
@@ -67,8 +67,7 @@ static inline int Wrap_MXC_SYS_GetUSN(uint8_t *usn)
 #if defined(CONFIG_SOC_MAX32650)
     return MXC_SYS_GetUSN(usn, MXC_SYS_USN_LEN);
 #else
-    uint8_t checksum[MXC_SYS_USN_CHECKSUM_LEN];
-    return MXC_SYS_GetUSN(usn, checksum);
+    return MXC_SYS_GetUSN(usn, NULL);
 #endif
 }
 
@@ -146,9 +145,7 @@ static inline int Wrap_MXC_SYS_GetUSN(uint8_t *usn)
 #if defined(CONFIG_SOC_MAX32660)
     return MXC_SYS_GetUSN(usn, MXC_SYS_USN_LEN, 0);
 #else
-    uint8_t checksum[MXC_SYS_USN_CHECKSUM_LEN];
-
-    return MXC_SYS_GetUSN(usn, checksum);
+    return MXC_SYS_GetUSN(usn, NULL);
 #endif
 }
 


### PR DESCRIPTION
Some scenarios (power on reset, at least), trigger checksum failures on some supported targets, so disable checking the USN checksum by passing NULL for that parameter.

### Description

Some Zephyr tests (secure storage, hwinfo) encounter periodic failures, who's exact nature is still being investigated, but at a minimum:

* On MAX78002, the checksum process will fail for valid data on a power on reset. I suspect an issue with the AES peripheral, but that is still being investigated.

To avoid that specific issue, update our SYS wrapper to skip the checksum process (for now).

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.