### PR TITLE
fix(PeriphDrivers): Fix clock speed configuration of SPI3 for MAX32650

### DIFF
--- a/Libraries/PeriphDrivers/Source/SPI/spi_me10.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me10.c
@@ -123,9 +123,7 @@ int MXC_SPI_ReadyForSleep(mxc_spi_regs_t *spi)
 /* ************************************************************************ */
 int MXC_SPI_GetPeripheralClock(mxc_spi_regs_t *spi)
 {
-    if (MXC_SPI_GET_IDX(spi) == 3) {
-        return PeripheralClock * 2;
-    } else if (MXC_SPI_GET_IDX(spi) != -1) {
+    if (MXC_SPI_GET_IDX(spi) != -1) {
         return PeripheralClock;
     } else {
         return E_BAD_PARAM;


### PR DESCRIPTION
### Description

spi_me10.c assumes the SPI3 peripheral clock is twice the frequency as other SPI instances. Looking at the [MAX32650 UG](https://www.analog.com/media/en/technical-documentation/user-guides/max32650max32652-user-guide.pdf) there is no indication SPI3 peripheral clock is twice the frequency.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.