### PR TITLE
fix(PeriphDrivers): Fix LPTMR clock sources for MAX32655

### DIFF
--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me17.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me17.c
@@ -47,11 +47,12 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         break;
 
     case MXC_TMR_IBRO_CLK:
-        if (tmr_id > 3) { // Timers 4-5 do not support this clock source
-            return E_NOT_SUPPORTED;
+        if (tmr_id > 3) {
+            clockSource = MXC_TMR_CLK0;
+        } else {
+            clockSource = MXC_TMR_CLK2;
         }
 
-        clockSource = MXC_TMR_CLK2;
         MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
         MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, IBRO_FREQ);
         break;
@@ -72,7 +73,7 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
             clockSource = MXC_TMR_CLK1;
         } else if (tmr_id < 4) {
             clockSource = MXC_TMR_CLK3;
-        } else { // Timers 5 do not support this clock source
+        } else { // Timer 5 does not support this clock source
             return E_NOT_SUPPORTED;
         }
 
@@ -84,9 +85,10 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
     case MXC_TMR_INRO_CLK:
         if (tmr_id < 4) { // Timers 0-3 do not support this clock source
             return E_NOT_SUPPORTED;
+        } else {
+            clockSource = MXC_TMR_CLK2;
         }
 
-        clockSource = MXC_TMR_CLK2;
         MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_INRO);
         MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, INRO_FREQ);
         break;


### PR DESCRIPTION
### Description

https://github.com/analogdevicesinc/msdk/issues/1410

Fix the clock source settings for LPTMR0/TMR4 and LPTMR1/TMR5 for the MAX32655. TMR5 does not use the ERTCO clock source.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation. For API changes or significant features, this is not optional.