### PR TITLE
ci(workflow): Include CMSIS SoC .svd files in the export

### DIFF
--- a/.github/workflows/scripts/zephyr_hal_sync.sh
+++ b/.github/workflows/scripts/zephyr_hal_sync.sh
@@ -105,6 +105,8 @@ check_is_adi_hal_zephyr_file () {
   return 1
 }
 
+beginswith() { case $2 in "$1"*) true;; *) false;; esac; }
+
 for ((index=1; index<=num_of_sha; index++)); do
     echo
     echo "Processing commit $index of $num_of_sha"
@@ -128,7 +130,7 @@ for ((index=1; index<=num_of_sha; index++)); do
 	if check_is_adi_hal_lib "$NAME"; then
 		dest="${hal_adi}/MAX/${NAME}"
 		mkdir -p $(dirname "${dest}")
-		if [ "${NAME##*.}" = "svd" ]; then
+		if [ "${NAME##*.}" = "svd" ] && ! beginswith "Libraries/CMSIS" "$NAME"; then
 			echo "Skipping ignored suffix svd: ${NAME}"
 		elif [ -e "${msdk}/${NAME}" ]; then
 			cp "${msdk}/${NAME}" "${dest}"


### PR DESCRIPTION
The core SoC .svd files are needed by consumers, so adjust our MSDK export to include those files when processing commits. A manual commit to add the existing .svd files to the ADI HAL repo will be added to catch up the existing export.

### Description

The ADI CFS team reports that the SoC .svd files are needed for their debug experience, so restoring them into the export, and the current export will have a manual commit added to include the latest files to catch it up.

Catch up PR for that export is up at https://github.com/analogdevicesinc/hal_adi/pull/10

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
