### PR TITLE
feat(PeriphDrivers): Enable optional clock management in GPIO drivers

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32520/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32520/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,6 +202,9 @@ typedef enum {
 
 /**
  * @brief      Initialize GPIO.
+ * @note       By default this function enables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to be initialized
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */
@@ -209,6 +212,9 @@ int MXC_GPIO_Init(uint32_t portMask);
 
 /**
  * @brief      Shutdown GPIO.
+ * @note       By default this function disables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to shutdown
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32570/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,6 +202,9 @@ typedef enum {
 
 /**
  * @brief      Initialize GPIO.
+ * @note       By default this function enables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to be initialized
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */
@@ -209,6 +212,9 @@ int MXC_GPIO_Init(uint32_t portMask);
 
 /**
  * @brief      Shutdown GPIO.
+ * @note       By default this function disables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to shutdown
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32572/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -203,6 +203,9 @@ typedef enum {
 
 /**
  * @brief      Initialize GPIO.
+ * @note       By default this function enables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to be initialized
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */
@@ -210,6 +213,9 @@ int MXC_GPIO_Init(uint32_t portMask);
 
 /**
  * @brief      Shutdown GPIO.
+ * @note       By default this function disables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to shutdown
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32650/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/gpio.h
@@ -192,12 +192,18 @@ typedef enum {
 
 /**
  * @brief      Initialize GPIO.
+ * @note       By default this function enables the GPIO clock for the specified port.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @return     #E_NO_ERROR if everything is successful.
  */
 int MXC_GPIO_Init(uint32_t port);
 
 /**
  * @brief      Shutdown GPIO.
+ * @note       By default this function disables the GPIO clock for the specified port.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to shutdown
  * @return     #E_NO_ERROR if everything is successful.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32655/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,6 +202,9 @@ typedef enum {
 
 /**
  * @brief      Initialize GPIO.
+ * @note       By default this function enables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to be initialized
  * @return     #E_NO_ERROR if everything is successful.
  */
@@ -209,7 +212,10 @@ int MXC_GPIO_Init(uint32_t portMask);
 
 /**
  * @brief      Shutdown GPIO.
- * @param      portMask     Mask for the port to be initialized
+ * @note       By default this function disables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
+ * @param      portMask     Mask for the port to shutdown
  * @return     #E_NO_ERROR if everything is successful.
  */
 int MXC_GPIO_Shutdown(uint32_t portMask);

--- a/Libraries/PeriphDrivers/Include/MAX32657/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/gpio.h
@@ -200,6 +200,9 @@ typedef enum {
 
 /**
  * @brief      Initialize GPIO.
+ * @note       By default this function enables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to be initialized
  * @return     #E_NO_ERROR if everything is successful.
  */
@@ -207,7 +210,10 @@ int MXC_GPIO_Init(uint32_t portMask);
 
 /**
  * @brief      Shutdown GPIO.
- * @param      portMask     Mask for the port to be initialized
+ * @note       By default this function disables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
+ * @param      portMask     Mask for the port to shutdown
  * @return     #E_NO_ERROR if everything is successful.
  */
 int MXC_GPIO_Shutdown(uint32_t portMask);

--- a/Libraries/PeriphDrivers/Include/MAX32660/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -181,6 +181,9 @@ typedef enum {
 
 /**
  * @brief      Initialize GPIO.
+ * @note       By default this function enables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to be initialized
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */
@@ -188,7 +191,10 @@ int MXC_GPIO_Init(uint32_t portMask);
 
 /**
  * @brief      Shutdown GPIO.
- * @param      portMask     Mask for the port to be initialized
+ * @note       By default this function disables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
+ * @param      portMask     Mask for the port to shutdown
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */
 int MXC_GPIO_Shutdown(uint32_t portMask);

--- a/Libraries/PeriphDrivers/Include/MAX32662/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -201,6 +201,9 @@ typedef enum {
 
 /**
  * @brief      Initialize GPIO.
+ * @note       By default this function enables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to be initialized
  * @return     #E_NO_ERROR if everything is successful.
  */
@@ -208,7 +211,10 @@ int MXC_GPIO_Init(uint32_t portMask);
 
 /**
  * @brief      Shutdown GPIO.
- * @param      portMask     Mask for the port to be initialized
+ * @note       By default this function disables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
+ * @param      portMask     Mask for the port to shutdown
  * @return     #E_NO_ERROR if everything is successful.
  */
 int MXC_GPIO_Shutdown(uint32_t portMask);

--- a/Libraries/PeriphDrivers/Include/MAX32665/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -201,6 +201,9 @@ typedef enum {
 
 /**
  * @brief      Initialize GPIO.
+ * @note       By default this function enables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to be initialized
  * @return     #E_NO_ERROR if everything is successful.
  */
@@ -208,6 +211,9 @@ int MXC_GPIO_Init(uint32_t portMask);
 
 /**
  * @brief      Shutdown GPIO.
+ * @note       By default this function disables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to shutdown
  * @return     #E_NO_ERROR if everything is successful.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32670/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,6 +202,9 @@ typedef enum {
 
 /**
  * @brief      Initialize GPIO.
+ * @note       By default this function enables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to be initialized
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */
@@ -209,7 +212,10 @@ int MXC_GPIO_Init(uint32_t portMask);
 
 /**
  * @brief      Shutdown GPIO.
- * @param      portMask     Mask for the port to be initialized
+ * @note       By default this function disables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
+ * @param      portMask     Mask for the port to shutdown
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */
 int MXC_GPIO_Shutdown(uint32_t portMask);

--- a/Libraries/PeriphDrivers/Include/MAX32672/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Libraries/PeriphDrivers/Include/MAX32675/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,6 +202,9 @@ typedef enum {
 
 /**
  * @brief      Initialize GPIO.
+ * @note       By default this function enables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to be initialized
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */
@@ -209,7 +212,10 @@ int MXC_GPIO_Init(uint32_t portMask);
 
 /**
  * @brief      Shutdown GPIO.
- * @param      portMask     Mask for the port to be initialized
+ * @note       By default this function disables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
+ * @param      portMask     Mask for the port to shutdown
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */
 int MXC_GPIO_Shutdown(uint32_t portMask);

--- a/Libraries/PeriphDrivers/Include/MAX32680/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,6 +202,9 @@ typedef enum {
 
 /**
  * @brief      Initialize GPIO.
+ * @note       By default this function enables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to be initialized
  * @return     #E_NO_ERROR if everything is successful.
  */
@@ -209,7 +212,10 @@ int MXC_GPIO_Init(uint32_t portMask);
 
 /**
  * @brief      Shutdown GPIO.
- * @param      portMask     Mask for the port to be initialized
+ * @note       By default this function disables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
+ * @param      portMask     Mask for the port to shutdown
  * @return     #E_NO_ERROR if everything is successful.
  */
 int MXC_GPIO_Shutdown(uint32_t portMask);

--- a/Libraries/PeriphDrivers/Include/MAX32690/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -203,6 +203,9 @@ typedef enum {
 
 /**
  * @brief      Initialize GPIO.
+ * @note       By default this function enables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to be initialized
  * @return     #E_NO_ERROR if everything is successful.
  */
@@ -210,7 +213,10 @@ int MXC_GPIO_Init(uint32_t portMask);
 
 /**
  * @brief      Shutdown GPIO.
- * @param      portMask     Mask for the port to be initialized
+ * @note       By default this function disables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
+ * @param      portMask     Mask for the port to shutdown
  * @return     #E_NO_ERROR if everything is successful.
  */
 int MXC_GPIO_Shutdown(uint32_t portMask);

--- a/Libraries/PeriphDrivers/Include/MAX78000/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,6 +202,9 @@ typedef enum {
 
 /**
  * @brief      Initialize GPIO.
+ * @note       By default this function enables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to be initialized
  * @return     #E_NO_ERROR if everything is successful.
  */
@@ -209,7 +212,10 @@ int MXC_GPIO_Init(uint32_t portMask);
 
 /**
  * @brief      Shutdown GPIO.
- * @param      portMask     Mask for the port to be initialized
+ * @note       By default this function disables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
+ * @param      portMask     Mask for the port to shutdown
  * @return     #E_NO_ERROR if everything is successful.
  */
 int MXC_GPIO_Shutdown(uint32_t portMask);

--- a/Libraries/PeriphDrivers/Include/MAX78002/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,6 +202,9 @@ typedef enum {
 
 /**
  * @brief      Initialize GPIO.
+ * @note       By default this function enables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
  * @param      portMask     Mask for the port to be initialized
  * @return     #E_NO_ERROR if everything is successful.
  */
@@ -209,7 +212,10 @@ int MXC_GPIO_Init(uint32_t portMask);
 
 /**
  * @brief      Shutdown GPIO.
- * @param      portMask     Mask for the port to be initialized
+ * @note       By default this function disables the GPIO clocks for the specified ports.
+ *             If you wish to manage the clock settings externally, define the flag
+ *             MSDK_NO_GPIO_CLK_INIT.
+ * @param      portMask     Mask for the port to shutdown
  * @return     #E_NO_ERROR if everything is successful.
  */
 int MXC_GPIO_Shutdown(uint32_t portMask);

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_ai85.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_ai85.c
@@ -51,6 +51,7 @@
 /* **** Functions **** */
 int MXC_GPIO_Init(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & 0x1) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -62,12 +63,14 @@ int MXC_GPIO_Init(uint32_t portmask)
     if (portmask & 0x4) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO2);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_GPIO_Common_Init(portmask);
 }
 
 int MXC_GPIO_Shutdown(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & 0x1) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -79,6 +82,7 @@ int MXC_GPIO_Shutdown(uint32_t portmask)
     if (portmask & 0x4) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO2);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_ai87.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_ai87.c
@@ -51,6 +51,7 @@
 /* **** Functions **** */
 int MXC_GPIO_Init(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & 0x1) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -62,12 +63,14 @@ int MXC_GPIO_Init(uint32_t portmask)
     if (portmask & 0x4) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO2);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_GPIO_Common_Init(portmask);
 }
 
 int MXC_GPIO_Shutdown(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & 0x1) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -79,6 +82,7 @@ int MXC_GPIO_Shutdown(uint32_t portmask)
     if (portmask & 0x4) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO2);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_es17.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_es17.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@
 
 int MXC_GPIO_Init(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & MXC_GPIO_PORT_0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -39,12 +40,14 @@ int MXC_GPIO_Init(uint32_t portmask)
     if (portmask & MXC_GPIO_PORT_1) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO1);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_GPIO_Common_Init(portmask);
 }
 
 int MXC_GPIO_Shutdown(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & MXC_GPIO_PORT_0) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -52,6 +55,7 @@ int MXC_GPIO_Shutdown(uint32_t portmask)
     if (portmask & MXC_GPIO_PORT_1) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO1);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me10.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me10.c
@@ -38,6 +38,7 @@
 
 int MXC_GPIO_Init(uint32_t port)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (port == MXC_GPIO_PORT_0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     } else if (port == MXC_GPIO_PORT_1) {
@@ -49,12 +50,15 @@ int MXC_GPIO_Init(uint32_t port)
     } else {
         return E_BAD_PARAM;
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
+
     return MXC_GPIO_Common_Init(port);
 }
 
 /* ************************************************************************** */
 int MXC_GPIO_Shutdown(uint32_t port)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (port == MXC_GPIO_PORT_0) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     } else if (port == MXC_GPIO_PORT_1) {
@@ -66,6 +70,7 @@ int MXC_GPIO_Shutdown(uint32_t port)
     } else {
         return E_BAD_PARAM;
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me11.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me11.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,18 +32,22 @@
 
 int MXC_GPIO_Init(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & MXC_GPIO_PORT_0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_GPIO_Common_Init(portmask);
 }
 
 int MXC_GPIO_Shutdown(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & MXC_GPIO_PORT_0) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me12.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me12.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,18 +36,22 @@ int MXC_GPIO_Init(uint32_t portmask)
 {
     int retval = MXC_GPIO_Common_Init(portmask);
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & 0x1) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_GPIO_Common_Init(portmask) + retval;
 }
 
 int MXC_GPIO_Shutdown(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & 0x1) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me13.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me13.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@
 
 int MXC_GPIO_Init(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & MXC_GPIO_PORT_0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -47,12 +48,14 @@ int MXC_GPIO_Init(uint32_t portmask)
     if (portmask & MXC_GPIO_PORT_3) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO3);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_GPIO_Common_Init(portmask);
 }
 
 int MXC_GPIO_Shutdown(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & MXC_GPIO_PORT_0) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -68,6 +71,7 @@ int MXC_GPIO_Shutdown(uint32_t portmask)
     if (portmask & MXC_GPIO_PORT_3) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO3);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me14.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me14.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@
 
 int MXC_GPIO_Init(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & 0x1) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -43,12 +44,14 @@ int MXC_GPIO_Init(uint32_t portmask)
     if (portmask & 0x2) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO1);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_GPIO_Common_Init(portmask);
 }
 
 int MXC_GPIO_Shutdown(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & 0x1) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -56,6 +59,7 @@ int MXC_GPIO_Shutdown(uint32_t portmask)
     if (portmask & 0x2) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO1);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me15.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me15.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@
 
 int MXC_GPIO_Init(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & MXC_GPIO_PORT_0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -38,12 +39,14 @@ int MXC_GPIO_Init(uint32_t portmask)
     if (portmask & MXC_GPIO_PORT_1) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO1);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_GPIO_Common_Init(portmask);
 }
 
 int MXC_GPIO_Shutdown(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & MXC_GPIO_PORT_0) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -51,6 +54,7 @@ int MXC_GPIO_Shutdown(uint32_t portmask)
     if (portmask & MXC_GPIO_PORT_1) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO1);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me16.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me16.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@
 
 int MXC_GPIO_Init(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & MXC_GPIO_PORT_0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -40,12 +41,14 @@ int MXC_GPIO_Init(uint32_t portmask)
     if (portmask & MXC_GPIO_PORT_1) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO1);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_GPIO_Common_Init(portmask);
 }
 
 int MXC_GPIO_Shutdown(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & MXC_GPIO_PORT_0) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -53,6 +56,7 @@ int MXC_GPIO_Shutdown(uint32_t portmask)
     if (portmask & MXC_GPIO_PORT_1) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO1);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me17.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me17.c
@@ -51,6 +51,7 @@
 /* **** Functions **** */
 int MXC_GPIO_Init(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & 0x1) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -62,12 +63,14 @@ int MXC_GPIO_Init(uint32_t portmask)
     if (portmask & 0x4) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO2);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_GPIO_Common_Init(portmask);
 }
 
 int MXC_GPIO_Shutdown(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & 0x1) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -79,6 +82,7 @@ int MXC_GPIO_Shutdown(uint32_t portmask)
     if (portmask & 0x4) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO2);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
@@ -60,6 +60,7 @@
 /* **** Functions **** */
 int MXC_GPIO_Init(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & 0x1) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -75,12 +76,14 @@ int MXC_GPIO_Init(uint32_t portmask)
     if (portmask & 0x8) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO3);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_GPIO_Common_Init(portmask);
 }
 
 int MXC_GPIO_Shutdown(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & 0x1) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -96,6 +99,7 @@ int MXC_GPIO_Shutdown(uint32_t portmask)
     if (portmask & 0x8) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO3);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me20.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me20.c
@@ -36,6 +36,7 @@
 /* **** Functions **** */
 int MXC_GPIO_Init(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & 0x1) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -43,12 +44,14 @@ int MXC_GPIO_Init(uint32_t portmask)
     if (portmask & 0x2) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO1);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_GPIO_Common_Init(portmask);
 }
 
 int MXC_GPIO_Shutdown(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & 0x1) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -56,6 +59,7 @@ int MXC_GPIO_Shutdown(uint32_t portmask)
     if (portmask & 0x2) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO1);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me21.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me21.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@
 
 int MXC_GPIO_Init(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & MXC_GPIO_PORT_0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -38,12 +39,14 @@ int MXC_GPIO_Init(uint32_t portmask)
     if (portmask & MXC_GPIO_PORT_1) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO1);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_GPIO_Common_Init(portmask);
 }
 
 int MXC_GPIO_Shutdown(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & MXC_GPIO_PORT_0) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -51,6 +54,7 @@ int MXC_GPIO_Shutdown(uint32_t portmask)
     if (portmask & MXC_GPIO_PORT_1) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO1);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me30.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me30.c
@@ -48,18 +48,22 @@
 /* **** Functions **** */
 int MXC_GPIO_Init(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & 0x1) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_GPIO_Common_Init(portmask);
 }
 
 int MXC_GPIO_Shutdown(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & 0x1) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me55.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me55.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2025 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ int MXC_GPIO_Init(uint32_t portmask)
 {
     int retval = MXC_GPIO_Common_Init(portmask);
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & MXC_GPIO_PORT_0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -41,12 +42,14 @@ int MXC_GPIO_Init(uint32_t portmask)
     if (portmask & MXC_GPIO_PORT_1) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO1);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_GPIO_Common_Init(portmask) + retval;
 }
 
 int MXC_GPIO_Shutdown(uint32_t portmask)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (portmask & MXC_GPIO_PORT_0) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     }
@@ -54,6 +57,7 @@ int MXC_GPIO_Shutdown(uint32_t portmask)
     if (portmask & MXC_GPIO_PORT_1) {
         MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_GPIO1);
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return E_NO_ERROR;
 }


### PR DESCRIPTION
Description
This PR can be considered a part of https://github.com/analogdevicesinc/msdk/pull/730 https://github.com/analogdevicesinc/msdk/pull/809 https://github.com/analogdevicesinc/msdk/pull/932 https://github.com/analogdevicesinc/msdk/pull/959 https://github.com/analogdevicesinc/msdk/pull/1452

The clock disable mechanism propagated to other devices.

Changes applied to below peripherals.

- GPIO

### Description

Please include a summary of the changes and related issues. Please also include relevant motivation and context.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
