### PR TITLE
chore(Other): Rename SBT Zephyr config for consistency

### DIFF
--- a/Libraries/zephyr/MAX/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/CMakeLists.txt
@@ -32,7 +32,7 @@ zephyr_compile_definitions(
     -DMSDK_NO_LOCKING=1
 )
 
-if (CONFIG_MAX32_SECURE_SOC_SIGNING)
+if (CONFIG_SOC_FAMILY_MAX32_SECURE_SOC_SIGNING)
 zephyr_compile_definitions(
     -D__SLA_FWK__
     -DUSE_ZEPHYR_SECTIONS=1

--- a/Libraries/zephyr/MAX/Source/MAX32650/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32650/CMakeLists.txt
@@ -83,7 +83,7 @@ zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/SRCC/srcc_reva.c
 )
 
-if (CONFIG_MAX32_SECURE_SOC_SIGNING)
+if (CONFIG_SOC_FAMILY_MAX32_SECURE_SOC_SIGNING)
 zephyr_library_sources(${MSDK_CMSIS_DIR}/Source/sla_header_MAX32650.c)
 endif()
 


### PR DESCRIPTION
### Description

This PR renames Zephyr SBT config name from "CONFIG_MAX32_SECURE_SOC" to "CONFIG_SOC_FAMILY_MAX32_SECURE_SOC_SIGNING" to align with the naming convention of the Zephyr SBT implementation.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
