### PR TITLE
feat(PeriphDrivers): Add new MXC_SPI_InitState API

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32650/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/spi.h
@@ -173,6 +173,15 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
                  unsigned ssPolarity, unsigned int hz);
 
 /**
+ * @brief   Initialize in-memory SPI peripheral state.
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_SPI_InitState(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Disable and shutdown SPI peripheral.
  *
  * @param   spi         Pointer to SPI registers (selects the SPI block used.)

--- a/Libraries/PeriphDrivers/Include/MAX32655/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/spi.h
@@ -193,6 +193,15 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
                  unsigned ssPolarity, unsigned int hz, mxc_spi_pins_t pins);
 
 /**
+ * @brief   Initialize in-memory SPI peripheral state.
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_SPI_InitState(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Disable and shutdown SPI peripheral.
  *
  * @param   spi         Pointer to SPI registers (selects the SPI block used.)

--- a/Libraries/PeriphDrivers/Include/MAX32690/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/spi.h
@@ -250,6 +250,15 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, mxc_spi_type_t controller_target, mxc_spi_
                  int numTargets, uint8_t ts_active_pol_mask, uint32_t freq, mxc_spi_pins_t pins);
 
 /**
+ * @brief   Initialize in-memory SPI peripheral state.
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_SPI_InitState(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Configure the SPI peripheral.
  *
  * List of Setting that will be updated:

--- a/Libraries/PeriphDrivers/Include/MAX78000/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/spi.h
@@ -186,6 +186,15 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
                  unsigned ssPolarity, unsigned int hz, mxc_spi_pins_t pins);
 
 /**
+ * @brief   Initialize in-memory SPI peripheral state.
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_SPI_InitState(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Disable and shutdown SPI peripheral.
  *
  * @param   spi         Pointer to SPI registers (selects the SPI block used.)

--- a/Libraries/PeriphDrivers/Include/MAX78002/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/spi.h
@@ -251,6 +251,15 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, mxc_spi_type_t controller_target, mxc_spi_
                  int numTargets, uint8_t ts_active_pol_mask, uint32_t freq, mxc_spi_pins_t pins);
 
 /**
+ * @brief   Initialize in-memory SPI peripheral state.
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_SPI_InitState(mxc_spi_regs_t *spi);
+
+/**
  * @brief   Configure the SPI peripheral.
  *
  * List of Setting that will be updated:

--- a/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_ai87.c
@@ -179,6 +179,11 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, mxc_spi_type_t controller_target, mxc_spi_
                               ssPolarity, hz);
 }
 
+int MXC_SPI_InitState(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_InitState((mxc_spi_reva_regs_t *)spi);
+}
+
 int MXC_SPI_Shutdown(mxc_spi_regs_t *spi)
 {
     int spi_num;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_es17.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_es17.c
@@ -64,6 +64,11 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
                               ssPolarity, hz);
 }
 
+int MXC_SPI_InitState(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_InitState((mxc_spi_reva_regs_t *)spi);
+}
+
 int MXC_SPI_Shutdown(mxc_spi_regs_t *spi)
 {
     int spi_num;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me10.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me10.c
@@ -84,6 +84,11 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
                               ssPolarity, hz);
 }
 
+int MXC_SPI_InitState(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_InitState((mxc_spi_reva_regs_t *)spi);
+}
+
 /* ************************************************************************ */
 int MXC_SPI_Shutdown(mxc_spi_regs_t *spi)
 {

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
@@ -63,6 +63,11 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
                               ssPolarity, hz);
 }
 
+int MXC_SPI_InitState(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_InitState((mxc_spi_reva_regs_t *)spi);
+}
+
 int MXC_SPI_Shutdown(mxc_spi_regs_t *spi)
 {
     int spi_num;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
@@ -148,6 +148,11 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
                               ssPolarity, hz);
 }
 
+int MXC_SPI_InitState(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_InitState((mxc_spi_reva_regs_t *)spi);
+}
+
 int MXC_SPI_Shutdown(mxc_spi_regs_t *spi)
 {
     int spi_num;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me13.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me13.c
@@ -72,6 +72,11 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
                               ssPolarity, hz);
 }
 
+int MXC_SPI_InitState(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_InitState((mxc_spi_reva_regs_t *)spi);
+}
+
 int MXC_SPI_Shutdown(mxc_spi_regs_t *spi)
 {
     int spi_num;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
@@ -136,6 +136,11 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
                               ssPolarity, hz);
 }
 
+int MXC_SPI_InitState(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_InitState((mxc_spi_reva_regs_t *)spi);
+}
+
 int MXC_SPI_Shutdown(mxc_spi_regs_t *spi)
 {
     int spi_num;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me15.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me15.c
@@ -73,6 +73,11 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
                               ssPolarity, hz);
 }
 
+int MXC_SPI_InitState(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_InitState((mxc_spi_reva_regs_t *)spi);
+}
+
 int MXC_SPI_Shutdown(mxc_spi_regs_t *spi)
 {
     int spi_num;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me16.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me16.c
@@ -70,6 +70,11 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
     return MXC_SPI_RevA1_Init(spi, masterMode, quadModeUsed, numSlaves, ssPolarity, hz);
 }
 
+int MXC_SPI_InitState(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_InitState((mxc_spi_reva_regs_t *)spi);
+}
+
 int MXC_SPI_Shutdown(mxc_spi_regs_t *spi)
 {
     int spi_num;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
@@ -178,6 +178,11 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
                               ssPolarity, hz);
 }
 
+int MXC_SPI_InitState(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_InitState((mxc_spi_reva_regs_t *)spi);
+}
+
 int MXC_SPI_Shutdown(mxc_spi_regs_t *spi)
 {
     int spi_num;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
@@ -162,6 +162,11 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, mxc_spi_type_t controller_target, mxc_spi_
                               ssPolarity, hz);
 }
 
+int MXC_SPI_InitState(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_InitState((mxc_spi_reva_regs_t *)spi);
+}
+
 int MXC_SPI_Shutdown(mxc_spi_regs_t *spi)
 {
     int spi_num;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me21.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me21.c
@@ -90,6 +90,11 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
                               ssPolarity, hz);
 }
 
+int MXC_SPI_InitState(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_InitState((mxc_spi_reva_regs_t *)spi);
+}
+
 int MXC_SPI_Shutdown(mxc_spi_regs_t *spi)
 {
     int spi_num;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me30.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me30.c
@@ -115,6 +115,11 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
                               ssPolarity, hz);
 }
 
+int MXC_SPI_InitState(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_InitState((mxc_spi_reva_regs_t *)spi);
+}
+
 int MXC_SPI_Shutdown(mxc_spi_regs_t *spi)
 {
     int spi_num;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me55.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me55.c
@@ -70,6 +70,11 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
                               ssPolarity, hz);
 }
 
+int MXC_SPI_InitState(mxc_spi_regs_t *spi)
+{
+    return MXC_SPI_RevA1_InitState((mxc_spi_reva_regs_t *)spi);
+}
+
 int MXC_SPI_Shutdown(mxc_spi_regs_t *spi)
 {
     int spi_num;

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
@@ -59,24 +59,12 @@ static int MXC_SPI_RevA1_TransSetup(mxc_spi_reva_req_t *req);
 int MXC_SPI_RevA1_Init(mxc_spi_reva_regs_t *spi, int masterMode, int quadModeUsed, int numSlaves,
                        unsigned ssPolarity, unsigned int hz)
 {
+    int retval;
     int spi_num = MXC_SPI_GET_IDX((mxc_spi_regs_t *)spi);
-    /*  Validate that the specified SPI instance exists.
-        Note:  The Init function is the only one that performs this check.
-        It catches the rare edge case where a user has casted
-        a custom SPI regs struct with an incorrect base address.
-     */
-    if (spi_num < 0)
-        return E_BAD_PARAM;
 
-    states[spi_num].req = NULL;
-    states[spi_num].last_size = 0;
-    states[spi_num].ssDeassert = 1;
-    states[spi_num].defaultTXData = 0;
-    states[spi_num].mtMode = 0;
-    states[spi_num].mtFirstTrans = 0;
-    states[spi_num].channelTx = E_NO_DEVICE;
-    states[spi_num].channelRx = E_NO_DEVICE;
-    states[spi_num].hw_ss_control = true;
+    retval = MXC_SPI_RevA1_InitState(spi);
+    if (retval)
+        return retval;
 
     spi->ctrl0 = (MXC_F_SPI_REVA_CTRL0_EN);
     spi->sstime =
@@ -126,6 +114,30 @@ int MXC_SPI_RevA1_Init(mxc_spi_reva_regs_t *spi, int masterMode, int quadModeUse
     if (quadModeUsed) {
         spi->ctrl2 |= MXC_S_SPI_REVA_CTRL2_DATA_WIDTH_QUAD;
     }
+
+    return E_NO_ERROR;
+}
+
+int MXC_SPI_RevA1_InitState(mxc_spi_reva_regs_t *spi)
+{
+    int spi_num = MXC_SPI_GET_IDX((mxc_spi_regs_t *)spi);
+    /*  Validate that the specified SPI instance exists.
+        Note:  The Init function is the only one that performs this check.
+        It catches the rare edge case where a user has casted
+        a custom SPI regs struct with an incorrect base address.
+     */
+    if (spi_num < 0)
+        return E_BAD_PARAM;
+
+    states[spi_num].req = NULL;
+    states[spi_num].last_size = 0;
+    states[spi_num].ssDeassert = 1;
+    states[spi_num].defaultTXData = 0;
+    states[spi_num].mtMode = 0;
+    states[spi_num].mtFirstTrans = 0;
+    states[spi_num].channelTx = E_NO_DEVICE;
+    states[spi_num].channelRx = E_NO_DEVICE;
+    states[spi_num].hw_ss_control = true;
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.h
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.h
@@ -69,6 +69,7 @@ struct _mxc_spi_reva_req_t {
 
 int MXC_SPI_RevA1_Init(mxc_spi_reva_regs_t *spi, int masterMode, int quadModeUsed, int numSlaves,
                        unsigned ssPolarity, unsigned int hz);
+int MXC_SPI_RevA1_InitState(mxc_spi_reva_regs_t *spi);
 int MXC_SPI_RevA1_Shutdown(mxc_spi_reva_regs_t *spi);
 int MXC_SPI_RevA1_ReadyForSleep(mxc_spi_reva_regs_t *spi);
 int MXC_SPI_RevA1_SetFrequency(mxc_spi_reva_regs_t *spi, unsigned int hz);


### PR DESCRIPTION
### Description

Zephyr's SPI driver needs to reset/initialize the SPI peripheral, but the MXC_SPI_Init API has require parameter not available during device initialization. To ensure the internal state is correct before the Zephyr driver calls MXC_SPI_Shutdown, add a new API to properly initialize state first.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.