### PR TITLE
fix(ThirdParty): Correct name used in CMakeLists.txt for SPIMSS Library for MAX32660

### DIFF
--- a/Libraries/zephyr/MAX/Source/MAX32660/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32660/CMakeLists.txt
@@ -80,7 +80,7 @@ zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/SPI/spi_me11.c
     ${MSDK_PERIPH_SRC_DIR}/SPI/spi_reva1.c
     ${MSDK_PERIPH_SRC_DIR}/SPIMSS/spimss_me11.c
-    ${MSDK_PERIPH_SRC_DIR}/SPIMSS/spimss_reva1.c
+    ${MSDK_PERIPH_SRC_DIR}/SPIMSS/spimss_reva.c
 )
 endif()
 


### PR DESCRIPTION
### Description

The file `spimss_reva1.c` was being added as a source file in the CMakeLists.txt. This file does not exist to it causes a build that enables the SPI on the MAX32660 to fail. I removed the `1` at the end of the file name so it matches the file that actually exists.

I stumbled across this when trying to build a Zephyr project that enabled the SPIMSS on a board using the MAX32660. Changing the file name allowed the build to continue.

### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [X] Description of changes and all other relevant information.
- [X] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [X] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

_______________________________________________________________________________

