### PR TITLE
fix(PeriphDrivers): MAX32655 I2C driver hang forever (#1289)

### DIFF
--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
@@ -1035,6 +1035,9 @@ int MXC_I2C_RevA_MasterTransactionAsync(mxc_i2c_reva_req_t *req)
         return E_BAD_STATE;
     }
 
+    while (i2c->status & MXC_F_I2C_REVA_STATUS_BUSY) {}
+    // Wait for the last Transaction to finish and the Bus is ready
+
     if (AsyncRequests[i2cNum] == NULL) {
         if (req->addr > MXC_I2C_REVA_MAX_ADDR_WIDTH) {
             return E_NOT_SUPPORTED;


### PR DESCRIPTION
### Description

Add a waiting for the last Transaction to finish and the Bus is ready.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

