### PR TITLE
fix(Examples): Fix default board name in settings.json in MAX78000 I2S_DMA_TARGET Example

### DIFF
--- a/Examples/MAX78000/I2S_DMA_Target/.vscode/settings.json
+++ b/Examples/MAX78000/I2S_DMA_Target/.vscode/settings.json
@@ -15,7 +15,7 @@
     },
     
     "target":"MAX78000",
-    "board":"EvKit_V1",
+    "board":"FTHR_RevA",
 
     "project_name":"${workspaceFolderBasename}",
 


### PR DESCRIPTION

### Description

Updated the board default from EvKit_V1 to FTHR_RevA since the example works only on the feather board.
This PR Addresses and resolves https://github.com/analogdevicesinc/msdk/issues/1478


### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

_______________________________________________________________________________
