### PR TITLE
fix(Build): Fix PROJ_LDFLAGS for MAX78xxx parts too

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/max78000.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/max78000.mk
@@ -145,7 +145,7 @@ $(ARM_MAP_FILE):
 # complicates things significantly.  The RISC-V linkerfile (max78000_riscv.ld)
 # has a hard-coded INCLUDE "buildrv/common_riscv.ld" to look for this file.
 RISCV_COMMON_LD = $(BUILD_DIR)/buildrv/common_riscv.ld
-PROJ_LDFLAGS += -L$(abspath $(BUILD_DIR))
+PROJ_LDFLAGS += -L$(if $(filter "${_OS}","windows_msys"), $(shell cygpath -m ${BUILD_DIR}), ${BUILD_DIR})
 # ^ Add to search path to locate buildrv/common_riscv.ld
 
 .PHONY: rvcommonld
@@ -213,7 +213,7 @@ else # RISCV_LOAD
 # the Arm core, so this is really only useful for
 # being able to compile and link quickly for RISC-V.
 RISCV_COMMON_LD = $(BUILD_DIR)/common_riscv.ld
-PROJ_LDFLAGS += -L$(abspath $(BUILD_DIR))
+PROJ_LDFLAGS += -L$(if $(filter "${_OS}","windows_msys"), $(shell cygpath -m ${BUILD_DIR}), ${BUILD_DIR})
 # ^ Add to search path to locate buildrv/common_riscv.ld
 
 $(RISCV_COMMON_LD):

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Source/GCC/max78002.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Source/GCC/max78002.mk
@@ -142,7 +142,7 @@ $(ARM_MAP_FILE):
 # complicates things significantly.  The RISC-V linkerfile (max78000_riscv.ld)
 # has a hard-coded INCLUDE "buildrv/common_riscv.ld" to look for this file.
 RISCV_COMMON_LD = $(BUILD_DIR)/buildrv/common_riscv.ld
-PROJ_LDFLAGS += -L$(abspath $(BUILD_DIR))
+PROJ_LDFLAGS += -L$(if $(filter "${_OS}","windows_msys"), $(shell cygpath -m ${BUILD_DIR}), ${BUILD_DIR})
 # ^ Add to search path to locate buildrv/common_riscv.ld
 
 .PHONY: rvcommonld
@@ -210,7 +210,7 @@ else # RISCV_LOAD
 # the Arm core, so this is really only useful for
 # being able to compile and link quickly for RISC-V.
 RISCV_COMMON_LD = $(BUILD_DIR)/common_riscv.ld
-PROJ_LDFLAGS += -L$(abspath $(BUILD_DIR))
+PROJ_LDFLAGS += -L$(if $(filter "${_OS}","windows_msys"), $(shell cygpath -m ${BUILD_DIR}), ${BUILD_DIR})
 # ^ Add to search path to locate buildrv/common_riscv.ld
 
 $(RISCV_COMMON_LD):


### PR DESCRIPTION


### Description

For MSYS platforms, we need to fix up the path used in PROJ_LDFLAGS too to use the correct syntax. This is an extension to the fix in https://github.com/analogdevicesinc/msdk/pull/1433.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

