### PR TITLE
fix(PeriphDrivers): Add MXC_SPI_InitState declaration for all parts

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32520/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32520/spi.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -161,6 +161,15 @@ struct _mxc_spi_req_t {
  */
 int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numSlaves,
                  unsigned ssPolarity, unsigned int hz);
+
+/**
+ * @brief   Initialize in-memory SPI peripheral state.
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_SPI_InitState(mxc_spi_regs_t *spi);
 
 /**
  * @brief   Disable and shutdown SPI peripheral.

--- a/Libraries/PeriphDrivers/Include/MAX32570/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/spi.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -168,6 +168,15 @@ struct _mxc_spi_req_t {
  */
 int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numSlaves,
                  unsigned ssPolarity, unsigned int hz);
+
+/**
+ * @brief   Initialize in-memory SPI peripheral state.
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_SPI_InitState(mxc_spi_regs_t *spi);
 
 /**
  * @brief   Disable and shutdown SPI peripheral.

--- a/Libraries/PeriphDrivers/Include/MAX32572/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/spi.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -250,6 +250,15 @@ struct _mxc_spi_req_t {
  */
 int MXC_SPI_Init(mxc_spi_regs_t *spi, mxc_spi_type_t controller_target, mxc_spi_interface_t if_mode,
                  int numTargets, uint8_t ts_active_pol_mask, uint32_t freq, mxc_spi_pins_t pins);
+
+/**
+ * @brief   Initialize in-memory SPI peripheral state.
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_SPI_InitState(mxc_spi_regs_t *spi);
 
 /**
  * @brief   Configure the SPI peripheral.

--- a/Libraries/PeriphDrivers/Include/MAX32650/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/spi.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Libraries/PeriphDrivers/Include/MAX32655/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/spi.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Libraries/PeriphDrivers/Include/MAX32657/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/spi.h
@@ -5,7 +5,7 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2024-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -190,6 +190,15 @@ struct _mxc_spi_req_t {
  */
 int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numSlaves,
                  unsigned ssPolarity, unsigned int hz, mxc_spi_pins_t pins);
+
+/**
+ * @brief   Initialize in-memory SPI peripheral state.
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_SPI_InitState(mxc_spi_regs_t *spi);
 
 /**
  * @brief   Disable and shutdown SPI peripheral.

--- a/Libraries/PeriphDrivers/Include/MAX32660/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/spi.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,6 +167,15 @@ struct _mxc_spi_req_t {
  */
 int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numSlaves,
                  unsigned ssPolarity, unsigned int hz);
+
+/**
+ * @brief   Initialize in-memory SPI peripheral state.
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_SPI_InitState(mxc_spi_regs_t *spi);
 
 /**
  * @brief   Disable and shutdown SPI peripheral.

--- a/Libraries/PeriphDrivers/Include/MAX32662/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/spi.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -191,6 +191,15 @@ struct _mxc_spi_req_t {
  */
 int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numSlaves,
                  unsigned ssPolarity, unsigned int hz, mxc_spi_pins_t pins);
+
+/**
+ * @brief   Initialize in-memory SPI peripheral state.
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_SPI_InitState(mxc_spi_regs_t *spi);
 
 /**
  * @brief   Disable and shutdown SPI peripheral.

--- a/Libraries/PeriphDrivers/Include/MAX32665/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/spi.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -169,6 +169,15 @@ struct _mxc_spi_req_t {
  */
 int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numSlaves,
                  unsigned ssPolarity, unsigned int hz, sys_map_t map);
+
+/**
+ * @brief   Initialize in-memory SPI peripheral state.
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_SPI_InitState(mxc_spi_regs_t *spi);
 
 /**
  * @brief   Disable and shutdown SPI peripheral.

--- a/Libraries/PeriphDrivers/Include/MAX32670/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/spi.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,6 +167,15 @@ struct _mxc_spi_req_t {
  */
 int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numSlaves,
                  unsigned ssPolarity, unsigned int hz);
+
+/**
+ * @brief   Initialize in-memory SPI peripheral state.
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_SPI_InitState(mxc_spi_regs_t *spi);
 
 /**
  * @brief   Disable and shutdown SPI peripheral.

--- a/Libraries/PeriphDrivers/Include/MAX32672/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/spi.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -166,6 +166,15 @@ struct _mxc_spi_req_t {
  */
 int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numSlaves,
                  unsigned ssPolarity, unsigned int hz);
+
+/**
+ * @brief   Initialize in-memory SPI peripheral state.
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_SPI_InitState(mxc_spi_regs_t *spi);
 
 /**
  * @brief   Disable and shutdown SPI peripheral.

--- a/Libraries/PeriphDrivers/Include/MAX32675/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/spi.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -166,6 +166,15 @@ struct _mxc_spi_req_t {
  */
 int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numSlaves,
                  unsigned ssPolarity, unsigned int hz);
+
+/**
+ * @brief   Initialize in-memory SPI peripheral state.
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_SPI_InitState(mxc_spi_regs_t *spi);
 
 /**
  * @brief   Disable and shutdown SPI peripheral.

--- a/Libraries/PeriphDrivers/Include/MAX32680/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/spi.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -189,6 +189,15 @@ struct _mxc_spi_req_t {
  */
 int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numSlaves,
                  unsigned ssPolarity, unsigned int hz, mxc_spi_pins_t pins);
+
+/**
+ * @brief   Initialize in-memory SPI peripheral state.
+ *
+ * @param   spi         Pointer to SPI registers (selects the SPI block used.)
+ *
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_SPI_InitState(mxc_spi_regs_t *spi);
 
 /**
  * @brief   Disable and shutdown SPI peripheral.

--- a/Libraries/PeriphDrivers/Include/MAX32690/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/spi.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Libraries/PeriphDrivers/Include/MAX78000/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/spi.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2025 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Libraries/PeriphDrivers/Include/MAX78002/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/spi.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Add missing `MXC_SPI_InitState` declaration for the parts that were missing it.

### Description

Some parts were missing declaration for the recently added `MXC_SPI_InitState` API.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
