### PR TITLE
fix(Other): Fix typos in Zephyr SoC checks and headers

### DIFF
--- a/Libraries/zephyr/MAX/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 if (${CONFIG_SOC} MATCHES "max32666")
     set(TARGET_LC "max32665")
-elseif (${CONFIG_SOC} MATCHES "max326651")
+elseif (${CONFIG_SOC} MATCHES "max32651")
     set(TARGET_LC "max32650")
 else ()
     set(TARGET_LC ${CONFIG_SOC})

--- a/Libraries/zephyr/MAX/Include/wrap_max32xxx.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32xxx.h
@@ -40,7 +40,7 @@ extern "C" {
 #elif defined(CONFIG_SOC_MAX32662)
 #include <max32662.h>
 #elif defined(CONFIG_SOC_MAX32665)
-#include <max326665.h>
+#include <max32665.h>
 #elif defined(CONFIG_SOC_MAX32666)
 #include <max32665.h>
 #elif defined(CONFIG_SOC_MAX32670)


### PR DESCRIPTION
### Description

Correct two typos affecting MAX32651 and MAX32665 support:

In CMake logic, `CONFIG_SOC` was incorrectly compared to `max326651` instead of `max32651`.

In an include directive, `max32665.h` was mistyped as `max326665.h`.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
