### PR TITLE
fix(MAXUSB): Proper EP0 pending request check for WriteEndpoint

### DIFF
--- a/Libraries/MAXUSB/src/core/musbhsfc/usb.c
+++ b/Libraries/MAXUSB/src/core/musbhsfc/usb.c
@@ -1033,7 +1033,14 @@ int MXC_USB_WriteEndpoint(MXC_USB_Req_t *req)
     MXC_USBHS->index = ep;
 
     /* if pending request; error */
-    if (MXC_USB_Request[ep] || (MXC_USBHS->incsrl & MXC_F_USBHS_INCSRL_INPKTRDY)) {
+    if (MXC_USB_Request[ep]) {
+        MXC_SYS_Crit_Exit();
+        return -1;
+    }
+
+    /* if pending data; error */
+    if (ep ? (MXC_USBHS->incsrl & MXC_F_USBHS_INCSRL_INPKTRDY)
+           : (MXC_USBHS->csr0 & MXC_F_USBHS_CSR0_INPKTRDY)) {
         MXC_SYS_Crit_Exit();
         return -1;
     }


### PR DESCRIPTION
### Description

Adjust the check for endpoint in packet readiness to properly check EP0 when writing to that endpoint.

This was tested with our Zephyr USB integration, on this branch that has Zephyr driver fixes: https://github.com/petejohanson-adi/zephyr/tree/max32-usb-fixes
 
### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.