### PR TITLE
fix(PeriphDrivers): Update SDA Status message in I2C SVD files in max32xxx and max78xxx library

### DIFF
--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva.svd
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva.svd
@@ -165,7 +165,7 @@
           <!-- FIELD 9 SDA Status Read -->
           <field>
             <name>SDA</name>
-            <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+            <description>SDA status. This bit reflects the logic gate of SDA signal.</description>
             <bitRange>[9:9]</bitRange>
             <access>read-only</access>
           </field>

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva_ai87.svd
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva_ai87.svd
@@ -165,7 +165,7 @@
           <!-- FIELD 9 SDA Status Read -->
           <field>
             <name>SDA</name>
-            <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+            <description>SDA status. This bit reflects the logic gate of SDA signal.</description>
             <bitRange>[9:9]</bitRange>
             <access>read-only</access>
           </field>

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva_es17.svd
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva_es17.svd
@@ -165,7 +165,7 @@
           <!-- FIELD 9 SDA Status Read -->
           <field>
             <name>SDA</name>
-            <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+            <description>SDA status. This bit reflects the logic gate of SDA signal.</description>
             <bitRange>[9:9]</bitRange>
             <access>read-only</access>
           </field>

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me10.svd
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me10.svd
@@ -168,7 +168,7 @@
           </field>
           <field>
             <name>SDA</name>
-            <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+            <description>SDA status. This bit reflects the logic gate of SDA signal.</description>
             <bitRange>[9:9]</bitRange>
             <access>read-only</access>
             <enumeratedValues>

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me11.svd
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me11.svd
@@ -165,7 +165,7 @@
           <!-- FIELD 9 SDA Status Read -->
           <field>
             <name>SDA</name>
-            <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+            <description>SDA status. This bit reflects the logic gate of SDA signal.</description>
             <bitRange>[9:9]</bitRange>
             <access>read-only</access>
           </field>

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me12.svd
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me12.svd
@@ -165,7 +165,7 @@
           <!-- FIELD 9 SDA Status Read -->
           <field>
             <name>SDA</name>
-            <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+            <description>SDA status. This bit reflects the logic gate of SDA signal.</description>
             <bitRange>[9:9]</bitRange>
             <access>read-only</access>
           </field>

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me13.svd
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me13.svd
@@ -165,7 +165,7 @@
           <!-- FIELD 9 SDA Status Read -->
           <field>
             <name>SDA</name>
-            <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+            <description>SDA status. This bit reflects the logic gate of SDA signal.</description>
             <bitRange>[9:9]</bitRange>
             <access>read-only</access>
           </field>

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me14.svd
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me14.svd
@@ -165,7 +165,7 @@
           <!-- FIELD 9 SDA Status Read -->
           <field>
             <name>SDA</name>
-            <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+            <description>SDA status. This bit reflects the logic gate of SDA signal.</description>
             <bitRange>[9:9]</bitRange>
             <access>read-only</access>
           </field>

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me15.svd
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me15.svd
@@ -165,7 +165,7 @@
           <!-- FIELD 9 SDA Status Read -->
           <field>
             <name>SDA</name>
-            <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+            <description>SDA status. This bit reflects the logic gate of SDA signal.</description>
             <bitRange>[9:9]</bitRange>
             <access>read-only</access>
           </field>

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me18.svd
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me18.svd
@@ -165,7 +165,7 @@
           <!-- FIELD 9 SDA Status Read -->
           <field>
             <name>SDA</name>
-            <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+            <description>SDA status. This bit reflects the logic gate of SDA signal.</description>
             <bitRange>[9:9]</bitRange>
             <access>read-only</access>
           </field>

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me21.svd
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me21.svd
@@ -165,7 +165,7 @@
           <!-- FIELD 9 SDA Status Read -->
           <field>
             <name>SDA</name>
-            <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+            <description>SDA status. This bit reflects the logic gate of SDA signal.</description>
             <bitRange>[9:9]</bitRange>
             <access>read-only</access>
           </field>

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me55.svd
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva_me55.svd
@@ -165,7 +165,7 @@
           <!-- FIELD 9 SDA Status Read -->
           <field>
             <name>SDA</name>
-            <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+            <description>SDA status. This bit reflects the logic gate of SDA signal.</description>
             <bitRange>[9:9]</bitRange>
             <access>read-only</access>
           </field>


### PR DESCRIPTION
Text updated from
Incorrect Text: "SDA status. THis bit reflects the logic gate of SDA signal."
to
SDA status. This bit reflects the logic gate of SDA signal.

Libraries/PeriphDrivers/Source/I2C/i2c_reva.svd
Libraries/PeriphDrivers/Source/I2C/i2c_reva_me21.svd
Libraries/PeriphDrivers/Source/I2C/i2c_reva_es17.svd
Libraries/PeriphDrivers/Source/I2C/i2c_reva_me10.svd
Libraries/PeriphDrivers/Source/I2C/i2c_reva_ai87.svd
Libraries/PeriphDrivers/Source/I2C/i2c_reva_me18.svd
Libraries/PeriphDrivers/Source/I2C/i2c_reva_me12.svd
Libraries/PeriphDrivers/Source/I2C/i2c_reva_me55.svd
Libraries/PeriphDrivers/Source/I2C/i2c_reva_me14.svd
Libraries/PeriphDrivers/Source/I2C/i2c_reva_me15.svd
Libraries/PeriphDrivers/Source/I2C/i2c_reva_me13.svd
Libraries/PeriphDrivers/Source/I2C/i2c_reva_me11.svd

For Libraries/PeriphDrivers/Source/I2C/i2c_reva_me17.svd --> PR already opened
