### PR TITLE
fix(PeriphDrivers): Fix limitations of the SPI V2 driver code

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32572/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/spi.h
@@ -138,6 +138,17 @@ typedef enum {
 } mxc_spi_mode_t;
 ///<<< Deprecated
 
+/**
+ * @brief The list of possible status codes returned in the result parameter
+ * of the mxc_spi_callback_t function.
+ */
+typedef enum {
+    SPI_ST_COMP = E_NO_ERROR, ///< SPI transaction completed without error
+    SPI_ST_TX_COMP,           ///< All requested bytes have been transmitted
+    SPI_ST_RX_COMP,           ///< All requested bytes have been received
+    SPI_ST_ABORT = E_ABORT,       ///< SPI transaction completed without error
+} mxc_spi_callback_status_t;
+
 typedef struct _mxc_spi_req_t mxc_spi_req_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32690/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/spi.h
@@ -137,6 +137,17 @@ typedef enum {
 } mxc_spi_mode_t;
 ///<<< Deprecated
 
+/**
+ * @brief The list of possible status codes returned in the result parameter
+ * of the mxc_spi_callback_t function.
+ */
+typedef enum {
+    SPI_ST_COMP = E_NO_ERROR, ///< SPI transaction completed without error
+    SPI_ST_TX_COMP,           ///< All requested bytes have been transmitted
+    SPI_ST_RX_COMP,           ///< All requested bytes have been received
+    SPI_ST_ABORT = E_ABORT,       ///< SPI transaction completed without error
+} mxc_spi_callback_status_t;
+
 typedef struct _mxc_spi_req_t mxc_spi_req_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX78002/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/spi.h
@@ -138,6 +138,17 @@ typedef enum {
 } mxc_spi_mode_t;
 ///<<< Deprecated
 
+/**
+ * @brief The list of possible status codes returned in the result parameter
+ * of the mxc_spi_callback_t function.
+ */
+typedef enum {
+    SPI_ST_COMP = E_NO_ERROR, ///< SPI transaction completed without error
+    SPI_ST_TX_COMP,           ///< All requested bytes have been transmitted
+    SPI_ST_RX_COMP,           ///< All requested bytes have been received
+    SPI_ST_ABORT = E_ABORT,       ///< SPI transaction completed without error
+} mxc_spi_callback_status_t;
+
 typedef struct _mxc_spi_req_t mxc_spi_req_t;
 
 /**


### PR DESCRIPTION
### Description

This PR addresses three issues that were found with the SPI V2 driver code:

1. Some SPI and DMA interrupt flags were being cleared with |= potentially clearing other 1WC flags in the register.  This was addressed by replacing the '!=' operators with '=" operators where necessary.
2. The SPI START bit was being set before all other SPI configuration had been completed.  The fix here was to make sure the START bit was the last field to be set in each of the transaction functions.
3. There was no way to distinguish the reason for a callback being issued.  To resolve this, an enumeration of possible callback reasons was created.  The second parameter of the SPI callback function now contains one of the values from that enumeration to indicate the reason for the callback.

