### PR TITLE
fix(CMSIS): Enable unaligned access for MAX32657

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.h
@@ -150,6 +150,7 @@ typedef enum {
 #define __VTOR_PRESENT 1U /**< Presence of VTOR register in SCB  */
 #define __NVIC_PRIO_BITS 3U /**< NVIC interrupt priority bits */
 #define __Vendor_SysTickConfig 0U /**< Is 1 if different SysTick counter is used */
+#define __ARM_FEATURE_UNALIGNED 1U /**< Enable unaligned access support */
 
 #include <core_cm33.h>
 #if (__CM_CMSIS_VERSION == 0x60000)


### PR DESCRIPTION
### Description

This PR may help alleviate Hard Fault errors from `memcpy()` calls in cases of unaligned memory. Including cases where the compiler recognizes a pattern in the code and then replaces it with `memcpy()` as a means of optimization. 