### PR TITLE
fix(PeriphDrivers): Update I2C in SDA status description MAX32655

### DIFF
--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me17.svd
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me17.svd
@@ -165,7 +165,7 @@
           <!-- FIELD 9 SDA Status Read -->
           <field>
             <name>SDA</name>
-            <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+            <description>SDA status. This bit reflects the logic gate of SDA signal.</description>
             <bitRange>[9:9]</bitRange>
             <access>read-only</access>
           </field>


### PR DESCRIPTION
The following sentence is updated for a typo.

Updated from THis to This

<description>SDA status. This bit reflects the logic gate of SDA signal.</description>

