### PR TITLE
fix(Build): Share multi core data 7800x when using RISCV_LOAD

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/common.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/common.ld
@@ -1,5 +1,6 @@
 /* Shared RISC-V and ARM memory map */
 _FlashLength_ =  __FlashLength;
+
 MEMORY {
     ROM     (rx)  : ORIGIN = 0x00000000, LENGTH = 0x00010000 /* 64kB - ROM */
     
@@ -9,8 +10,14 @@ MEMORY {
 
     SRAM1   (rwx) : ORIGIN = 0x20008000, LENGTH = 0x00008000 /* 32 kB - ARM Stack */
     
-    SRAM2   (rwx) : ORIGIN = 0x20010000, LENGTH = 0x0000C000 /* 48kB SRAM2 - RV Data */
+    SRAM2   (rwx) : ORIGIN = 0x20010000, LENGTH = 0x0000BFF8 /* ~48kB SRAM2 - RV Data */
+
+    SHARED  (rw)  : ORIGIN = 0x2001BFF8, LENGTH = 0x00000008 /* 8B Shared - ARM, RV Data */
     
     SRAM3   (rwx) : ORIGIN = 0x2001C000, LENGTH = 0x00004000 /* 16kB SRAM3 - RV Code */
 }
+
+/* The address and length of the SHARED section defined above. */
+__shared_origin = ORIGIN(SHARED);
+__shared_length = LENGTH(SHARED);
 

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/max78000.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/max78000.ld
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,13 @@
 MEMORY {
     ROM        (rx) : ORIGIN = 0x00000000, LENGTH = 0x00010000 /* 64kB ROM */
     FLASH      (rx) : ORIGIN = 0x10000000, LENGTH = 0x00080000 /* 512KB Flash */
-    SRAM      (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00020000 /* 128kB SRAM */
+    SRAM      (rwx) : ORIGIN = 0x20000000, LENGTH = 0x0001FFF8 /* ~128KB SRAM */
+    SHARED     (rw) : ORIGIN = 0x2001FFF8, LENGTH = 0x00000008 /* 8B Shared */
 }
+
+/* The address and length of the SHARED section defined above. */
+__shared_origin = ORIGIN(SHARED);
+__shared_length = LENGTH(SHARED);
 
 SECTIONS {
     .rom :
@@ -149,7 +154,15 @@ SECTIONS {
         _ebss = ALIGN(., 4);
     } > SRAM
 
-    .shared :
+    /* We map the .shared section to a symbol rather than >SHARED to allow for backwards compatibility in CFS
+     * with older projects that did not provide SHARED (note that CFS replaces the MEMORY command at the top of
+     * this file). In that case, we just map to the end of memory.
+     * We add an assert to ensure that the section fits in the available space.
+     */
+    PROVIDE(__shared_origin = 0x2001FFF8);
+    PROVIDE(__shared_length = 8);
+
+    .shared __shared_origin (NOLOAD) :
     {
         . = ALIGN(4);
         _shared = .;
@@ -157,8 +170,10 @@ SECTIONS {
         . = ALIGN(4);
         *(.shared*)     /*read-write zero initialized data: uninitialzed global variable*/
         _eshared = ALIGN(., 4);
-    } > SRAM AT>FLASH
+    }
     __shared_data = LOADADDR(.shared);
+
+    ASSERT(SIZEOF(.shared) <= __shared_length, ".shared section overflow: exceeds inter-core shared memory region")
 
     /* Set stack top to end of RAM, and stack limit move down by
      * size of stack_dummy section */

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/max78000_arm.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/max78000_arm.ld
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ SECTIONS {
      * aligned to mod 256 address... REQUIRED                  */
     __FlashStart_ =  (((LOADADDR(.data) + SIZEOF(.data)) & 0x1FFFFF00) + 0x100);
 
-    .shared :
+    .shared (NOLOAD) :
     {
         . = ALIGN(4);
         _shared = .;
@@ -70,7 +70,7 @@ SECTIONS {
         . = ALIGN(4);
         *(.shared*)     /*read-write zero initialized data: uninitialzed global variable*/
         _eshared = ALIGN(., 4);
-    } > SRAM2 AT>FLASH
+    } > SHARED
     __shared_data = LOADADDR(.shared);
 
     .data :

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/max78000_riscv.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/max78000_riscv.ld
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,15 @@ SECTIONS {
         _etext = .;
     } > FLASH
 
-    .shared (NOLOAD) : /* CM4 loads this section from flash in startup code */
+    /* We map the .shared section to a symbol rather than >SHARED to allow for backwards compatibility in CFS
+     * with older projects that did not provide SHARED (note that CFS replaces the MEMORY command at the top of
+     * this file). In that case, we just map to the end of memory.
+     * We add an assert to ensure that the section fits in the available space.
+     */
+    PROVIDE(__shared_origin = 0x2001FFF8);
+    PROVIDE(__shared_length = 8);
+
+    .shared __shared_origin (NOLOAD) :
     {
         . = ALIGN(4);
         _shared = .;
@@ -48,7 +56,8 @@ SECTIONS {
         . = ALIGN(4);
         *(.shared*)     /*read-write zero initialized data: uninitialzed global variable*/
         _eshared = ALIGN(., 4);
-    } > SRAM2
+    }
+    ASSERT(SIZEOF(.shared) <= __shared_length, ".shared section overflow: exceeds inter-core shared memory region")
 
     /* short/global data section */
     .sdata :

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Source/GCC/common.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Source/GCC/common.ld
@@ -1,5 +1,6 @@
 /* Shared RISC-V and ARM memory map */
 _FlashLength_ =  __FlashLength;
+
 MEMORY {
     ROM     (rx)  : ORIGIN = 0x00000000, LENGTH = 0x00010000 /* 64kB - ROM */
     
@@ -15,10 +16,16 @@ MEMORY {
 
     SRAM4   (rwx) : ORIGIN = 0x20030000, LENGTH = 0x00010000 /* 64kB SRAM4 - RV, ARM */
 
-    SRAM5   (rwx) : ORIGIN = 0x20040000, LENGTH = 0x00010000 /* 64kB SRAM5 - RV, ARM */
+    SRAM5   (rwx) : ORIGIN = 0x20040000, LENGTH = 0x00010000 /* ~64kB SRAM5 - RV, ARM */
+
+    SHARED  (rw)  : ORIGIN = 0x2004FFF8, LENGTH = 0x00000008 /* 8B Shared - RV, ARM */
 
     SRAM6   (rwx) : ORIGIN = 0x20050000, LENGTH = 0x0000C000 /* 48kB SRAM6 - RV, ARM */
 
     SRAM7   (rwx) : ORIGIN = 0x2005C000, LENGTH = 0x00004000 /* 16kB SRAM7 - RV, ICC1, or ARM */
 }
+
+/* The address and length of the SHARED section defined above. */
+__shared_origin = ORIGIN(SHARED);
+__shared_length = LENGTH(SHARED);
 

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Source/GCC/max78002.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Source/GCC/max78002.ld
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,14 @@
 MEMORY {
     ROM (rx)   : ORIGIN = 0x00000000, LENGTH = 0x00010000 /* 64 kB ROM */
     FLASH (rx) : ORIGIN = 0x10000000, LENGTH = 0x00280000 /* 2.5 MB Flash */
-    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00060000 /* 384 kB SRAM */
+    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x0005FFF8 /* ~384kB SRAM */
+    SHARED (rw)  : ORIGIN = 0x2005FFF8, LENGTH = 0x00000008 /* 8B Shared */
     /*CSI2 (rwx) : ORIGIN = 0x2001F000, LENGTH = 0x00001000 4096 B CSI2 Buffer */
 }
+
+/* The address and length of the SHARED section defined above. */
+__shared_origin = ORIGIN(SHARED);
+__shared_length = LENGTH(SHARED);
 
 SECTIONS {
     .rom :
@@ -152,7 +157,15 @@ SECTIONS {
         _ebss = ALIGN(., 4);
     } > SRAM
 
-    .shared :
+    /* We map the .shared section to a symbol rather than >SHARED to allow for backwards compatibility in CFS
+     * with older projects that did not provide SHARED (note that CFS replaces the MEMORY command at the top of
+     * this file). In that case, we just map to the end of memory.
+     * We add an assert to ensure that the section fits in the available space.
+     */
+    PROVIDE(__shared_origin = 0x2005FFF8);
+    PROVIDE(__shared_length = 8);
+
+    .shared __shared_origin (NOLOAD) :
     {
         . = ALIGN(4);
         _shared = .;
@@ -160,8 +173,10 @@ SECTIONS {
         . = ALIGN(4);
         *(.shared*)     /*read-write zero initialized data: uninitialzed global variable*/
         _eshared = ALIGN(., 4);
-    } > SRAM
+    }
     __shared_data = LOADADDR(.shared);
+
+    ASSERT(SIZEOF(.shared) <= __shared_length, ".shared section overflow: exceeds inter-core shared memory region")
 
     /* Set stack top to end of RAM, and stack limit move down by
      * size of stack_dummy section */

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Source/GCC/max78002_arm.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Source/GCC/max78002_arm.ld
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ SECTIONS {
      * aligned to mod 256 address... REQUIRED                  */
     __FlashStart_ =  (((LOADADDR(.data) + SIZEOF(.data)) & 0x1FFFFF00) + 0x100);
 
-    .shared :
+    .shared (NOLOAD) :
     {
         . = ALIGN(4);
         _shared = .;
@@ -60,7 +60,7 @@ SECTIONS {
         . = ALIGN(4);
         *(.shared*)     /*read-write zero initialized data: uninitialzed global variable*/
         _eshared = ALIGN(., 4);
-    } > SRAM5 AT>FLASH
+    } > SHARED
     __shared_data = LOADADDR(.shared);
 
     .data :

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Source/GCC/max78002_riscv.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Source/GCC/max78002_riscv.ld
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,15 @@ SECTIONS {
         _etext = .;
     } > FLASH
 
-    .shared (NOLOAD) : /* CM4 loads this section from flash in startup code */
+    /* We map the .shared section to a symbol rather than >SHARED to allow for backwards compatibility in CFS
+     * with older projects that did not provide SHARED (note that CFS replaces the MEMORY command at the top of
+     * this file). In that case, we just map to the end of memory.
+     * We add an assert to ensure that the section fits in the available space.
+     */
+    PROVIDE(__shared_origin = 0x2005FFF8);
+    PROVIDE(__shared_length = 8);
+
+    .shared __shared_origin (NOLOAD) :
     {
         . = ALIGN(4);
         _shared = .;
@@ -48,7 +56,8 @@ SECTIONS {
         . = ALIGN(4);
         *(.shared*)     /*read-write zero initialized data: uninitialzed global variable*/
         _eshared = ALIGN(., 4);
-    } > SRAM5
+    }
+    ASSERT(SIZEOF(.shared) <= __shared_length, ".shared section overflow: exceeds inter-core shared memory region")
 
     /* short/global data section */
     .sdata :


### PR DESCRIPTION
### Description

The SystemCoreClock variable, placed into the .shared section, was only placed at identical addresses in the Cortex and RISC-V projects when using the _arm.ld and _rv ld scripts together. When using the max7800x.ld script and the RISCV_LOAD mechanism, the variable was placed at different addresses in both executables.

Fix this, by creating a SHARED memory region and placing the data there.

Note that there is a subtlety with how I do this: in CFS, we remove the MEMORY command from these .ld scripts and CFS provides it. Since old CFS projects won't have the SHARED memory region, we would get a link error if we map to that directly. So instead, define a symbol to that address, and map to that address instead. Use an assertion to check the data fits. Then, for old projects, we'll map the variable right to the end of memory if SHARED is not defined, otherwise CFS will provide the symbols with the address of the SHARED region defined there.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.