### PR TITLE
fix(PeriphDrivers): Convert timer prescaler macros to actual integer dividers for accurate tick calculation

### DIFF
--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
@@ -364,6 +364,10 @@ uint32_t MXC_TMR_RevB_GetPeriod(mxc_tmr_revb_regs_t *tmr, uint32_t clk_frequency
     (void)tmr_id;
     MXC_ASSERT(tmr_id >= 0);
 
+    // convert prescalar value in register to actual prescalar value in power of 2 for periodTicks calculation
+    uint32_t exponent = prescalar >> 4;
+    prescalar = 1 << exponent;
+
     periodTicks = clk_frequency / (frequency * prescalar);
 
     return periodTicks;


### PR DESCRIPTION
The `MXC_TMR_RevB_GetPeriod()` function in `Libraries/PeriphDrivers/Source/TMR/tmr_revb.c` currently uses prescaler macros (`MXC_TMR_PRES_1`, `MXC_TMR_PRES_8`) directly to compute `periodTicks`. However, these macros represent register-encoded values, not the actual prescaler values needed for the calculation:

`periodTicks = clock_frequency / (frequency * prescaler)`

`periodTicks` is heavily used to configure the timer comparator register for triggering timer interrupts.

The macros are encoded from `0x0` to `0xC`, left-shifted by 4 bits, to indicate 13 distinct prescaler values ranging from 1 to 4096.  

| **Prescaler Macro** | **Macro Value (hex)** | **Macro Value (decimal)** | **Actual Prescaler Value (decimal)** |
|---------------------|---------------------------|------------------------------------|------------------------------------|
| `MXC_TMR_PRES_1`    | `0x0 << 4`                  | 0 | 1                                                  |
| `MXC_TMR_PRES_2`    | `0x1 << 4`                  | 16 | 2                                                  |
| `MXC_TMR_PRES_4`    | `0x2 << 4`                  | 32 | 4                                                  |
| `MXC_TMR_PRES_8`    | `0x3 << 4`                  | 48 | 8                                                  |
| `MXC_TMR_PRES_16`   | `0x4 << 4`                 | 64 | 16                                                |
| `MXC_TMR_PRES_32`   | `0x5 << 4`                 | 80 | 32                                                |
| `MXC_TMR_PRES_64`   | `0x6 << 4`                 | 96 | 64                                                |
| `MXC_TMR_PRES_128`  | `0x7 << 4`                | 112 | 128                                              |
| `MXC_TMR_PRES_256`  | `0x8 << 4`                | 128 | 256                                              |
| `MXC_TMR_PRES_512`  | `0x9 << 4`                | 144 | 512                                              |
| `MXC_TMR_PRES_1024` | `0xA << 4`               | 160 | 1024                                            |
| `MXC_TMR_PRES_2048` | `0xB << 4`               | 176 |  2048                                            |
| `MXC_TMR_PRES_4096` | `0xC << 4`               | 192 | 4096                                            |

Currently, the timer library uses the values in column 3 to compute `periodTicks`, which can lead to a division-by-zero error when MSDK users set the timer prescaler to 1 (`MXC_TMR)PRES_1`). The miscalculation of `periodTicks` can lead to a significant inaccuracy in timer interrupts. 

To demonstrate the bug, I modified the MSDK TMR example code to generate continuous timer interrupts using TMR0 and TMR1. Both timers were configured identically and the code was loaded onto an AD-APARD32690_SL. I configured the timer interrupts to toggle 2 GPIO pins and used a logic analyzer to probe both pins. 

This code snippet shows the configuration for one of the timers:
```
void ContinuousTimer0(void)
{
    // Declare variables
    mxc_tmr_cfg_t tmr;
    uint32_t periodTicks = MXC_TMR_GetPeriod(CONT_TIMER0, MXC_TMR_IBRO_CLK, MXC_TMR_PRES_4096, 2);

    /*
    Steps for configuring a timer for PWM mode:
    1. Disable the timer
    2. Set the prescale value
    3  Configure the timer for continuous mode
    4. Set polarity, timer parameters
    5. Enable Timer
    */ 

    MXC_TMR_Shutdown(CONT_TIMER0);

    tmr.pres = MXC_TMR_PRES_4096;
    tmr.mode = TMR_MODE_CONTINUOUS;
    tmr.bitMode = TMR_BIT_MODE_32;
    tmr.clock = MXC_TMR_IBRO_CLK;
    tmr.cmp_cnt = periodTicks; //SystemCoreClock*(1/interval_time);
    tmr.pol = 0;

    if (MXC_TMR_Init(CONT_TIMER0, &tmr, 0) != E_NO_ERROR) {
        printf("Failed Continuous timer Initialization.\n");
        return;
    }

    MXC_TMR_EnableInt(CONT_TIMER0);

    MXC_NVIC_SetVector(TMR0_IRQn, ContinuousTimerHandler0);
    NVIC_EnableIRQ(TMR0_IRQn);

    MXC_TMR_Start(CONT_TIMER0);

    printf("Continuous timer0 started.\n\n");
}
```

The following image illustrates a 2 Hz timer interrupt using the IBRO clock with a 4096 prescaler on Channel 0 and a 128 prescaler on Channel 1, prior to the modifications in this PR:

<img width="877" height="322" alt="image" src="https://github.com/user-attachments/assets/ffe44bae-c512-48ac-aebb-41b5fb6c8179" />

Ideally, these 2 curves should be identical because modifying the timer prescaler should not affect the interrupt period. The timer interrupt configured with a 4096 prescaler is significantly off because its evaluated macro value (192) differs greatly from the intended prescaler value (4096). Channel 0 evaluates to 0.093 Hz and Channel 1 evaluates to 1.735 Hz.

To convert the macros (column 3 of the table) to actual prescalers (column 4 of the table), I:
1. right-shifted the macros by 4 bits to extract the exponent
2. computed the actual prescaler as `2 ^ exponent`

The resulting curves are:
<img width="667" height="320" alt="image" src="https://github.com/user-attachments/assets/584b77cc-346e-4d04-9ae4-b74fd1e7c0bd" />

The frequencies of both curves evaluate to 1.983 Hz (0.85% inaccuracy), probably due to base oscillator's inherent inaccuracies.

I have modified the same code to use the ISO clock to generate 2 Hz, 3 Hz and 4 Hz interrupts, the inaccuracies are all below 1%.

