### PR TITLE
fix(Examples): Fixed incorrect MCU name in MAX78002 SDHC FAT example

### DIFF
--- a/Examples/MAX78002/SDHC_FAT/main.c
+++ b/Examples/MAX78002/SDHC_FAT/main.c
@@ -48,7 +48,7 @@ int main(void)
 {
     mxc_sdhc_cfg_t cfg;
     int err;
-    printf("\n\n***** MAX78000 SDHC FAT Filesystem Example *****\n");
+    printf("\n\n***** MAX78002 SDHC FAT Filesystem Example *****\n");
 
     // Enable Power To Card
     printf("Enabling card power...\n");


### PR DESCRIPTION
### Description

Fixed incorrect board name in MAX78002 SDHC FAT example (was printing MAX78000).

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

_______________________________________________________________________________
