### PR TITLE
fix(Other): Enabled ICC with Zephyr on MAX32660, MAX32662, MAX32670, MAX32672, MAX32675, MAX78000, and MAX78002

### DIFF
--- a/Libraries/zephyr/MAX/Source/MAX32660/max32xxx_system.c
+++ b/Libraries/zephyr/MAX/Source/MAX32660/max32xxx_system.c
@@ -19,6 +19,7 @@
 #include "max32660.h"
 #include "mxc_sys.h"
 #include "wdt_regs.h"
+#include "icc.h"
 
 /* 
  * This function is called during boot up.
@@ -39,4 +40,7 @@ void max32xx_system_init(void)
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TMR1);
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TMR2);
     MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_I2C1);
+
+    /* Enable instruction caching */
+    MXC_ICC_Enable();
 }

--- a/Libraries/zephyr/MAX/Source/MAX32662/max32xxx_system.c
+++ b/Libraries/zephyr/MAX/Source/MAX32662/max32xxx_system.c
@@ -17,8 +17,13 @@
  ******************************************************************************/
 
 #include "max32662.h"
+#include "icc.h"
 
 /* 
  * This function is called during boot up.
  */
-void max32xx_system_init(void) {}
+void max32xx_system_init(void)
+{
+    /* Enable instruction caching */
+    MXC_ICC_Enable();
+}

--- a/Libraries/zephyr/MAX/Source/MAX32670/max32xxx_system.c
+++ b/Libraries/zephyr/MAX/Source/MAX32670/max32xxx_system.c
@@ -20,6 +20,7 @@
 #include "pwrseq_regs.h"
 #include "mxc_sys.h"
 #include "ecc_regs.h"
+#include "icc.h"
 
 /* 
  * This function is called during boot up.
@@ -31,4 +32,7 @@ void max32xx_system_init(void)
 
     /* Make sure INRO is enabled. INRO should already be enabled during power up. */
     MXC_PWRSEQ->lpcn |= MXC_F_PWRSEQ_LPCN_INRO_EN;
+
+    /* Enable instruction caching */
+    MXC_ICC_Enable();
 }

--- a/Libraries/zephyr/MAX/Source/MAX32672/max32xxx_system.c
+++ b/Libraries/zephyr/MAX/Source/MAX32672/max32xxx_system.c
@@ -18,6 +18,7 @@
 
 #include "max32672.h"
 #include "trimsir_regs.h"
+#include "icc.h"
 
 /* 
  * This function is called during boot up.
@@ -27,4 +28,7 @@ void max32xx_system_init(void)
     /* Disable SRAM ECC until it is handled on zephyr side */
     MXC_TRIMSIR->bb_sir2 &= ~(MXC_F_TRIMSIR_BB_SIR2_RAM0_1ECCEN | MXC_F_TRIMSIR_BB_SIR2_RAM2ECCEN |
                               MXC_F_TRIMSIR_BB_SIR2_RAM3ECCEN);
+
+    /* Enable instruction caching */
+    MXC_ICC_Enable();
 }

--- a/Libraries/zephyr/MAX/Source/MAX32675/max32xxx_system.c
+++ b/Libraries/zephyr/MAX/Source/MAX32675/max32xxx_system.c
@@ -18,6 +18,7 @@
 
 #include "max32675.h"
 #include "ecc_regs.h"
+#include "icc.h"
 
 /* 
  * This function is called during boot up.
@@ -26,4 +27,7 @@ void max32xx_system_init(void)
 {
     /* Disable SRAM ECC until it is handled on zephyr side */
     MXC_ECC->en &= ~MXC_F_ECC_EN_SRAM;
+
+    /* Enable instruction caching */
+    MXC_ICC_Enable();
 }

--- a/Libraries/zephyr/MAX/Source/MAX78000/max78xxx_system.c
+++ b/Libraries/zephyr/MAX/Source/MAX78000/max78xxx_system.c
@@ -24,5 +24,10 @@
  */
 void max32xx_system_init(void)
 {
+#ifndef CONFIG_SOC_MAX78000_RV32
+
+    /* Enable instruction caching */
     MXC_ICC_Enable(MXC_ICC0);
+
+#endif
 }

--- a/Libraries/zephyr/MAX/Source/MAX78002/max78xxx_system.c
+++ b/Libraries/zephyr/MAX/Source/MAX78002/max78xxx_system.c
@@ -17,8 +17,17 @@
  ******************************************************************************/
 
 #include "max78002.h"
+#include "icc.h"
 
 /* 
  * This function is called during boot up.
  */
-void max32xx_system_init(void) {}
+void max32xx_system_init(void)
+{
+#ifndef CONFIG_SOC_MAX78002_RV32
+
+    /* Enable instruction caching */
+    MXC_ICC_Enable(MXC_ICC0);
+
+#endif
+}


### PR DESCRIPTION
### Description

MAX32660, MAX32662, MAX32670, MAX32672, MAX32675 and MAX78002 do not natively enable ICC in Zephyr. Discovered while implementing time-critical firmware on MAX32672 in Zephyr, where kernel latency was significantly longer than expected. Fixed by calling `MXC_ICC_ENABLE` inside `max32xx_system_init` on all missing controllers. This is consistent with controllers that already have ICC enablement (i.e. [MAX32655](https://github.com/analogdevicesinc/msdk/blob/main/Libraries/zephyr/MAX/Source/MAX32655/max32xxx_system.c#L59-L60), [MAX78000](https://github.com/analogdevicesinc/msdk/blob/main/Libraries/zephyr/MAX/Source/MAX78000/max78xxx_system.c#L27)).

Fix was run with `tests/benchmarks/latency_measure` on `max32672evkit` and `max32662evkit.` Code seems to be building on `max32660evsys`,  `max32672evkit`, `max32675evkit`, and `max78002evkit/max78002/m4` though I don't have HW to verify performance improvement.

ICC enablement is critical for good performance during application execution. Disabling this leads to repeated flash wait states, causing kernel performance to degrade significantly. From looking at the user guide, this means up to 5 clock cycles are wasted on every instruction fetch when using MAX32672 on Zephyr with default flash wait state. Enabling ICC led to ~2x-3.5x performance increase on `tests/benchmarks/latency_measure` generally across the board on MAX32662 and MAX32672.

#### MAX32672
No ICC
```
*** Booting Zephyr OS build 4b950510da4d ***
thread.yield.preemptive.ctx.k_to_k       - Context switch via k_yield                         :     713 cycles ,     7137 ns :
thread.yield.cooperative.ctx.k_to_k      - Context switch via k_yield                         :     713 cycles ,     7137 ns :
isr.resume.interrupted.thread.kernel     - Return from ISR to interrupted thread              :     594 cycles ,     5945 ns :
isr.resume.different.thread.kernel       - Return from ISR to another thread                  :     841 cycles ,     8415 ns :
thread.create.kernel.from.kernel         - Create thread                                      :     769 cycles ,     7695 ns :
thread.start.kernel.from.kernel          - Start thread                                       :    1240 cycles ,    12405 ns :
thread.suspend.kernel.from.kernel        - Suspend thread                                     :     736 cycles ,     7365 ns :
thread.resume.kernel.from.kernel         - Resume thread                                      :     830 cycles ,     8305 ns :
thread.abort.kernel.from.kernel          - Abort thread                                       :     842 cycles ,     8425 ns :
fifo.put.immediate.kernel                - Add data to FIFO (no ctx switch)                   :  168125 cycles ,  1681251 ns :
fifo.get.immediate.kernel                - Get data from FIFO (no ctx switch)                 :     270 cycles ,     2705 ns :
fifo.put.alloc.immediate.kernel          - Allocate to add data to FIFO (no ctx switch)       :    1992 cycles ,    19920 ns :
fifo.get.free.immediate.kernel           - Free when getting data from FIFO (no ctx switch)   :    1749 cycles ,    17490 ns :
fifo.get.blocking.k_to_k                 - Get data from FIFO (w/ ctx switch)                 :    1668 cycles ,    16689 ns :
fifo.put.wake+ctx.k_to_k                 - Add data to FIFO (w/ ctx switch)                   :    1824 cycles ,    18240 ns :
fifo.get.free.blocking.k_to_k            - Free when getting data from FIFO (w/ ctx switch)   :  169436 cycles ,  1694366 ns :
fifo.put.alloc.wake+ctx.k_to_k           - Allocate to add data to FIFO (w/ ctx switch)       :    1835 cycles ,    18350 ns :
lifo.put.immediate.kernel                - Add data to LIFO (no ctx switch)                   :     350 cycles ,     3505 ns :
lifo.get.immediate.kernel                - Get data from LIFO (no ctx switch)                 :     271 cycles ,     2715 ns :
lifo.put.alloc.immediate.kernel          - Allocate to add data to LIFO (no ctx switch)       :    1996 cycles ,    19960 ns :
lifo.get.free.immediate.kernel           - Free when getting data from LIFO (no ctx switch)   :    1790 cycles ,    17900 ns :
lifo.get.blocking.k_to_k                 - Get data from LIFO (w/ ctx switch)                 :    1659 cycles ,    16599 ns :
lifo.put.wake+ctx.k_to_k                 - Add data to LIFO (w/ ctx switch)                   :    1805 cycles ,    18050 ns :
lifo.get.free.blocking.k_to_k            - Free when getting data from LIFO (w/ ctx switch)   :    1683 cycles ,    16830 ns :
lifo.put.alloc.wake+ctx.k_to_k           - Allocate to add data to LIFO (w/ ctx switch)       :    1821 cycles ,    18210 ns :
events.post.immediate.kernel             - Post events (nothing wakes)                        :     507 cycles ,     5074 ns :
events.set.immediate.kernel              - Set events (nothing wakes)                         :  168312 cycles ,  1683120 ns :
events.wait.immediate.kernel             - Wait for any events (no ctx switch)                :     383 cycles ,     3835 ns :
events.wait_all.immediate.kernel         - Wait for all events (no ctx switch)                :     368 cycles ,     3685 ns :
events.wait.blocking.k_to_k              - Wait for any events (w/ ctx switch)                :    1304 cycles ,    13044 ns :
events.set.wake+ctx.k_to_k               - Set events (w/ ctx switch)                         :    1846 cycles ,    18465 ns :
events.wait_all.blocking.k_to_k          - Wait for all events (w/ ctx switch)                :    1754 cycles ,    17541 ns :
events.post.wake+ctx.k_to_k              - Post events (w/ ctx switch)                        :    2328 cycles ,    23280 ns :
semaphore.give.immediate.kernel          - Give a semaphore (no waiters)                      :     221 cycles ,     2215 ns :
semaphore.take.immediate.kernel          - Take a semaphore (no blocking)                     :     354 cycles ,     3544 ns :
semaphore.take.blocking.k_to_k           - Take a semaphore (context switch)                  :    1219 cycles ,    12197 ns :
semaphore.give.wake+ctx.k_to_k           - Give a semaphore (context switch)                  :    1284 cycles ,    12845 ns :
condvar.wait.blocking.k_to_k             - Wait for a condvar (context switch)                :    1976 cycles ,    19761 ns :
condvar.signal.wake+ctx.k_to_k           - Signal a condvar (context switch)                  :  169796 cycles ,  1697966 ns :
stack.push.immediate.kernel              - Add data to k_stack (no ctx switch)                :     219 cycles ,     2195 ns :
stack.pop.immediate.kernel               - Get data from k_stack (no ctx switch)              :     172 cycles ,     1725 ns :
stack.pop.blocking.k_to_k                - Get data from k_stack (w/ ctx switch)              :    1586 cycles ,    15869 ns :
stack.push.wake+ctx.k_to_k               - Add data to k_stack (w/ ctx switch)                :    1787 cycles ,    17870 ns :
mutex.lock.immediate.recursive.kernel    - Lock a mutex                                       :     342 cycles ,     3424 ns :
mutex.unlock.immediate.recursive.kernel  - Unlock a mutex                                     :     234 cycles ,     2346 ns :
heap.malloc.immediate                    - Average time for heap malloc                       :    1474 cycles ,    14740 ns :
heap.free.immediate                      - Average time for heap free                         :    1442 cycles ,    14420 ns :
===================================================================
PROJECT EXECUTION SUCCESSFUL
```
With ICC patch
```
*** Booting Zephyr OS build 4b950510da4d ***
thread.yield.preemptive.ctx.k_to_k       - Context switch via k_yield                         :     308 cycles ,     3089 ns :
thread.yield.cooperative.ctx.k_to_k      - Context switch via k_yield                         :     308 cycles ,     3089 ns :
isr.resume.interrupted.thread.kernel     - Return from ISR to interrupted thread              :     267 cycles ,     2679 ns :
isr.resume.different.thread.kernel       - Return from ISR to another thread                  :     361 cycles ,     3618 ns :
thread.create.kernel.from.kernel         - Create thread                                      :     372 cycles ,     3728 ns :
thread.start.kernel.from.kernel          - Start thread                                       :     454 cycles ,     4548 ns :
thread.suspend.kernel.from.kernel        - Suspend thread                                     :     286 cycles ,     2869 ns :
thread.resume.kernel.from.kernel         - Resume thread                                      :     344 cycles ,     3448 ns :
thread.abort.kernel.from.kernel          - Abort thread                                       :     260 cycles ,     2608 ns :
fifo.put.immediate.kernel                - Add data to FIFO (no ctx switch)                   :  167925 cycles ,  1679256 ns :
fifo.get.immediate.kernel                - Get data from FIFO (no ctx switch)                 :     129 cycles ,     1299 ns :
fifo.put.alloc.immediate.kernel          - Allocate to add data to FIFO (no ctx switch)       :     750 cycles ,     7501 ns :
fifo.get.free.immediate.kernel           - Free when getting data from FIFO (no ctx switch)   :     663 cycles ,     6630 ns :
fifo.get.blocking.k_to_k                 - Get data from FIFO (w/ ctx switch)                 :     595 cycles ,     5950 ns :
fifo.put.wake+ctx.k_to_k                 - Add data to FIFO (w/ ctx switch)                   :     678 cycles ,     6780 ns :
fifo.get.free.blocking.k_to_k            - Free when getting data from FIFO (w/ ctx switch)   :     597 cycles ,     5970 ns :
fifo.put.alloc.wake+ctx.k_to_k           - Allocate to add data to FIFO (w/ ctx switch)       :     677 cycles ,     6770 ns :
lifo.put.immediate.kernel                - Add data to LIFO (no ctx switch)                   :     149 cycles ,     1498 ns :
lifo.get.immediate.kernel                - Get data from LIFO (no ctx switch)                 :     129 cycles ,     1298 ns :
lifo.put.alloc.immediate.kernel          - Allocate to add data to LIFO (no ctx switch)       :     748 cycles ,     7480 ns :
lifo.get.free.immediate.kernel           - Free when getting data from LIFO (no ctx switch)   :     663 cycles ,     6630 ns :
lifo.get.blocking.k_to_k                 - Get data from LIFO (w/ ctx switch)                 :     595 cycles ,     5950 ns :
lifo.put.wake+ctx.k_to_k                 - Add data to LIFO (w/ ctx switch)                   :     675 cycles ,     6750 ns :
lifo.get.free.blocking.k_to_k            - Free when getting data from LIFO (w/ ctx switch)   :     597 cycles ,     5970 ns :
lifo.put.alloc.wake+ctx.k_to_k           - Allocate to add data to LIFO (w/ ctx switch)       :     675 cycles ,     6750 ns :
events.post.immediate.kernel             - Post events (nothing wakes)                        :     222 cycles ,     2221 ns :
events.set.immediate.kernel              - Set events (nothing wakes)                         :     221 cycles ,     2211 ns :
events.wait.immediate.kernel             - Wait for any events (no ctx switch)                :     139 cycles ,     1391 ns :
events.wait_all.immediate.kernel         - Wait for all events (no ctx switch)                :     139 cycles ,     1391 ns :
events.wait.blocking.k_to_k              - Wait for any events (w/ ctx switch)                :     519 cycles ,     5198 ns :
events.set.wake+ctx.k_to_k               - Set events (w/ ctx switch)                         :     750 cycles ,     7509 ns :
events.wait_all.blocking.k_to_k          - Wait for all events (w/ ctx switch)                :     642 cycles ,     6420 ns :
events.post.wake+ctx.k_to_k              - Post events (w/ ctx switch)                        :     867 cycles ,     8670 ns :
semaphore.give.immediate.kernel          - Give a semaphore (no waiters)                      :      77 cycles ,      771 ns :
semaphore.take.immediate.kernel          - Take a semaphore (no blocking)                     :      90 cycles ,      901 ns :
semaphore.take.blocking.k_to_k           - Take a semaphore (context switch)                  :     453 cycles ,     4539 ns :
semaphore.give.wake+ctx.k_to_k           - Give a semaphore (context switch)                  :     500 cycles ,     5008 ns :
condvar.wait.blocking.k_to_k             - Wait for a condvar (context switch)                :     691 cycles ,     6910 ns :
condvar.signal.wake+ctx.k_to_k           - Signal a condvar (context switch)                  :  168494 cycles ,  1684947 ns :
stack.push.immediate.kernel              - Add data to k_stack (no ctx switch)                :      94 cycles ,      949 ns :
stack.pop.immediate.kernel               - Get data from k_stack (no ctx switch)              :     100 cycles ,     1009 ns :
stack.pop.blocking.k_to_k                - Get data from k_stack (w/ ctx switch)              :     585 cycles ,     5850 ns :
stack.push.wake+ctx.k_to_k               - Add data to k_stack (w/ ctx switch)                :     647 cycles ,     6470 ns :
mutex.lock.immediate.recursive.kernel    - Lock a mutex                                       :     112 cycles ,     1121 ns :
mutex.unlock.immediate.recursive.kernel  - Unlock a mutex                                     :      63 cycles ,      631 ns :
heap.malloc.immediate                    - Average time for heap malloc                       :     542 cycles ,     5420 ns :
heap.free.immediate                      - Average time for heap free                         :     531 cycles ,     5315 ns :
===================================================================
PROJECT EXECUTION SUCCESSFUL
```

#### MAX32662
No ICC
```
*** Booting Zephyr OS build 4b950510da4d ***
thread.yield.preemptive.ctx.k_to_k       - Context switch via k_yield                         :     749 cycles ,     7497 ns :
thread.yield.cooperative.ctx.k_to_k      - Context switch via k_yield                         :     749 cycles ,     7497 ns :
isr.resume.interrupted.thread.kernel     - Return from ISR to interrupted thread              :     555 cycles ,     5555 ns :
isr.resume.different.thread.kernel       - Return from ISR to another thread                  :     768 cycles ,     7685 ns :
thread.create.kernel.from.kernel         - Create thread                                      :     882 cycles ,     8825 ns :
thread.start.kernel.from.kernel          - Start thread                                       :    1233 cycles ,    12335 ns :
thread.suspend.kernel.from.kernel        - Suspend thread                                     :     700 cycles ,     7005 ns :
thread.resume.kernel.from.kernel         - Resume thread                                      :  168629 cycles ,  1686292 ns :
thread.abort.kernel.from.kernel          - Abort thread                                       :     875 cycles ,     8755 ns :
fifo.put.immediate.kernel                - Add data to FIFO (no ctx switch)                   :  168104 cycles ,  1681042 ns :
fifo.get.immediate.kernel                - Get data from FIFO (no ctx switch)                 :     204 cycles ,     2045 ns :
fifo.put.alloc.immediate.kernel          - Allocate to add data to FIFO (no ctx switch)       :    2012 cycles ,    20120 ns :
fifo.get.free.immediate.kernel           - Free when getting data from FIFO (no ctx switch)   :    1682 cycles ,    16820 ns :
fifo.get.blocking.k_to_k                 - Get data from FIFO (w/ ctx switch)                 :    1623 cycles ,    16239 ns :
fifo.put.wake+ctx.k_to_k                 - Add data to FIFO (w/ ctx switch)                   :    1823 cycles ,    18230 ns :
fifo.get.free.blocking.k_to_k            - Free when getting data from FIFO (w/ ctx switch)   :  169407 cycles ,  1694076 ns :
fifo.put.alloc.wake+ctx.k_to_k           - Allocate to add data to FIFO (w/ ctx switch)       :    1838 cycles ,    18380 ns :
lifo.put.immediate.kernel                - Add data to LIFO (no ctx switch)                   :     343 cycles ,     3435 ns :
lifo.get.immediate.kernel                - Get data from LIFO (no ctx switch)                 :     206 cycles ,     2065 ns :
lifo.put.alloc.immediate.kernel          - Allocate to add data to LIFO (no ctx switch)       :    2004 cycles ,    20040 ns :
lifo.get.free.immediate.kernel           - Free when getting data from LIFO (no ctx switch)   :    1724 cycles ,    17240 ns :
lifo.get.blocking.k_to_k                 - Get data from LIFO (w/ ctx switch)                 :    1598 cycles ,    15989 ns :
lifo.put.wake+ctx.k_to_k                 - Add data to LIFO (w/ ctx switch)                   :    1835 cycles ,    18350 ns :
lifo.get.free.blocking.k_to_k            - Free when getting data from LIFO (w/ ctx switch)   :    1642 cycles ,    16420 ns :
lifo.put.alloc.wake+ctx.k_to_k           - Allocate to add data to LIFO (w/ ctx switch)       :    1839 cycles ,    18390 ns :
events.post.immediate.kernel             - Post events (nothing wakes)                        :     570 cycles ,     5704 ns :
events.set.immediate.kernel              - Set events (nothing wakes)                         :     604 cycles ,     6044 ns :
events.wait.immediate.kernel             - Wait for any events (no ctx switch)                :  168104 cycles ,  1681040 ns :
events.wait_all.immediate.kernel         - Wait for all events (no ctx switch)                :     332 cycles ,     3324 ns :
events.wait.blocking.k_to_k              - Wait for any events (w/ ctx switch)                :    1262 cycles ,    12625 ns :
events.set.wake+ctx.k_to_k               - Set events (w/ ctx switch)                         :    1881 cycles ,    18815 ns :
events.wait_all.blocking.k_to_k          - Wait for all events (w/ ctx switch)                :    1687 cycles ,    16871 ns :
events.post.wake+ctx.k_to_k              - Post events (w/ ctx switch)                        :    2305 cycles ,    23050 ns :
semaphore.give.immediate.kernel          - Give a semaphore (no waiters)                      :     231 cycles ,     2314 ns :
semaphore.take.immediate.kernel          - Take a semaphore (no blocking)                     :     334 cycles ,     3344 ns :
semaphore.take.blocking.k_to_k           - Take a semaphore (context switch)                  :    1183 cycles ,    11837 ns :
semaphore.give.wake+ctx.k_to_k           - Give a semaphore (context switch)                  :    1338 cycles ,    13385 ns :
condvar.wait.blocking.k_to_k             - Wait for a condvar (context switch)                :  169722 cycles ,  1697227 ns :
condvar.signal.wake+ctx.k_to_k           - Signal a condvar (context switch)                  :    2043 cycles ,    20430 ns :
stack.push.immediate.kernel              - Add data to k_stack (no ctx switch)                :     231 cycles ,     2315 ns :
stack.pop.immediate.kernel               - Get data from k_stack (no ctx switch)              :     167 cycles ,     1675 ns :
stack.pop.blocking.k_to_k                - Get data from k_stack (w/ ctx switch)              :    1543 cycles ,    15439 ns :
stack.push.wake+ctx.k_to_k               - Add data to k_stack (w/ ctx switch)                :    1796 cycles ,    17960 ns :
mutex.lock.immediate.recursive.kernel    - Lock a mutex                                       :     312 cycles ,     3124 ns :
mutex.unlock.immediate.recursive.kernel  - Unlock a mutex                                     :     203 cycles ,     2036 ns :
heap.malloc.immediate                    - Average time for heap malloc                       :    1449 cycles ,    14490 ns :
heap.free.immediate                      - Average time for heap free                         :    1420 cycles ,    14200 ns :
===================================================================
PROJECT EXECUTION SUCCESSFUL
```
With ICC patch
```
*** Booting Zephyr OS build 4b950510da4d ***
thread.yield.preemptive.ctx.k_to_k       - Context switch via k_yield                         :     308 cycles ,     3089 ns :
thread.yield.cooperative.ctx.k_to_k      - Context switch via k_yield                         :     308 cycles ,     3089 ns :
isr.resume.interrupted.thread.kernel     - Return from ISR to interrupted thread              :     267 cycles ,     2679 ns :
isr.resume.different.thread.kernel       - Return from ISR to another thread                  :     401 cycles ,     4018 ns :
thread.create.kernel.from.kernel         - Create thread                                      :     372 cycles ,     3728 ns :
thread.start.kernel.from.kernel          - Start thread                                       :     454 cycles ,     4548 ns :
thread.suspend.kernel.from.kernel        - Suspend thread                                     :     286 cycles ,     2869 ns :
thread.resume.kernel.from.kernel         - Resume thread                                      :     344 cycles ,     3448 ns :
thread.abort.kernel.from.kernel          - Abort thread                                       :     260 cycles ,     2608 ns :
fifo.put.immediate.kernel                - Add data to FIFO (no ctx switch)                   :  167925 cycles ,  1679257 ns :
fifo.get.immediate.kernel                - Get data from FIFO (no ctx switch)                 :     129 cycles ,     1299 ns :
fifo.put.alloc.immediate.kernel          - Allocate to add data to FIFO (no ctx switch)       :     750 cycles ,     7502 ns :
fifo.get.free.immediate.kernel           - Free when getting data from FIFO (no ctx switch)   :     663 cycles ,     6630 ns :
fifo.get.blocking.k_to_k                 - Get data from FIFO (w/ ctx switch)                 :     595 cycles ,     5950 ns :
fifo.put.wake+ctx.k_to_k                 - Add data to FIFO (w/ ctx switch)                   :     678 cycles ,     6780 ns :
fifo.get.free.blocking.k_to_k            - Free when getting data from FIFO (w/ ctx switch)   :     597 cycles ,     5970 ns :
fifo.put.alloc.wake+ctx.k_to_k           - Allocate to add data to FIFO (w/ ctx switch)       :     677 cycles ,     6770 ns :
lifo.put.immediate.kernel                - Add data to LIFO (no ctx switch)                   :     149 cycles ,     1499 ns :
lifo.get.immediate.kernel                - Get data from LIFO (no ctx switch)                 :     129 cycles ,     1298 ns :
lifo.put.alloc.immediate.kernel          - Allocate to add data to LIFO (no ctx switch)       :     748 cycles ,     7480 ns :
lifo.get.free.immediate.kernel           - Free when getting data from LIFO (no ctx switch)   :     663 cycles ,     6630 ns :
lifo.get.blocking.k_to_k                 - Get data from LIFO (w/ ctx switch)                 :     595 cycles ,     5950 ns :
lifo.put.wake+ctx.k_to_k                 - Add data to LIFO (w/ ctx switch)                   :     675 cycles ,     6750 ns :
lifo.get.free.blocking.k_to_k            - Free when getting data from LIFO (w/ ctx switch)   :     597 cycles ,     5970 ns :
lifo.put.alloc.wake+ctx.k_to_k           - Allocate to add data to LIFO (w/ ctx switch)       :     675 cycles ,     6750 ns :
events.post.immediate.kernel             - Post events (nothing wakes)                        :     222 cycles ,     2221 ns :
events.set.immediate.kernel              - Set events (nothing wakes)                         :     221 cycles ,     2211 ns :
events.wait.immediate.kernel             - Wait for any events (no ctx switch)                :     139 cycles ,     1391 ns :
events.wait_all.immediate.kernel         - Wait for all events (no ctx switch)                :     139 cycles ,     1391 ns :
events.wait.blocking.k_to_k              - Wait for any events (w/ ctx switch)                :     519 cycles ,     5198 ns :
events.set.wake+ctx.k_to_k               - Set events (w/ ctx switch)                         :     750 cycles ,     7509 ns :
events.wait_all.blocking.k_to_k          - Wait for all events (w/ ctx switch)                :     642 cycles ,     6420 ns :
events.post.wake+ctx.k_to_k              - Post events (w/ ctx switch)                        :     867 cycles ,     8670 ns :
semaphore.give.immediate.kernel          - Give a semaphore (no waiters)                      :      77 cycles ,      771 ns :
semaphore.take.immediate.kernel          - Take a semaphore (no blocking)                     :      90 cycles ,      901 ns :
semaphore.take.blocking.k_to_k           - Take a semaphore (context switch)                  :     453 cycles ,     4539 ns :
semaphore.give.wake+ctx.k_to_k           - Give a semaphore (context switch)                  :     500 cycles ,     5008 ns :
condvar.wait.blocking.k_to_k             - Wait for a condvar (context switch)                :  168463 cycles ,  1684637 ns :
condvar.signal.wake+ctx.k_to_k           - Signal a condvar (context switch)                  :     722 cycles ,     7220 ns :
stack.push.immediate.kernel              - Add data to k_stack (no ctx switch)                :      94 cycles ,      949 ns :
stack.pop.immediate.kernel               - Get data from k_stack (no ctx switch)              :     100 cycles ,     1009 ns :
stack.pop.blocking.k_to_k                - Get data from k_stack (w/ ctx switch)              :     585 cycles ,     5850 ns :
stack.push.wake+ctx.k_to_k               - Add data to k_stack (w/ ctx switch)                :     647 cycles ,     6470 ns :
mutex.lock.immediate.recursive.kernel    - Lock a mutex                                       :     112 cycles ,     1121 ns :
mutex.unlock.immediate.recursive.kernel  - Unlock a mutex                                     :      63 cycles ,      631 ns :
heap.malloc.immediate                    - Average time for heap malloc                       :     541 cycles ,     5419 ns :
heap.free.immediate                      - Average time for heap free                         :     531 cycles ,     5315 ns :
===================================================================
PROJECT EXECUTION SUCCESSFUL
```


### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.