### PR TITLE
fix(Other): Include MAX32651 in MXC_SYS_RESET0_USB define fix

### DIFF
--- a/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
@@ -51,11 +51,7 @@ void max32xx_system_init(void);
 
 #endif
 
-#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666) || defined(CONFIG_SOC_MAX32650)
-
 #define MXC_SYS_RESET0_USB MXC_SYS_RESET_USB
-
-#endif
 
 #define z_sysclk_prescaler(v) MXC_SYS_SYSTEM_DIV_##v
 #define sysclk_prescaler(v) z_sysclk_prescaler(v)


### PR DESCRIPTION
### Description

Remove the redundant #if and make sure MXC_SYS_RESET0_USB is defined on MAX32651 as well.

See #1546 for the original fix that this adjusts.

### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [X] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
