### PR TITLE
fix(MAXUSB): Allow packet mode ReadEndpoint on EP0

### DIFF
--- a/Libraries/MAXUSB/src/core/musbhsfc/usb.c
+++ b/Libraries/MAXUSB/src/core/musbhsfc/usb.c
@@ -692,7 +692,7 @@ static void event_out_data(uint32_t irqs)
         req->actlen += reqsize;
 
         if (!ep) {
-            if (req->actlen == req->reqlen) {
+            if ((req->actlen == req->reqlen) || reqsize < ep_size[0]) {
                 /* No more data */
                 MXC_USBHS->csr0 |= MXC_F_USBHS_CSR0_SERV_OUTPKTRDY | MXC_F_USBHS_CSR0_DATA_END;
                 /* Done */
@@ -1179,7 +1179,7 @@ int MXC_USB_ReadEndpoint(MXC_USB_Req_t *req)
 
             /* Signal to H/W that FIFO has been read */
             MXC_USBHS->csr0 |= MXC_F_USBHS_CSR0_SERV_OUTPKTRDY;
-            if (req->actlen == req->reqlen) {
+            if ((req->actlen == req->reqlen) || reqsize < ep_size[0]) {
                 /* Signal end of transaction to hardware */
                 MXC_USBHS->csr0 |= MXC_F_USBHS_CSR0_DATA_END;
 


### PR DESCRIPTION


### Description

Zephyr's USB stack issues a full size (MPS) OUT request on EP0 to help the stack avoid issues with not enough buffer allocated when hosts might accidentally send too much data. Adjust the MAXUSB library to allow packet mode to complete the request even if the MPS number of bytes hasn't be received (unlikely).

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
