### PR TITLE
docs(Examples): Update Jumper Name in the SPI Example (MAX32655)

### DIFF
--- a/Examples/MAX32655/SPI/README.md
+++ b/Examples/MAX32655/SPI/README.md
@@ -23,7 +23,7 @@ If using the MAX32655EVKIT (EvKit\_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.
 -   Open an terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
--   Connect pins labeled  5 and 6 on JH7 (GPIO PORT 0) together.
+-   Connect pins labeled  5 and 6 on JH6 (GPIO PORT 0) together.
 
 If using the MAX32655FTHR (FTHR\_Apps\_P1):
 -   Connect a USB cable between the PC and the J4 (USB/PWR) connector.


### PR DESCRIPTION


### Description
The readme was mentioning the incorrect jumper name(JH7). Updated the JH7 to JH6 (GPIO Port 0). See screenshot below:
<img width="459" height="431" alt="image" src="https://github.com/user-attachments/assets/715adea3-734d-4cff-88f3-a76cc01ddb6d" />


### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

_______________________________________________________________________________
