### PR TITLE
feat(PeriphDrivers): Add new MXC_SPI_GetAndClearFlags API

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32520/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32520/spi.h
@@ -471,6 +471,18 @@ unsigned int MXC_SPI_GetFlags(mxc_spi_regs_t *spi);
 void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi);
 
 /**
+ * @brief   Gets and clears the interrupt flags that are currently set
+ *
+ * These functions should not be used while using non-blocking Transaction Level
+ * functions (Async or DMA)
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return The interrupt flags
+ */
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Enables specific interrupts
  *
  * These functions should not be used while using non-blocking Transaction Level

--- a/Libraries/PeriphDrivers/Include/MAX32570/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/spi.h
@@ -479,6 +479,18 @@ unsigned int MXC_SPI_GetFlags(mxc_spi_regs_t *spi);
 void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi);
 
 /**
+ * @brief   Gets and clears the interrupt flags that are currently set
+ *
+ * These functions should not be used while using non-blocking Transaction Level
+ * functions (Async or DMA)
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return The interrupt flags
+ */
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Enables specific interrupts
  *
  * These functions should not be used while using non-blocking Transaction Level

--- a/Libraries/PeriphDrivers/Include/MAX32572/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/spi.h
@@ -321,6 +321,18 @@ unsigned int MXC_SPI_GetFlags(mxc_spi_regs_t *spi);
 void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi);
 
 /**
+ * @brief   Gets and clears the interrupt flags that are currently set
+ *
+ * These functions should not be used while using non-blocking Transaction Level
+ * functions (Async or DMA)
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return The interrupt flags
+ */
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Enables specific interrupts
  *
  * These functions should not be used while using non-blocking Transaction Level

--- a/Libraries/PeriphDrivers/Include/MAX32650/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/spi.h
@@ -481,6 +481,18 @@ unsigned int MXC_SPI_GetFlags(mxc_spi_regs_t *spi);
 void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi);
 
 /**
+ * @brief   Gets and clears the interrupt flags that are currently set
+ *
+ * These functions should not be used while using non-blocking Transaction Level
+ * functions (Async or DMA)
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return The interrupt flags
+ */
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Enables specific interrupts
  *
  * These functions should not be used while using non-blocking Transaction Level

--- a/Libraries/PeriphDrivers/Include/MAX32655/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/spi.h
@@ -524,6 +524,18 @@ unsigned int MXC_SPI_GetFlags(mxc_spi_regs_t *spi);
 void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi);
 
 /**
+ * @brief   Gets and clears the interrupt flags that are currently set
+ *
+ * These functions should not be used while using non-blocking Transaction Level
+ * functions (Async or DMA)
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return The interrupt flags
+ */
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Enables specific interrupts
  *
  * These functions should not be used while using non-blocking Transaction Level

--- a/Libraries/PeriphDrivers/Include/MAX32657/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/spi.h
@@ -523,6 +523,18 @@ unsigned int MXC_SPI_GetFlags(mxc_spi_regs_t *spi);
 void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi);
 
 /**
+ * @brief   Gets and clears the interrupt flags that are currently set
+ *
+ * These functions should not be used while using non-blocking Transaction Level
+ * functions (Async or DMA)
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return The interrupt flags
+ */
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Enables specific interrupts
  *
  * These functions should not be used while using non-blocking Transaction Level

--- a/Libraries/PeriphDrivers/Include/MAX32660/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/spi.h
@@ -477,6 +477,18 @@ unsigned int MXC_SPI_GetFlags(mxc_spi_regs_t *spi);
 void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi);
 
 /**
+ * @brief   Gets and clears the interrupt flags that are currently set
+ *
+ * These functions should not be used while using non-blocking Transaction Level
+ * functions (Async or DMA)
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return The interrupt flags
+ */
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Enables specific interrupts
  *
  * These functions should not be used while using non-blocking Transaction Level

--- a/Libraries/PeriphDrivers/Include/MAX32662/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/spi.h
@@ -502,6 +502,18 @@ unsigned int MXC_SPI_GetFlags(mxc_spi_regs_t *spi);
 void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi);
 
 /**
+ * @brief   Gets and clears the interrupt flags that are currently set
+ *
+ * These functions should not be used while using non-blocking Transaction Level
+ * functions (Async or DMA)
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return The interrupt flags
+ */
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Enables specific interrupts
  *
  * These functions should not be used while using non-blocking Transaction Level

--- a/Libraries/PeriphDrivers/Include/MAX32665/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/spi.h
@@ -479,6 +479,18 @@ unsigned int MXC_SPI_GetFlags(mxc_spi_regs_t *spi);
 void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi);
 
 /**
+ * @brief   Gets and clears the interrupt flags that are currently set
+ *
+ * These functions should not be used while using non-blocking Transaction Level
+ * functions (Async or DMA)
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return The interrupt flags
+ */
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Enables specific interrupts
  *
  * These functions should not be used while using non-blocking Transaction Level

--- a/Libraries/PeriphDrivers/Include/MAX32670/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/spi.h
@@ -477,6 +477,18 @@ unsigned int MXC_SPI_GetFlags(mxc_spi_regs_t *spi);
 void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi);
 
 /**
+ * @brief   Gets and clears the interrupt flags that are currently set
+ *
+ * These functions should not be used while using non-blocking Transaction Level
+ * functions (Async or DMA)
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return The interrupt flags
+ */
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Enables specific interrupts
  *
  * These functions should not be used while using non-blocking Transaction Level

--- a/Libraries/PeriphDrivers/Include/MAX32672/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/spi.h
@@ -476,6 +476,18 @@ unsigned int MXC_SPI_GetFlags(mxc_spi_regs_t *spi);
 void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi);
 
 /**
+ * @brief   Gets and clears the interrupt flags that are currently set
+ *
+ * These functions should not be used while using non-blocking Transaction Level
+ * functions (Async or DMA)
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return The interrupt flags
+ */
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Enables specific interrupts
  *
  * These functions should not be used while using non-blocking Transaction Level

--- a/Libraries/PeriphDrivers/Include/MAX32675/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/spi.h
@@ -476,6 +476,18 @@ unsigned int MXC_SPI_GetFlags(mxc_spi_regs_t *spi);
 void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi);
 
 /**
+ * @brief   Gets and clears the interrupt flags that are currently set
+ *
+ * These functions should not be used while using non-blocking Transaction Level
+ * functions (Async or DMA)
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return The interrupt flags
+ */
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Enables specific interrupts
  *
  * These functions should not be used while using non-blocking Transaction Level

--- a/Libraries/PeriphDrivers/Include/MAX32680/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/spi.h
@@ -500,6 +500,18 @@ unsigned int MXC_SPI_GetFlags(mxc_spi_regs_t *spi);
 void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi);
 
 /**
+ * @brief   Gets and clears the interrupt flags that are currently set
+ *
+ * These functions should not be used while using non-blocking Transaction Level
+ * functions (Async or DMA)
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return The interrupt flags
+ */
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Enables specific interrupts
  *
  * These functions should not be used while using non-blocking Transaction Level

--- a/Libraries/PeriphDrivers/Include/MAX32690/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/spi.h
@@ -319,6 +319,18 @@ unsigned int MXC_SPI_GetFlags(mxc_spi_regs_t *spi);
 void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi);
 
 /**
+ * @brief   Gets and clears the interrupt flags that are currently set
+ *
+ * These functions should not be used while using non-blocking Transaction Level
+ * functions (Async or DMA)
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return The interrupt flags
+ */
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Enables specific interrupts
  *
  * These functions should not be used while using non-blocking Transaction Level

--- a/Libraries/PeriphDrivers/Include/MAX78000/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/spi.h
@@ -495,6 +495,18 @@ unsigned int MXC_SPI_GetFlags(mxc_spi_regs_t *spi);
 void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi);
 
 /**
+ * @brief   Gets and clears the interrupt flags that are currently set
+ *
+ * These functions should not be used while using non-blocking Transaction Level
+ * functions (Async or DMA)
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return The interrupt flags
+ */
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Enables specific interrupts
  *
  * These functions should not be used while using non-blocking Transaction Level

--- a/Libraries/PeriphDrivers/Include/MAX78002/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/spi.h
@@ -320,6 +320,18 @@ unsigned int MXC_SPI_GetFlags(mxc_spi_regs_t *spi);
 void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi);
 
 /**
+ * @brief   Gets and clears the interrupt flags that are currently set
+ *
+ * These functions should not be used while using non-blocking Transaction Level
+ * functions (Async or DMA)
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return The interrupt flags
+ */
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Enables specific interrupts
  *
  * These functions should not be used while using non-blocking Transaction Level

--- a/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
@@ -373,6 +373,11 @@ void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi)
     MXC_SPI_RevA1_ClearFlags((mxc_spi_reva_regs_t *)spi);
 }
 
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_GetAndClearFlags((mxc_spi_reva_regs_t *)spi);
+}
+
 void MXC_SPI_EnableInt(mxc_spi_regs_t *spi, unsigned int intEn)
 {
     MXC_SPI_RevA1_EnableInt((mxc_spi_reva_regs_t *)spi, intEn);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_ai87_v2.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_ai87_v2.c
@@ -273,6 +273,11 @@ void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi)
     MXC_SPI_RevA2_ClearFlags((mxc_spi_reva_regs_t *)spi);
 }
 
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA2_GetAndClearFlags((mxc_spi_reva_regs_t *)spi);
+}
+
 void MXC_SPI_EnableInt(mxc_spi_regs_t *spi, unsigned int intEn)
 {
     MXC_SPI_RevA2_EnableInt((mxc_spi_reva_regs_t *)spi, (uint32_t)intEn);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me10.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me10.c
@@ -294,6 +294,11 @@ void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi)
     MXC_SPI_RevA1_ClearFlags((mxc_spi_reva_regs_t *)spi);
 }
 
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_GetAndClearFlags((mxc_spi_reva_regs_t *)spi);
+}
+
 /* ************************************************************************ */
 void MXC_SPI_EnableInt(mxc_spi_regs_t *spi, unsigned int mask)
 {

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
@@ -220,6 +220,11 @@ void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi)
     MXC_SPI_RevA1_ClearFlags((mxc_spi_reva_regs_t *)spi);
 }
 
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_GetAndClearFlags((mxc_spi_reva_regs_t *)spi);
+}
+
 void MXC_SPI_EnableInt(mxc_spi_regs_t *spi, unsigned int mask)
 {
     MXC_SPI_RevA1_EnableInt((mxc_spi_reva_regs_t *)spi, mask);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
@@ -329,6 +329,11 @@ void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi)
     MXC_SPI_RevA1_ClearFlags((mxc_spi_reva_regs_t *)spi);
 }
 
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_GetAndClearFlags((mxc_spi_reva_regs_t *)spi);
+}
+
 void MXC_SPI_EnableInt(mxc_spi_regs_t *spi, unsigned int intEn)
 {
     MXC_SPI_RevA1_EnableInt((mxc_spi_reva_regs_t *)spi, intEn);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me13.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me13.c
@@ -254,6 +254,11 @@ void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi)
     MXC_SPI_RevA1_ClearFlags((mxc_spi_reva_regs_t *)spi);
 }
 
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_GetAndClearFlags((mxc_spi_reva_regs_t *)spi);
+}
+
 void MXC_SPI_EnableInt(mxc_spi_regs_t *spi, unsigned int mask)
 {
     MXC_SPI_RevA1_EnableInt((mxc_spi_reva_regs_t *)spi, mask);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
@@ -314,6 +314,11 @@ void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi)
     MXC_SPI_RevA1_ClearFlags((mxc_spi_reva_regs_t *)spi);
 }
 
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_GetAndClearFlags((mxc_spi_reva_regs_t *)spi);
+}
+
 void MXC_SPI_EnableInt(mxc_spi_regs_t *spi, unsigned int mask)
 {
     MXC_SPI_RevA1_EnableInt((mxc_spi_reva_regs_t *)spi, mask);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me15.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me15.c
@@ -234,6 +234,11 @@ void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi)
     MXC_SPI_RevA1_ClearFlags((mxc_spi_reva_regs_t *)spi);
 }
 
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_GetAndClearFlags((mxc_spi_reva_regs_t *)spi);
+}
+
 void MXC_SPI_EnableInt(mxc_spi_regs_t *spi, unsigned int mask)
 {
     MXC_SPI_RevA1_EnableInt((mxc_spi_reva_regs_t *)spi, mask);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me16.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me16.c
@@ -230,6 +230,11 @@ void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi)
     MXC_SPI_RevA1_ClearFlags(spi);
 }
 
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_GetAndClearFlags((mxc_spi_reva_regs_t *)spi);
+}
+
 void MXC_SPI_EnableInt(mxc_spi_regs_t *spi, unsigned int mask)
 {
     MXC_SPI_RevA1_EnableInt(spi, mask);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
@@ -387,6 +387,11 @@ void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi)
     MXC_SPI_RevA1_ClearFlags((mxc_spi_reva_regs_t *)spi);
 }
 
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_GetAndClearFlags((mxc_spi_reva_regs_t *)spi);
+}
+
 void MXC_SPI_EnableInt(mxc_spi_regs_t *spi, unsigned int intEn)
 {
     MXC_SPI_RevA1_EnableInt((mxc_spi_reva_regs_t *)spi, intEn);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
@@ -360,6 +360,11 @@ void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi)
     MXC_SPI_RevA1_ClearFlags((mxc_spi_reva_regs_t *)spi);
 }
 
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_GetAndClearFlags((mxc_spi_reva_regs_t *)spi);
+}
+
 void MXC_SPI_EnableInt(mxc_spi_regs_t *spi, unsigned int intEn)
 {
     MXC_SPI_RevA1_EnableInt((mxc_spi_reva_regs_t *)spi, intEn);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me18_v2.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me18_v2.c
@@ -506,6 +506,11 @@ void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi)
     MXC_SPI_RevA2_ClearFlags((mxc_spi_reva_regs_t *)spi);
 }
 
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA2_GetAndClearFlags((mxc_spi_reva_regs_t *)spi);
+}
+
 void MXC_SPI_EnableInt(mxc_spi_regs_t *spi, unsigned int intEn)
 {
     MXC_SPI_RevA2_EnableInt((mxc_spi_reva_regs_t *)spi, (uint32_t)intEn);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me21.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me21.c
@@ -251,6 +251,11 @@ void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi)
     MXC_SPI_RevA1_ClearFlags((mxc_spi_reva_regs_t *)spi);
 }
 
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_GetAndClearFlags((mxc_spi_reva_regs_t *)spi);
+}
+
 void MXC_SPI_EnableInt(mxc_spi_regs_t *spi, unsigned int mask)
 {
     MXC_SPI_RevA1_EnableInt((mxc_spi_reva_regs_t *)spi, mask);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me30.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me30.c
@@ -276,6 +276,11 @@ void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi)
     MXC_SPI_RevA1_ClearFlags((mxc_spi_reva_regs_t *)spi);
 }
 
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_GetAndClearFlags((mxc_spi_reva_regs_t *)spi);
+}
+
 void MXC_SPI_EnableInt(mxc_spi_regs_t *spi, unsigned int intEn)
 {
     MXC_SPI_RevA1_EnableInt((mxc_spi_reva_regs_t *)spi, intEn);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me55.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me55.c
@@ -250,6 +250,11 @@ void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi)
     MXC_SPI_RevA1_ClearFlags((mxc_spi_reva_regs_t *)spi);
 }
 
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_GetAndClearFlags((mxc_spi_reva_regs_t *)spi);
+}
+
 void MXC_SPI_EnableInt(mxc_spi_regs_t *spi, unsigned int mask)
 {
     MXC_SPI_RevA1_EnableInt((mxc_spi_reva_regs_t *)spi, mask);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me55_v2.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me55_v2.c
@@ -371,6 +371,11 @@ void MXC_SPI_ClearFlags(mxc_spi_regs_t *spi)
     MXC_SPI_RevA2_ClearFlags((mxc_spi_reva_regs_t *)spi);
 }
 
+unsigned int MXC_SPI_GetAndClearFlags(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA2_GetAndClearFlags((mxc_spi_reva_regs_t *)spi);
+}
+
 void MXC_SPI_EnableInt(mxc_spi_regs_t *spi, unsigned int intEn)
 {
     MXC_SPI_RevA2_EnableInt((mxc_spi_reva_regs_t *)spi, (uint32_t)intEn);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
@@ -678,6 +678,15 @@ void MXC_SPI_RevA1_ClearFlags(mxc_spi_reva_regs_t *spi)
     spi->intfl = spi->intfl;
 }
 
+unsigned int MXC_SPI_RevA1_GetAndClearFlags(mxc_spi_reva_regs_t *spi)
+{
+    unsigned int intfl = spi->intfl;
+
+    spi->intfl = intfl;
+
+    return intfl;
+}
+
 void MXC_SPI_RevA1_EnableInt(mxc_spi_reva_regs_t *spi, unsigned int intEn)
 {
     spi->inten |= intEn;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.h
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.h
@@ -100,6 +100,7 @@ int MXC_SPI_RevA1_SetTXThreshold(mxc_spi_reva_regs_t *spi, unsigned int numBytes
 unsigned int MXC_SPI_RevA1_GetTXThreshold(mxc_spi_reva_regs_t *spi);
 unsigned int MXC_SPI_RevA1_GetFlags(mxc_spi_reva_regs_t *spi);
 void MXC_SPI_RevA1_ClearFlags(mxc_spi_reva_regs_t *spi);
+unsigned int MXC_SPI_RevA1_GetAndClearFlags(mxc_spi_reva_regs_t *spi);
 void MXC_SPI_RevA1_EnableInt(mxc_spi_reva_regs_t *spi, unsigned int mask);
 void MXC_SPI_RevA1_DisableInt(mxc_spi_reva_regs_t *spi, unsigned int mask);
 int MXC_SPI_RevA1_MasterTransaction(mxc_spi_reva_req_t *req);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva2.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva2.c
@@ -518,6 +518,15 @@ void MXC_SPI_RevA2_ClearFlags(mxc_spi_reva_regs_t *spi)
     spi->intfl = spi->intfl;
 }
 
+unsigned int MXC_SPI_RevA2_GetAndClearFlags(mxc_spi_reva_regs_t *spi)
+{
+    unsigned int intfl = spi->intfl;
+
+    spi->intfl = intfl;
+
+    return intfl;
+}
+
 void MXC_SPI_RevA2_EnableInt(mxc_spi_reva_regs_t *spi, uint32_t en)
 {
     spi->inten |= en;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva2.h
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva2.h
@@ -52,6 +52,8 @@ uint32_t MXC_SPI_RevA2_GetFlags(mxc_spi_reva_regs_t *spi);
 
 void MXC_SPI_RevA2_ClearFlags(mxc_spi_reva_regs_t *spi);
 
+unsigned int MXC_SPI_RevA2_GetAndClearFlags(mxc_spi_reva_regs_t *spi);
+
 void MXC_SPI_RevA2_EnableInt(mxc_spi_reva_regs_t *spi, uint32_t en);
 
 void MXC_SPI_RevA2_DisableInt(mxc_spi_reva_regs_t *spi, uint32_t dis);


### PR DESCRIPTION
### Description

Add new MXC_SPI_GetAndClearFlags to simultaneously retrieve the current interrupt flags, and clear only the returned flags. This avoids accidentally clearing flags that have been set since a call to get the current flags using the existing MXC_SPI_ClearFlags API.

This is needed to fix a race condition discovered in the Zephyr MAX32 SPI driver. In particular, the ISR there is fetching the flags, then clearing the flags (via `MXC_SPI_ClearFlags`), which can lead to missed flags if a flag is set between the call to get the flags, and clear them: https://github.com/zephyrproject-rtos/zephyr/blob/acc53653b4707aa40c22aec8c33f1d733e5e670f/drivers/spi/spi_max32.c#L1064

Testing here on MAX32666 (where flake was most prevalent due to this race condition) confirms that moving to the new API eliminates all flake.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

_______________________________________________________________________________
