### PR TITLE
fix(PeriphDrivers): Fix configuration issues when using DMA1 for MAX32657

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.h
@@ -696,10 +696,10 @@ We may want to handle GET_IRQ better...
                  ((p) == MXC_DMA0_NS && (i) == 1) ? DMA0_CH1_IRQn : \
                  ((p) == MXC_DMA0_NS && (i) == 2) ? DMA0_CH2_IRQn : \
                  ((p) == MXC_DMA0_NS && (i) == 3) ? DMA0_CH3_IRQn : \
-                 ((p) == MXC_DMA1_S && (i) == 0)  ? DMA1_CH0_IRQn : \
-                 ((p) == MXC_DMA1_S && (i) == 1)  ? DMA1_CH1_IRQn : \
-                 ((p) == MXC_DMA1_S && (i) == 2)  ? DMA1_CH2_IRQn : \
-                 ((p) == MXC_DMA1_S && (i) == 3)  ? DMA1_CH3_IRQn : \
+                 ((p) == MXC_DMA1_S && (i) == 4)  ? DMA1_CH0_IRQn : \
+                 ((p) == MXC_DMA1_S && (i) == 5)  ? DMA1_CH1_IRQn : \
+                 ((p) == MXC_DMA1_S && (i) == 6)  ? DMA1_CH2_IRQn : \
+                 ((p) == MXC_DMA1_S && (i) == 7)  ? DMA1_CH3_IRQn : \
                                                     0))
 
 #else


### PR DESCRIPTION
### Description

Noticed interaction with the DMA channels was incorrect when using DMA1_S with MAX32657 in secure mode. PR updates the DMA resources to include and properly access/configure all 8 (4 DMA0_NS, 4 DMA1_S) channels when operating in this mode.

Changes were tested via porting the UART_DMA example to MAX32657. Results indicate that both UART TX and RX are working with these updates.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
