### PR TITLE
fix(Other): Corrected SoC targets for the MXC_SYS_RESET0_USB define

### DIFF
--- a/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
@@ -49,7 +49,12 @@ void max32xx_system_init(void);
 #define ADI_MAX32_CLK_INRO MXC_SYS_CLOCK_NANORING
 #define ADI_MAX32_CLK_ERTCO MXC_SYS_CLOCK_X32K
 
+#endif
+
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666) || defined(CONFIG_SOC_MAX32650)
+
 #define MXC_SYS_RESET0_USB MXC_SYS_RESET_USB
+
 #endif
 
 #define z_sysclk_prescaler(v) MXC_SYS_SYSTEM_DIV_##v


### PR DESCRIPTION
### Description

Correctly define the MXC_SYS_RESET0_USB alias for targets that instead define MXC_SYS_RESET_USB instead.

This is needed to bring us the HS USB peripheral on MAX32666 on Zephyr.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.