### PR TITLE
fix(PeriphDrivers): Fix an error in the MXC_ICC_Disable function of the MAX32650

### DIFF
--- a/Libraries/PeriphDrivers/Source/ICC/icc_me10.c
+++ b/Libraries/PeriphDrivers/Source/ICC/icc_me10.c
@@ -49,7 +49,7 @@ void MXC_ICC_Enable(void)
 void MXC_ICC_Disable(void)
 {
     MXC_ICC_RevA_Disable((mxc_icc_reva_regs_t *)MXC_ICC0);
-    MXC_ICC_RevA_Enable((mxc_icc_reva_regs_t *)MXC_ICC1);
+    MXC_ICC_RevA_Disable((mxc_icc_reva_regs_t *)MXC_ICC1);
 }
 
 /* **************************************************************************** */


### PR DESCRIPTION
### Description

The code was not properly disabling the ICC1 instance.