### PR TITLE
feat(PeriphDrivers): Support ext_clk for timer on MAX32690, MAX78000 and MAX78002

### DIFF
--- a/Libraries/PeriphDrivers/Source/TMR/tmr_ai85.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_ai85.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,13 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
     MXC_ASSERT(tmr_id >= 0);
 
     switch (cfg->clock) {
+    case MXC_TMR_EXT_CLK:
+        if (tmr_id < 4) { // Timers 0-3 do not support this clock source
+            return E_NOT_SUPPORTED;
+        }
+
+        clockSource = MXC_TMR_CLK3;
+        break;
     case MXC_TMR_ISO_CLK:
         if (tmr_id > 3) { // Timers 4-5 do not support this clock source
             return E_NOT_SUPPORTED;

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2025 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,6 +141,13 @@ uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
     uint8_t clockSource = MXC_TMR_CLK0;
 
     switch (clk_src) {
+    case MXC_TMR_EXT_CLK:
+        if (tmr_id < 4) { // Timers 0-3 do not support this clock source
+            return E_NOT_SUPPORTED;
+        }
+
+        clockSource = MXC_TMR_CLK3;
+        break;
     case MXC_TMR_ISO_CLK:
         if (tmr_id > 3) { // Timers 4-5 do not support this clock source
             return E_NOT_SUPPORTED;

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,13 +206,11 @@ uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
         break;
 
     case MXC_TMR_EXT_CLK:
-        if (tmr_id < 3) { // GPIO3[5]
-            clockSource = MXC_TMR_CLK3;
-        } else {
+        if (tmr_id < 4) { // Timers 0-3 do not support this clock source
             return E_NOT_SUPPORTED;
         }
 
-        MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_EXTCLK);
+        clockSource = MXC_TMR_CLK3;
         break;
 
     default:


### PR DESCRIPTION
### Description

Enables use of an external clock source for low-power timers on MAX32690, MAX78000 and MAX78002.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
