### PR TITLE
fix(PeriphDrivers): Fix UART static request upon initialization

### DIFF
--- a/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_revb.c
@@ -167,6 +167,9 @@ int MXC_UART_RevB_Init(mxc_uart_revb_regs_t *uart, unsigned int baud, mxc_uart_r
     states[i].auto_dma_handlers = false;
     states[i].dma = NULL;
 
+    AsyncTxRequests[i] = NULL;
+    AsyncRxRequests[i] = NULL;
+
     return E_NO_ERROR;
 }
 


### PR DESCRIPTION
Initialize AsyncTxRequests and AsyncRxRequests arrays to NULL in MXC_UART_RevB_Init to prevent errors upon multiple initialization of same peripheral.

### Description

When the UART is reinitialized using asynchronous settings, a static variable retains previous requests, leading to a potential deadlock.

In particular, when initializing tinyIIOD from the no-OS repository, the system becomes stuck. This occurs because tinyIIOD configures the UART with specific settings without reading back characters. Upon attempting to reinitialize the same UART instance, the leftover requests from the previous initialization prevent the process from completing.

This fix ensures proper cleanup of pending UART requests during reinitialization to avoid deadlocks.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
