### PR TITLE
fix(PeriphDrivers): Support IBRO/8 for LPTMR1 clock source on MAX78002

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX78002/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/tmr.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,6 +147,7 @@ typedef enum {
     MXC_TMR_IBRO_CLK = 3, /**< 7.3728MHz Clock */
     MXC_TMR_ERTCO_CLK = 4, /**< 32.768KHz Clock */
     MXC_TMR_INRO_CLK = 5, /**< 8-30KHz Clock */
+    MXC_TMR_IBRO_DIV8_CLK = 6, /**< (7.3728/8)MHz Clock */
 
     // Legacy names
     /*8M and 60M clocks can be used for Timers 0,1,2 and 3*/

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -183,6 +183,16 @@ uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
         clockSource = MXC_TMR_CLK2;
         MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_INRO);
         MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, INRO_FREQ);
+        break;
+
+    case MXC_TMR_IBRO_DIV8_CLK:
+        if (tmr_id != 5) { // Only Timer 5 supports this clock source divide
+            return E_NOT_SUPPORTED;
+        }
+
+        clockSource = MXC_TMR_CLK1;
+        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+        MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, (IBRO_FREQ / 8));
         break;
 
     default:


### PR DESCRIPTION
The LPTMR1 (TMR5) timer supports IBRO/8 as a clock source on MAX78002. MSDK-1354.

### Description

Please include a summary of the changes and related issues. Please also include relevant motivation and context.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
