### PR TITLE
fix(PeriphDrivers): ME18-191: Add code to workaround a power fail issue when entering and exiting Standby or UPM modes on the MAX32690

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/gcr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/gcr_regs.h
@@ -82,13 +82,16 @@ typedef struct {
     __IO uint32_t rst0;                 /**< <tt>\b 0x04:</tt> GCR RST0 Register */
     __IO uint32_t clkctrl;              /**< <tt>\b 0x08:</tt> GCR CLKCTRL Register */
     __IO uint32_t pm;                   /**< <tt>\b 0x0C:</tt> GCR PM Register */
-    __R  uint32_t rsv_0x10_0x17[2];
+    __IO uint32_t pfrst;                /**< <tt>\b 0x10:</tt> GCR PFRST Register */
+    __I  uint32_t pfstat;               /**< <tt>\b 0x14:</tt> GCR PFSTAT Register */
     __IO uint32_t pclkdiv;              /**< <tt>\b 0x18:</tt> GCR PCLKDIV Register */
     __R  uint32_t rsv_0x1c_0x23[2];
     __IO uint32_t pclkdis0;             /**< <tt>\b 0x24:</tt> GCR PCLKDIS0 Register */
     __IO uint32_t memctrl;              /**< <tt>\b 0x28:</tt> GCR MEMCTRL Register */
     __IO uint32_t memz;                 /**< <tt>\b 0x2C:</tt> GCR MEMZ Register */
-    __R  uint32_t rsv_0x30_0x3f[4];
+    __R  uint32_t rsv_0x30;
+    __I  uint32_t pfbuf;                /**< <tt>\b 0x34:</tt> GCR PFBUF Register */
+    __R  uint32_t rsv_0x38_0x3f[2];
     __IO uint32_t sysst;                /**< <tt>\b 0x40:</tt> GCR SYSST Register */
     __IO uint32_t rst1;                 /**< <tt>\b 0x44:</tt> GCR RST1 Register */
     __IO uint32_t pclkdis1;             /**< <tt>\b 0x48:</tt> GCR PCLKDIS1 Register */
@@ -117,10 +120,13 @@ typedef struct {
 #define MXC_R_GCR_RST0                     ((uint32_t)0x00000004UL) /**< Offset from GCR Base Address: <tt> 0x0004</tt> */
 #define MXC_R_GCR_CLKCTRL                  ((uint32_t)0x00000008UL) /**< Offset from GCR Base Address: <tt> 0x0008</tt> */
 #define MXC_R_GCR_PM                       ((uint32_t)0x0000000CUL) /**< Offset from GCR Base Address: <tt> 0x000C</tt> */
+#define MXC_R_GCR_PFRST                    ((uint32_t)0x00000010UL) /**< Offset from GCR Base Address: <tt> 0x0010</tt> */
+#define MXC_R_GCR_PFSTAT                   ((uint32_t)0x00000014UL) /**< Offset from GCR Base Address: <tt> 0x0014</tt> */
 #define MXC_R_GCR_PCLKDIV                  ((uint32_t)0x00000018UL) /**< Offset from GCR Base Address: <tt> 0x0018</tt> */
 #define MXC_R_GCR_PCLKDIS0                 ((uint32_t)0x00000024UL) /**< Offset from GCR Base Address: <tt> 0x0024</tt> */
 #define MXC_R_GCR_MEMCTRL                  ((uint32_t)0x00000028UL) /**< Offset from GCR Base Address: <tt> 0x0028</tt> */
 #define MXC_R_GCR_MEMZ                     ((uint32_t)0x0000002CUL) /**< Offset from GCR Base Address: <tt> 0x002C</tt> */
+#define MXC_R_GCR_PFBUF                    ((uint32_t)0x00000034UL) /**< Offset from GCR Base Address: <tt> 0x0034</tt> */
 #define MXC_R_GCR_SYSST                    ((uint32_t)0x00000040UL) /**< Offset from GCR Base Address: <tt> 0x0040</tt> */
 #define MXC_R_GCR_RST1                     ((uint32_t)0x00000044UL) /**< Offset from GCR Base Address: <tt> 0x0044</tt> */
 #define MXC_R_GCR_PCLKDIS1                 ((uint32_t)0x00000048UL) /**< Offset from GCR Base Address: <tt> 0x0048</tt> */
@@ -408,6 +414,28 @@ typedef struct {
 
 /**
  * @ingroup  gcr_registers
+ * @defgroup GCR_PFRST GCR_PFRST
+ * @brief    Power Fail Reset Register.
+ * @{
+ */
+#define MXC_F_GCR_PFRST_EN_POS                         0 /**< PFRST_EN Position */
+#define MXC_F_GCR_PFRST_EN                             ((uint32_t)(0x1UL << MXC_F_GCR_PFRST_EN_POS)) /**< PFRST_EN Mask */
+
+/**@} end of group GCR_PFRST_Register */
+
+/**
+ * @ingroup  gcr_registers
+ * @defgroup GCR_PFSTAT GCR_PFSTAT
+ * @brief    Power Fail Reset Status Register.
+ * @{
+ */
+#define MXC_F_GCR_PFSTAT_RST_POS                       1 /**< PFSTAT_RST Position */
+#define MXC_F_GCR_PFSTAT_RST                           ((uint32_t)(0x1UL << MXC_F_GCR_PFSTAT_RST_POS)) /**< PFSTAT_RST Mask */
+
+/**@} end of group GCR_PFSTAT_Register */
+
+/**
+ * @ingroup  gcr_registers
  * @defgroup GCR_PCLKDIV GCR_PCLKDIV
  * @brief    Peripheral Clock Divider.
  * @{
@@ -582,6 +610,20 @@ typedef struct {
 #define MXC_F_GCR_MEMZ_DCACHE_TAG                      ((uint32_t)(0x1UL << MXC_F_GCR_MEMZ_DCACHE_TAG_POS)) /**< MEMZ_DCACHE_TAG Mask */
 
 /**@} end of group GCR_MEMZ_Register */
+
+/**
+ * @ingroup  gcr_registers
+ * @defgroup GCR_PFBUF GCR_PFBUF
+ * @brief    Power Fail Reset Buffer Register.
+ * @{
+ */
+#define MXC_F_GCR_PFBUF_PWRGOOD_BUF_POS                15 /**< PFBUF_PWRGOOD_BUF Position */
+#define MXC_F_GCR_PFBUF_PWRGOOD_BUF                    ((uint32_t)(0x7UL << MXC_F_GCR_PFBUF_PWRGOOD_BUF_POS)) /**< PFBUF_PWRGOOD_BUF Mask */
+
+#define MXC_F_GCR_PFBUF_PWRGOOD_POS                    31 /**< PFBUF_PWRGOOD Position */
+#define MXC_F_GCR_PFBUF_PWRGOOD                        ((uint32_t)(0x1UL << MXC_F_GCR_PFBUF_PWRGOOD_POS)) /**< PFBUF_PWRGOOD Mask */
+
+/**@} end of group GCR_PFBUF_Register */
 
 /**
  * @ingroup  gcr_registers

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.svd
@@ -6424,6 +6424,35 @@ memory.
      </fields>
     </register>
     <register>
+     <name>PFRST</name>
+     <description>Power Fail Reset Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Power Fail Reset Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PFSTAT</name>
+     <description>Power Fail Reset Status Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RST</name>
+       <description>Power Fail Reset Status</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
      <name>PCLKDIV</name>
      <description>Peripheral Clock Divider.</description>
      <addressOffset>0x18</addressOffset>
@@ -6778,6 +6807,28 @@ memory.
        <description>Data-Cache Controller Tag Zeroization.</description>
        <bitOffset>15</bitOffset>
        <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PFBUF</name>
+     <description>Power Fail Reset Buffer Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>PWRGOOD_BUF</name>
+       <description>Power Good Detection.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>3</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>PWRGOOD</name>
+       <description>Power Good Detected.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
       </field>
      </fields>
     </register>
@@ -12418,6 +12469,143 @@ memory.
    </registers>
   </peripheral>
 <!--PTG Pulse Train Generation-->
+  <peripheral>
+   <name>PUF</name>
+   <description>PUF Registers</description>
+   <baseAddress>0x40070000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>PUF Control Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PUF_EN</name>
+       <description>PUF Controller Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY_CLR_EN</name>
+       <description>Key Clear Enable or PUFSEC Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY0_GEN_EN</name>
+       <description>PUF Key0 Generation Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY1_GEN_EN</name>
+       <description>PUF Key1 Generation Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYGEN_ERR_IE</name>
+       <description>Key Generation Error Interrupt Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY0_DN_IE</name>
+       <description>Key0 Done Interrupt Enable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY1_DN_IE</name>
+       <description>Key1 Done Interrupt Enable </description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>PUF Status Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>PUF Controller Busy.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MAGIC_ERR</name>
+       <description>PUF Magic Word Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYGEN_EN_ERR</name>
+       <description>PUF Magic Word Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYGEN_ERR</name>
+       <description>PUF Magic Word Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADC_FREQ_FL</name>
+       <description>ADC Frequency Flag</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY0_INIT_ERR</name>
+       <description>PUF Key0 Initialization Error.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY0_CNST_ERR</name>
+       <description> PUF Key0 Constant Key Mismatch Error</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY1_INIT_ERR</name>
+       <description>PUF Key1 Initialization Error.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY1_CNST_ERR</name>
+       <description> PUF Key1 Constant Key Mismatch Error</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY0_DN</name>
+       <description>Key0 Done.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY1_DN</name>
+       <description>Key1 Done.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PUF PUF Registers-->
   <peripheral>
    <name>PWRSEQ</name>
    <description>Power Sequencer / Low Power Control Register.</description>

--- a/Libraries/PeriphDrivers/Source/LP/lp_me18.c
+++ b/Libraries/PeriphDrivers/Source/LP/lp_me18.c
@@ -28,15 +28,15 @@
 
 static void MXC_LP_DisablePowerFailDetection(void)
 {
-	MXC_GCR->pfrst &= ~MXC_F_GCR_PFRST_EN;
+    MXC_GCR->pfrst &= ~MXC_F_GCR_PFRST_EN;
 }
 
 static void MXC_LP_EnablePowerFailDetection(void)
 {
-	// Wait for power to be stable before enabling.
-	while((MXC_GCR->pfbuf & (MXC_F_GCR_PFBUF_PWRGOOD_BUF | MXC_F_GCR_PFBUF_PWRGOOD)) == 
-          (MXC_F_GCR_PFBUF_PWRGOOD_BUF | MXC_F_GCR_PFBUF_PWRGOOD));
-	MXC_GCR->pfrst |= MXC_F_GCR_PFRST_EN;
+    // Wait for power to be stable before enabling.
+    while ((MXC_GCR->pfbuf & (MXC_F_GCR_PFBUF_PWRGOOD_BUF | MXC_F_GCR_PFBUF_PWRGOOD)) ==
+           (MXC_F_GCR_PFBUF_PWRGOOD_BUF | MXC_F_GCR_PFBUF_PWRGOOD)) {}
+    MXC_GCR->pfrst |= MXC_F_GCR_PFRST_EN;
 }
 
 void MXC_LP_EnterSleepMode(void)

--- a/Libraries/PeriphDrivers/Source/SYS/SVD/gcr_me18.svd
+++ b/Libraries/PeriphDrivers/Source/SYS/SVD/gcr_me18.svd
@@ -687,6 +687,35 @@
         </fields>
       </register>
       <register>
+        <name>PFRST</name>
+        <description>Power Fail Reset Register.</description>
+        <addressOffset>0x10</addressOffset>
+        <fields>
+          <field>
+            <name>EN</name>
+            <description>Power Fail Reset Enable.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>PFSTAT</name>
+        <description>Power Fail Reset Status Register.</description>
+        <addressOffset>0x14</addressOffset>
+        <access>read-only</access>
+        <fields>
+          <field>
+            <name>RST</name>
+            <description>Power Fail Reset Status</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-only</access>
+          </field>
+        </fields>
+      </register>
+      <register>
         <name>PCLKDIV</name>
         <description>Peripheral Clock Divider.</description>
         <addressOffset>0x18</addressOffset>
@@ -1041,6 +1070,28 @@
             <description>Data-Cache Controller Tag Zeroization.</description>
             <bitOffset>15</bitOffset>
             <bitWidth>1</bitWidth>
+          </field>
+        </fields>
+      </register>
+      <register>
+        <name>PFBUF</name>
+        <description>Power Fail Reset Buffer Register.</description>
+        <addressOffset>0x34</addressOffset>
+        <access>read-only</access>
+        <fields>
+          <field>
+            <name>PWRGOOD_BUF</name>
+            <description>Power Good Detection.</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>3</bitWidth>
+            <access>read-only</access>
+          </field>
+          <field>
+            <name>PWRGOOD</name>
+            <description>Power Good Detected.</description>
+            <bitOffset>31</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-only</access>
           </field>
         </fields>
       </register>
@@ -1596,161 +1647,161 @@
         <description>BTLE LDO Control Register</description>
         <addressOffset>0x74</addressOffset>
         <fields>
-         <field>
-          <name>LDOBBEN</name>
-          <description>LDOBB Enable.</description>
-          <bitOffset>0</bitOffset>
-          <bitWidth>1</bitWidth>
-         </field>
-         <field>
-          <name>LDOBBPULLD</name>
-          <description>LDOBB Pull Down.</description>
-          <bitOffset>1</bitOffset>
-          <bitWidth>1</bitWidth>
-         </field>
-         <field>
-          <name>LDOBBVSEL</name>
-          <description>LDOBB Voltage Setting.</description>
-          <bitOffset>2</bitOffset>
-          <bitWidth>2</bitWidth>
-          <enumeratedValues>
-           <enumeratedValue>
-            <name>0_85</name>
-            <description>0.85V</description>
-            <value>0</value>
-           </enumeratedValue>
-           <enumeratedValue>
-            <name>0_9</name>
-            <description>0.9V</description>
-            <value>1</value>
-           </enumeratedValue>
-           <enumeratedValue>
-            <name>1_0</name>
-            <description>1.0V</description>
-            <value>2</value>
-           </enumeratedValue>
-           <enumeratedValue>
-            <name>1_1</name>
-            <description>1.1V</description>
-            <value>3</value>
-           </enumeratedValue>
-          </enumeratedValues>
-         </field>
-         <field>
-          <name>LDORFEN</name>
-          <description>LDORF Enable.</description>
-          <bitOffset>4</bitOffset>
-          <bitWidth>1</bitWidth>
-         </field>
-         <field>
-          <name>LDORFPULLD</name>
-          <description>LDORF Pull Down.</description>
-          <bitOffset>5</bitOffset>
-          <bitWidth>1</bitWidth>
-         </field>
-         <field>
-          <name>LDORFVSEL</name>
-          <description>LDORF Voltage Setting.</description>
-          <bitOffset>6</bitOffset>
-          <bitWidth>2</bitWidth>
-           <enumeratedValues>
-           <enumeratedValue>
-            <name>0_85</name>
-            <description>0.85V</description>
-            <value>0</value>
-           </enumeratedValue>
-           <enumeratedValue>
-            <name>0_9</name>
-            <description>0.9V</description>
-            <value>1</value>
-           </enumeratedValue>
-           <enumeratedValue>
-            <name>1_0</name>
-            <description>1.0V</description>
-            <value>2</value>
-           </enumeratedValue>
-           <enumeratedValue>
-            <name>1_1</name>
-            <description>1.1V</description>
-            <value>3</value>
-           </enumeratedValue>
-          </enumeratedValues>
-         </field>
-         <field>
-          <name>LDORFBYP</name>
-          <description>LDORF Bypass Enable.</description>
-          <bitOffset>8</bitOffset>
-          <bitWidth>1</bitWidth>
-         </field>
-         <field>
-          <name>LDORFDISCH</name>
-          <description>LDORF Discharge.</description>
-          <bitOffset>9</bitOffset>
-          <bitWidth>1</bitWidth>
-         </field>
-         <field>
-          <name>LDOBBBYP</name>
-          <description>LDOBB Bypass Enable.</description>
-          <bitOffset>10</bitOffset>
-          <bitWidth>1</bitWidth>
-         </field>
-         <field>
-          <name>LDOBBDISCH</name>
-          <description>LDOBB Discharge.</description>
-          <bitOffset>11</bitOffset>
-          <bitWidth>1</bitWidth>
-         </field>
-         <field>
-          <name>LDOBBENDLY</name>
-          <description>LDOBB Enable Delay.</description>
-          <bitOffset>12</bitOffset>
-          <bitWidth>1</bitWidth>
-         </field>
-         <field>
-          <name>LDORFENDLY</name>
-          <description>LDORF Enable Delay.</description>
-          <bitOffset>13</bitOffset>
-          <bitWidth>1</bitWidth>
-         </field>
-         <field>
-          <name>LDORFBYPENENDLY</name>
-          <description>LDORF Bypass Enable Delay.</description>
-          <bitOffset>14</bitOffset>
-          <bitWidth>1</bitWidth>
-         </field>
-         <field>
-          <name>LDOBBBYPENENDLY</name>
-          <description>LDOBB Bypass Enable Delay.</description>
-          <bitOffset>15</bitOffset>
-          <bitWidth>1</bitWidth>
-         </field>
+          <field>
+            <name>LDOBBEN</name>
+            <description>LDOBB Enable.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>LDOBBPULLD</name>
+            <description>LDOBB Pull Down.</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>LDOBBVSEL</name>
+            <description>LDOBB Voltage Setting.</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>2</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>0_85</name>
+                <description>0.85V</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>0_9</name>
+                <description>0.9V</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>1_0</name>
+                <description>1.0V</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>1_1</name>
+                <description>1.1V</description>
+                <value>3</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>LDORFEN</name>
+            <description>LDORF Enable.</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>LDORFPULLD</name>
+            <description>LDORF Pull Down.</description>
+            <bitOffset>5</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>LDORFVSEL</name>
+            <description>LDORF Voltage Setting.</description>
+            <bitOffset>6</bitOffset>
+            <bitWidth>2</bitWidth>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>0_85</name>
+                <description>0.85V</description>
+                <value>0</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>0_9</name>
+                <description>0.9V</description>
+                <value>1</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>1_0</name>
+                <description>1.0V</description>
+                <value>2</value>
+              </enumeratedValue>
+              <enumeratedValue>
+                <name>1_1</name>
+                <description>1.1V</description>
+                <value>3</value>
+              </enumeratedValue>
+            </enumeratedValues>
+          </field>
+          <field>
+            <name>LDORFBYP</name>
+            <description>LDORF Bypass Enable.</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>LDORFDISCH</name>
+            <description>LDORF Discharge.</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>LDOBBBYP</name>
+            <description>LDOBB Bypass Enable.</description>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>LDOBBDISCH</name>
+            <description>LDOBB Discharge.</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>LDOBBENDLY</name>
+            <description>LDOBB Enable Delay.</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>LDORFENDLY</name>
+            <description>LDORF Enable Delay.</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>LDORFBYPENENDLY</name>
+            <description>LDORF Bypass Enable Delay.</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field>
+            <name>LDOBBBYPENENDLY</name>
+            <description>LDOBB Bypass Enable Delay.</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
         </fields>
-       </register>
-       <register>
+      </register>
+      <register>
         <name>BTLELDODLY</name>
         <description>BTLE LDO Delay Register</description>
         <addressOffset>0x78</addressOffset>
         <fields>
-         <field>
-          <name>BYPDLYCNT</name>
-          <description>Bypass Delay Count.</description>
-          <bitOffset>0</bitOffset>
-          <bitWidth>8</bitWidth>
-         </field>
-         <field>
-          <name>LDORFDLYCNT</name>
-          <description>LDORF Delay Count.</description>
-          <bitOffset>8</bitOffset>
-          <bitWidth>9</bitWidth>
-         </field>
-         <field>
-          <name>LDOBBDLYCNT</name>
-          <description>LDOBB Delay Count.</description>
-          <bitOffset>20</bitOffset>
-          <bitWidth>9</bitWidth>
-         </field>
+          <field>
+            <name>BYPDLYCNT</name>
+            <description>Bypass Delay Count.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>8</bitWidth>
+          </field>
+          <field>
+            <name>LDORFDLYCNT</name>
+            <description>LDORF Delay Count.</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>9</bitWidth>
+          </field>
+          <field>
+            <name>LDOBBDLYCNT</name>
+            <description>LDOBB Delay Count.</description>
+            <bitOffset>20</bitOffset>
+            <bitWidth>9</bitWidth>
+          </field>
         </fields>
-       </register>
+      </register>
       <register>
         <name>GPR0</name>
         <description>General Purpose Register 0</description>


### PR DESCRIPTION
### Description

Revision A4 and later of the device may inadvertently reset when exiting Standby or UPM if the power fail monitoring is enabled during these events.  The fix is to always disable the power fail reset just before entering one of these low power modes.  Once the part wakes up, the code then should wait for the power to be stable again before re-enabling the power fail monitor.
