### PR TITLE
fix(BLE): Align WSF timer behavior between baremetal and freertos

### DIFF
--- a/Libraries/Cordio/wsf/sources/targets/baremetal/wsf_timer.c
+++ b/Libraries/Cordio/wsf/sources/targets/baremetal/wsf_timer.c
@@ -158,7 +158,12 @@ static void wsfTimerInsert(wsfTimer_t *pTimer, wsfTimerTicks_t ticks)
   }
 
   pTimer->isStarted = TRUE;
-  pTimer->ticks = ticks;
+  /* offset requested ticks by any elapsed but unclaimed WSF ticks so the
+   * timer fires at the correct absolute time regardless of how long since the
+   * last WsfTimerSleepUpdate() call. */
+  uint32_t rtcNow = PalRtcCounterGet();
+  uint32_t elapsed = WSF_TIMER_RTC_ELAPSED_TICKS(rtcNow);
+  pTimer->ticks = ticks + WSF_RTC_TICKS_TO_WSF(elapsed);
 
   pElem = (wsfTimer_t *) wsfTimerTimerQueue.pHead;
 
@@ -400,7 +405,10 @@ void WsfTimerSleep(void)
     uint32_t elapsed = WSF_TIMER_RTC_ELAPSED_TICKS(rtcCurrentTicks);
 
     /* if we have time to sleep before timer expiration */
-    if ((awake - elapsed) > WSF_TIMER_MIN_RTC_TICKS_FOR_SLEEP)
+    /* protect against unsigned underflow to avoid hang: if elapsed RTC ticks exceed awake, e.g.
+     * if timer is about to expire and WsfTimerSleepUpdate() hasn't run in a while because 
+     * of long handler execution, treat the timer as already expired and skip sleep. */
+    if ((elapsed < awake) && ((awake - elapsed) > WSF_TIMER_MIN_RTC_TICKS_FOR_SLEEP))
     {
       uint32_t compareVal = (rtcCurrentTicks + awake - elapsed) & PAL_MAX_RTC_COUNTER_VAL;
 

--- a/Libraries/Cordio/wsf/sources/targets/freertos/wsf_timer.c
+++ b/Libraries/Cordio/wsf/sources/targets/freertos/wsf_timer.c
@@ -103,6 +103,8 @@ void WsfTimerStartMs(wsfTimer_t *pTimer, wsfTimerTicks_t ms)
         if (ticks != pTimer->ticks) {
             /* Update timer interval */
             xTimerChangePeriod(existingTimer->tmr, ticks, 0);
+            /* save it too to catch future updates at initial setting */
+            pTimer->ticks = ticks;
         }
         /* Restart the existing timer */
         pTimer->isStarted = xTimerReset(existingTimer->tmr, 0);


### PR DESCRIPTION
### Description

Fixes for #1553: 
- start baremetal wsf timer countdown at time of call
- prevent baremetal sleep time underflow
- cache all freertos wsf timer tick changes

I tested this PR using a peripheral app based on BLE_FreeRTOS running on a vanilla MAX32666FTHR sending notifications 1x/second to a iOS iPad Air central. I ran 200 repeats of 20 second connections across baremetal, and freertos (not tickless) with only a few #1508 failures:

#### Baremetal
```
regression % grep 'test complete' repeats-20260509-baremetal.log  | wc -l
     200

regression % grep FAIL repeats-20260509-baremetal.log       
2026-05-09 09:41:16.284 test complete: FAIL (ready timed out)
2026-05-09 12:52:51.485 test complete: FAIL (ready timed out)

regression % grep -a SUP_TIMEOUT analog-20260509-baremetal.log 
2026-05-09T09:40:17.048682: lctrConnStatelessEventHandler: handle=0, state=2, event=SUP_TIMEOUT
2026-05-09T09:41:10.777898: lctrConnStatelessEventHandler: handle=0, state=2, event=SUP_TIMEOUT
2026-05-09T12:52:45.913806: lctrConnStatelessEventHandler: handle=0, state=2, event=SUP_TIMEOUT
```
#### FreeRTOS
```
regression % grep 'test complete' repeats-20260509-freertos.log | wc -l                                                                                         
     200

regression % grep 'FAIL' repeats-20260509-freertos.log        
2026-05-09 15:24:44.084 test complete: FAIL (ready timed out)
2026-05-09 16:14:19.855 test complete: FAIL (ready timed out)
2026-05-09 16:18:09.979 test complete: FAIL (ready timed out)
2026-05-09 17:09:06.950 test complete: FAIL (ready timed out)
2026-05-09 18:25:12.114 test complete: FAIL (ready timed out)

regression % grep -a 'SUP_TIMEOUT' analog-20260509-freertos.log
2026-05-09T15:24:39.604630: lctrConnStatelessEventHandler: handle=0, state=2, event=SUP_TIMEOUT
2026-05-09T16:14:14.291194: lctrConnStatelessEventHandler: handle=0, state=2, event=SUP_TIMEOUT
2026-05-09T16:18:04.840497: lctrConnStatelessEventHandler: handle=0, state=2, event=SUP_TIMEOUT
2026-05-09T17:09:01.564716: lctrConnStatelessEventHandler: handle=0, state=2, event=SUP_TIMEOUT
2026-05-09T18:25:07.213680: lctrConnStatelessEventHandler: handle=0, state=2, event=SUP_TIMEOUT
```

I also tested this PR by running my own test suite which sweeps a range of traffic patterns (varying characteristics, lengths, properties, rate of notifications, etc) between a MAX32666FTHR running as peripheral against the same iOS iPad Air central device for both baremetal and freertos (not tickless) builds:

#### Baremetal

| Case | Platform | Result | Reason | Comments |
|------|----------|--------|--------|----------|
| spec-0100 | ios | PASS |  |  |
| spec-0101 | ios | PASS |  |  |
| spec-0102 | ios | PASS |  |  |
| spec-0103 | ios | PASS |  |  |
| spec-0104 | ios | PASS |  |  |
| spec-0105 | ios | PASS |  |  |
| spec-0106 | ios | PASS |  |  |
| spec-0107 | ios | PASS |  |  |
| spec-0108 | ios | PASS |  |  |
| spec-0109 | ios | PASS |  |  |
| spec-0110 | ios | PASS |  |  |
| spec-0111 | ios | PASS |  |  |
| spec-0112 | ios | PASS |  |  |
| spec-0113 | ios | PASS |  |  |
| spec-0114 | ios | PASS |  |  |
| spec-0115 | ios | PASS |  |  |
| spec-0116 | ios | PASS |  |  |
| spec-0117 | ios | PASS |  |  |
| spec-0118 | ios | PASS |  |  |
| spec-0119 | ios | PASS |  |  |
| spec-0120 | ios | PASS |  |  |
| spec-0121 | ios | PASS |  |  |
| spec-0200 | ios | PASS |  |  |
| spec-0201 | ios | PASS |  |  |
| spec-0202 | ios | PASS |  |  |
| spec-0203 | ios | PASS |  |  |
| spec-0204 | ios | PASS |  |  |
| spec-0205 | ios | PASS |  |  |
| spec-0206 | ios | PASS |  |  |
| spec-0207 | ios | PASS |  |  |
| spec-0208 | ios | PASS |  |  |
| spec-0209 | ios | PASS |  |  |
| spec-0210 | ios | PASS |  |  |
| spec-0211 | ios | PASS |  |  |
| spec-0212 | ios | PASS |  |  |
| spec-0213 | ios | PASS |  |  |
| spec-0214 | ios | PASS |  |  |
| spec-0215 | ios | PASS |  |  |

#### FreeRTOS

| Case | Platform | Result | Reason | Comments |
|------|----------|--------|--------|----------|
| spec-0100 | ios | PASS |  |  |
| spec-0101 | ios | PASS |  |  |
| spec-0102 | ios | PASS |  |  |
| spec-0103 | ios | PASS |  |  |
| spec-0104 | ios | PASS |  |  |
| spec-0105 | ios | PASS |  |  |
| spec-0106 | ios | PASS |  |  |
| spec-0107 | ios | PASS |  |  |
| spec-0108 | ios | PASS |  |  |
| spec-0109 | ios | PASS |  |  |
| spec-0110 | ios | PASS |  |  |
| spec-0111 | ios | PASS |  |  |
| spec-0112 | ios | PASS |  |  |
| spec-0113 | ios | PASS |  |  |
| spec-0114 | ios | PASS |  |  |
| spec-0115 | ios | PASS |  |  |
| spec-0116 | ios | PASS |  |  |
| spec-0117 | ios | PASS |  |  |
| spec-0118 | ios | FAIL | ready timed out | #1508 SUP_TIMEOUT |
| spec-0119 | ios | PASS |  |  |
| spec-0120 | ios | PASS |  |  |
| spec-0121 | ios | PASS |  |  |
| spec-0200 | ios | PASS |  |  |
| spec-0201 | ios | PASS |  |  |
| spec-0202 | ios | PASS |  |  |
| spec-0203 | ios | PASS |  |  |
| spec-0204 | ios | PASS |  |  |
| spec-0205 | ios | PASS |  |  |
| spec-0206 | ios | PASS |  |  |
| spec-0207 | ios | PASS |  |  |
| spec-0208 | ios | PASS |  |  |
| spec-0209 | ios | PASS |  |  |
| spec-0210 | ios | PASS |  |  |
| spec-0211 | ios | PASS |  |  |
| spec-0212 | ios | PASS |  |  |
| spec-0213 | ios | PASS |  |  |
| spec-0214 | ios | PASS |  |  |
| spec-0215 | ios | PASS |  |  |




### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
