### PR TITLE
ci(workflow): Explicitly use bash to run Zephyr HAL script

### DIFF
--- a/.github/workflows/zephyr-hal.yml
+++ b/.github/workflows/zephyr-hal.yml
@@ -49,7 +49,7 @@ jobs:
           # The working directory for scripts will be the root of the runner workspace.
           # Using the checkout commands above, the script will start out in the same 
           # directory that contains the 'msdk' and 'hal_adi' folders.
-          sh ./msdk/.github/workflows/scripts/zephyr_hal_sync.sh
+          bash ./msdk/.github/workflows/scripts/zephyr_hal_sync.sh
 
       - name: Push changes to hal_adi repository
         run: |


### PR DESCRIPTION
Explicitly use `bash` to run the Zephyr HAL export script, due to the usage of pushd/popd.

### Description

Fixes the error noted in https://github.com/analogdevicesinc/msdk/pull/1414#issuecomment-3144705441

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
