### PR TITLE
fix(Examples): Update MAX32655 Flash Readme file for reset info

### DIFF
--- a/Examples/MAX32655/Flash/README.md
+++ b/Examples/MAX32655/Flash/README.md
@@ -44,7 +44,7 @@ After flashing and launching the example, an LED on the board will blink once ev
 
 ```
 ***** Flash Control Example *****
-Press Push Button 1 (PB1/SW1) to continue...
+Press Push Button 1 (PB1/SW3) to continue...
 
 ---(Critical)---
 Successfully erased page 64 of flash (addr 0x1007e000)
@@ -64,7 +64,7 @@ At this point, the "magic" and test pattern values have been written to flash.  
 
 ```
 ***** Flash Control Example *****
-Press Push Button 1 (PB1/SW1) to continue...
+Press Push Button 1 (PB1/SW3) to continue...
 
 ** Magic value 0xfeedbeef found at address 0x1007e000! **
 


### PR DESCRIPTION
Fix README pushbutton reference (PB1/SW3)

### What changed
- Corrected Flash example README button reference from PB1/SW1 to PB1/SW3.

### Why
- MAX32655 EV kit schematic and board silkscreen show that PB1 is physically labeled SW3.
- README reference to SW1 was incorrect and confusing for users.

### Validation
- Verified against EV kit schematic (P0.18 → SW3).
- Verified against board silkscreen photo.
