### PR TITLE
fix(PeriphDrivers): Fix for special GPIO ports

### DIFF
--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_ai85.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_ai85.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -207,11 +207,14 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     }
 
     // Configure the drive strength
-    if (cfg->func == MXC_GPIO_FUNC_IN) {
-        return E_NO_ERROR;
-    } else {
-        return MXC_GPIO_SetDriveStrength(gpio, cfg->drvstr, cfg->mask);
+    if (cfg->func != MXC_GPIO_FUNC_IN && cfg->port != MXC_GPIO3) {
+        error = MXC_GPIO_SetDriveStrength(gpio, cfg->drvstr, cfg->mask);
+        if (error != E_NO_ERROR) {
+            return error;
+        }
     }
+
+    return E_NO_ERROR;
 }
 
 /* ************************************************************************** */

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_ai87.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_ai87.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -207,11 +207,14 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     }
 
     // Configure the drive strength
-    if (cfg->func == MXC_GPIO_FUNC_IN) {
-        return E_NO_ERROR;
-    } else {
-        return MXC_GPIO_SetDriveStrength(gpio, cfg->drvstr, cfg->mask);
+    if (cfg->func != MXC_GPIO_FUNC_IN && cfg->port != MXC_GPIO3) {
+        error = MXC_GPIO_SetDriveStrength(gpio, cfg->drvstr, cfg->mask);
+        if (error != E_NO_ERROR) {
+            return error;
+        }
     }
+
+    return E_NO_ERROR;
 }
 
 /* ************************************************************************** */

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me17.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me17.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -207,11 +207,14 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     }
 
     // Configure the drive strength
-    if (cfg->func == MXC_GPIO_FUNC_IN) {
-        return E_NO_ERROR;
-    } else {
-        return MXC_GPIO_SetDriveStrength(gpio, cfg->drvstr, cfg->mask);
+    if (cfg->func != MXC_GPIO_FUNC_IN && cfg->port != MXC_GPIO3) {
+        error = MXC_GPIO_SetDriveStrength(gpio, cfg->drvstr, cfg->mask);
+        if (error != E_NO_ERROR) {
+            return error;
+        }
     }
+
+    return E_NO_ERROR;
 }
 
 /* ************************************************************************** */

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -252,11 +252,14 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     }
 
     // Configure the drive strength
-    if (cfg->func == MXC_GPIO_FUNC_IN) {
-        return E_NO_ERROR;
-    } else {
-        return MXC_GPIO_SetDriveStrength(gpio, cfg->drvstr, cfg->mask);
+    if (cfg->func != MXC_GPIO_FUNC_IN && port < 4) {
+        error = MXC_GPIO_SetDriveStrength(gpio, cfg->drvstr, cfg->mask);
+        if (error != E_NO_ERROR) {
+            return error;
+        }
     }
+
+    return E_NO_ERROR;
 }
 
 /* ************************************************************************** */

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me20.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me20.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -203,11 +203,14 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     }
 
     // Configure the drive strength
-    if (cfg->func == MXC_GPIO_FUNC_IN) {
-        return E_NO_ERROR;
-    } else {
-        return MXC_GPIO_SetDriveStrength(gpio, cfg->drvstr, cfg->mask);
+    if (cfg->func != MXC_GPIO_FUNC_IN && cfg->port != MXC_GPIO3) {
+        error = MXC_GPIO_SetDriveStrength(gpio, cfg->drvstr, cfg->mask);
+        if (error != E_NO_ERROR) {
+            return error;
+        }
     }
+
+    return E_NO_ERROR;
 }
 
 /* ************************************************************************** */


### PR DESCRIPTION


### Description

Don't call MXC_GPIO_SetDriveStrength for the special GPIO ports that are set up via MCR registers. MXC_GPIO_SetDriveStrength calls MXC_GPIO_RevA_SetDriveStrength directly and this only configures pins that are handled via the usual GCR registers.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.