### PR TITLE
fix(Examples): Interpret MXC_OWM_Reset() return value correctly for MAX32650

### DIFF
--- a/Examples/MAX32650/OWM/main.c
+++ b/Examples/MAX32650/OWM/main.c
@@ -97,7 +97,7 @@ int32_t ow_romid_test(uint8_t od)
     MXC_OWM_SetOverdrive(0);
 
     /* Error if presence pulse not detected. */
-    if (MXC_OWM_Reset() == 1) {
+    if (MXC_OWM_Reset() == 0) {
         return -2;
     }
 
@@ -107,7 +107,7 @@ int32_t ow_romid_test(uint8_t od)
         MXC_OWM_Write(buffer, 1);
         MXC_OWM_SetOverdrive(1);
         /* Error if presence pulse not detected. */
-        if (MXC_OWM_Reset() == 1) {
+        if (MXC_OWM_Reset() == 0) {
             return -4;
         }
     }


### PR DESCRIPTION
### Description

#### Problem
The **MAX32650 OWM (1-Wire Master)** example misinterpreted the return value of `MXC_OWM_Reset()`.

- The code **aborted when a presence pulse was detected** and **continued when none was present**.  
- As a result, all subsequent commands were issued onto an **idle bus**, causing the **ROM ID read to fail**.  
- Feedback indicates the same issue occurs on **MAX32690**, but this PR addresses **MAX32650 only**.

#### Solution
Update `main.c` so that:

- A return value of **0** from `MXC_OWM_Reset()` means **no device present → abort with error**.  
- Execution proceeds only when the function returns **1 (presence detected)**.

This change aligns the example with the **OWM driver API** and **MAX32650 reference documentation**.


### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.