### PR TITLE
fix(Examples): Configure UART2 to use MAP_B pins for MAX32672

### DIFF
--- a/Examples/MAX32672/UART/main.c
+++ b/Examples/MAX32672/UART/main.c
@@ -90,10 +90,6 @@ int main(void)
     NVIC_EnableIRQ(MXC_UART_GET_IRQ(READING_UART_IDX));
 #endif //
 
-    // Set UART2 to use MAP_B for correct pin mapping
-    // UART2 TX is on P0.15 and UART2 RX is on P0.14 in MAP_B
-    MXC_UART_SetPinMapping(WRITING_UART, MAP_B);
-
     // Initialize the UART
     error = MXC_UART_Init(READING_UART, UART_BAUD, MXC_UART_APB_CLK);
     if (error < E_NO_ERROR) {
@@ -104,6 +100,9 @@ int main(void)
     printf("-->Reading UART Initialized\n");
 
     // Initialize writing UART
+    // Set UART2 to use MAP_B for correct pin mapping
+    // UART2 TX is on P0.15 and UART2 RX is on P0.14 in MAP_B
+    MXC_UART_SetPinMapping(WRITING_UART, MAP_B);
     error = MXC_UART_Init(WRITING_UART, UART_BAUD, MXC_UART_APB_CLK);
     if (error < E_NO_ERROR) {
         printf("-->Error initializing UART: %d\n", error);


### PR DESCRIPTION
### Description

#### Problem
The UART example for **MAX32672** was hanging during transmission due to a **GPIO pin mapping mismatch**.

By default, all UARTs were configured to use **MAP_A** pins:

- **UART1 (MAP_A):** P0.28 (RX), P0.29 (TX)  
- **UART2 (MAP_A):** P1.5 (RX), P1.6 (TX)

However, the README and comments indicated hardware wiring as:

- **UART1 RX (P0.28)** connected to **UART2 TX (P0.15)**

Pin **P0.15** belongs to **UART2’s MAP_B configuration** (`gpio_cfg_uart2b`), which uses:

- **UART2 (MAP_B):** P0.14 (RX), P0.15 (TX)

The code initialized UART2 with **MAP_A**, causing the loopback test to fail and the program to hang waiting for data on incorrect pins.

#### Solution
Added a call to:

```c
MXC_UART_SetPinMapping(WRITING_UART, MAP_B);
```

before initializing UART2.

This ensures UART2 uses **MAP_B pins (P0.14/P0.15)** instead of **MAP_A** pins, aligning software configuration with hardware wiring.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.