### PR TITLE
feat(PeriphDrivers): Avoid div-by-zero in SPI SetFrequency calls

### DIFF
--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
@@ -190,6 +190,10 @@ int MXC_SPI_RevA1_SetFrequency(mxc_spi_reva_regs_t *spi, unsigned int hz)
     int hi_clk, lo_clk, scale;
     uint32_t freq_div;
 
+    if (!hz) {
+        return E_BAD_PARAM;
+    }
+
     // Check if frequency is too high
     if (hz > PeripheralClock) {
         return E_BAD_PARAM;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva2.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva2.c
@@ -581,6 +581,10 @@ int MXC_SPI_RevA2_SetFrequency(mxc_spi_reva_regs_t *spi, uint32_t freq)
     int hi_clk, lo_clk, scale;
     uint32_t freq_div;
 
+    if (!freq) {
+        return E_BAD_PARAM;
+    }
+
     // Check if frequency is too high
     if (freq > PeripheralClock) {
         return E_BAD_PARAM;


### PR DESCRIPTION
### Description

Add a check on the frequency during SetFrequency to avoid a divide-by-zero.

This has been tested locally from the Zephyr driver consuming this API. In particular, working on adding target support, we may be initializing without a known frequency, so may be passing a value of zero.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.