### PR TITLE
fix(PeriphDrivers): DMA build fixes for RV32

### DIFF
--- a/Libraries/PeriphDrivers/Source/DMA/dma_reva.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_reva.c
@@ -49,7 +49,9 @@ typedef struct {
 static unsigned int dma_initialized[MXC_DMA_INSTANCES] = { 0 };
 static mxc_dma_channel_t dma_resource[MXC_DMA_CHANNELS];
 static mxc_dma_highlevel_t memcpy_resource[MXC_DMA_CHANNELS];
+#ifndef __riscv
 static uint32_t dma_lock;
+#endif
 
 /****** Functions ******/
 static void memcpy_callback(int ch, int error);
@@ -166,14 +168,18 @@ int MXC_DMA_RevA_AcquireChannel(mxc_dma_reva_regs_t *dma)
 int MXC_DMA_RevA_ReleaseChannel(int ch)
 {
     if (CHECK_HANDLE(ch)) {
+#ifndef __riscv
         if (MXC_GetLock(&dma_lock, 1) != E_NO_ERROR) {
             return E_BUSY;
         }
+#endif
 
         dma_resource[ch].valid = 0;
         dma_resource[ch].regs->ctrl = 0;
         dma_resource[ch].regs->status = dma_resource[ch].regs->status;
+#ifndef __riscv
         MXC_FreeLock(&dma_lock);
+#endif
     } else {
         return E_BAD_PARAM;
     }


### PR DESCRIPTION
Ensure all lock related calls/declarations are behind a pre-processor check.

### Description

Encountered this build issue with a few build edge cases for my work to upstream RV32 support into Zephyr where a few locking pieces were not properly wrapped in `#ifndef __riscv` checks. See https://github.com/zephyrproject-rtos/zephyr/actions/runs/18392396196/job/52405446740?pr=97309#step:13:749

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

