### PR TITLE
fix(CMSIS): Revert unaligned access for MAX32657 (#1434)

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.h
@@ -150,7 +150,6 @@ typedef enum {
 #define __VTOR_PRESENT 1U /**< Presence of VTOR register in SCB  */
 #define __NVIC_PRIO_BITS 3U /**< NVIC interrupt priority bits */
 #define __Vendor_SysTickConfig 0U /**< Is 1 if different SysTick counter is used */
-#define __ARM_FEATURE_UNALIGNED 1U /**< Enable unaligned access support */
 
 #include <core_cm33.h>
 #if (__CM_CMSIS_VERSION == 0x60000)


### PR DESCRIPTION
### Description

This reverts commit af78e62581756b5292c2b893870de3b32c5aecee.

Unaligned access should be disabled for M33.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.