### PR TITLE
fix(PeriphDrivers): Return correct SDHC input clock frequency for MAX32650

### DIFF
--- a/Libraries/PeriphDrivers/Source/SDHC/sdhc_me10.c
+++ b/Libraries/PeriphDrivers/Source/SDHC/sdhc_me10.c
@@ -87,9 +87,9 @@ unsigned int MXC_SDHC_Get_Clock_Config(void)
 unsigned int MXC_SDHC_Get_Input_Clock_Freq(void)
 {
     if (MXC_GCR->pclk_div & MXC_F_GCR_PCLK_DIV_SDHCFRQ) {
-        return HIRC96_FREQ >> 1; // Div by 2
-    } else {
         return 50000000; // UG specifies a hard-coded 50Mhz low-power oscillator
+    } else {
+        return HIRC96_FREQ >> 1; // Div by 2
     }
 }
 


### PR DESCRIPTION
### Description

Fix the condition in `MXC_SDHC_Get_Input_Clock_Freq` so that it returns correct frequency based on the value of `GCR_PCLKDIV.sdhcfreq` bit.

Fixes https://github.com/analogdevicesinc/msdk/issues/1453

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.