### PR TITLE
fix(PeriphDrivers): Remove unsupported UART flow control stuff

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX78002/mxc_pins.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/mxc_pins.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,14 +39,8 @@ extern const mxc_gpio_cfg_t gpio_cfg_uart0;
 extern const mxc_gpio_cfg_t gpio_cfg_uart0_flow;
 extern const mxc_gpio_cfg_t gpio_cfg_uart0_flow_disable;
 extern const mxc_gpio_cfg_t gpio_cfg_uart1;
-extern const mxc_gpio_cfg_t gpio_cfg_uart1_flow;
-extern const mxc_gpio_cfg_t gpio_cfg_uart1_flow_disable;
 extern const mxc_gpio_cfg_t gpio_cfg_uart2;
-extern const mxc_gpio_cfg_t gpio_cfg_uart2_flow;
-extern const mxc_gpio_cfg_t gpio_cfg_uart2_flow_disable;
 extern const mxc_gpio_cfg_t gpio_cfg_uart3;
-extern const mxc_gpio_cfg_t gpio_cfg_uart3_flow;
-extern const mxc_gpio_cfg_t gpio_cfg_uart3_flow_disable;
 
 // Timers are only defined once, depending on package, each timer could be mapped to other pins
 extern const mxc_gpio_cfg_t gpio_cfg_tmr0;

--- a/Libraries/PeriphDrivers/Source/SYS/pins_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_ai87.c
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,10 +49,6 @@ const mxc_gpio_cfg_t gpio_cfg_uart0_flow_disable = { MXC_GPIO0, (MXC_GPIO_PIN_2 
                                                      MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart1 = { MXC_GPIO0, (MXC_GPIO_PIN_12 | MXC_GPIO_PIN_13), MXC_GPIO_FUNC_ALT1,
                                         MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_uart1_flow = { MXC_GPIO0, (MXC_GPIO_PIN_14 | MXC_GPIO_PIN_15), MXC_GPIO_FUNC_ALT2,
-                                             MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_uart1_flow_disable = { MXC_GPIO0, (MXC_GPIO_PIN_14 | MXC_GPIO_PIN_15), MXC_GPIO_FUNC_IN,
-                                                     MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart2 = { MXC_GPIO1, (MXC_GPIO_PIN_0 | MXC_GPIO_PIN_1), MXC_GPIO_FUNC_ALT1,
                                         MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart3 = { MXC_GPIO2, (MXC_GPIO_PIN_6 | MXC_GPIO_PIN_7), MXC_GPIO_FUNC_ALT2,

--- a/Libraries/PeriphDrivers/Source/UART/uart_ai87.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_ai87.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -225,14 +225,6 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
             MXC_GPIO_Config(&gpio_cfg_uart0_flow);
             break;
 
-        case 1:
-            MXC_GPIO_Config(&gpio_cfg_uart1_flow);
-            break;
-
-        case 2:
-            MXC_GPIO_Config(&gpio_cfg_uart2_flow);
-            break;
-
         default:
             return E_BAD_PARAM;
         }
@@ -240,14 +232,6 @@ int MXC_UART_SetFlowCtrl(mxc_uart_regs_t *uart, mxc_uart_flow_t flowCtrl, int rt
         switch (MXC_UART_GET_IDX(uart)) {
         case 0:
             MXC_GPIO_Config(&gpio_cfg_uart0_flow_disable);
-            break;
-
-        case 1:
-            MXC_GPIO_Config(&gpio_cfg_uart1_flow_disable);
-            break;
-
-        case 2:
-            MXC_GPIO_Config(&gpio_cfg_uart2_flow_disable);
             break;
 
         default:


### PR DESCRIPTION
For MAX78002, if you tried to use the MXC_UART_SetFlowCtrl function, your code didn't build because it referenced undefined uart2 flow control pin variables.
Delete the code that used them, and also delete declarations of uart3 flow control pins, and declarations and definitions of uart1 flow control pins. The latter were set to P0.14 and P0.15 but those pins don't have UART signals on them according to the data sheet.

### Description

Please include a summary of the changes and related issues. Please also include relevant motivation and context.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

