### PR TITLE
fix(PeriphDrivers): Adding AIN_TRIG_C for ADC in MAX32662

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32662/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/adc.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,6 +128,7 @@ typedef enum {
     MXC_ADC_TRIG_SEL_TMR3, ///< Timer 3 Out Rising Edge
     MXC_ADC_TRIG_SEL_P0_9, ///< GPIO P0.9, AF4
     MXC_ADC_TRIG_SEL_P0_0, ///< GPIO P0.0, AF5
+    MXC_ADC_TRIG_SEL_P0_17, ///< GPIO P0.17, AF3
 } mxc_adc_trig_sel_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32662/mxc_pins.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/mxc_pins.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,6 +82,7 @@ extern const mxc_gpio_cfg_t gpio_cfg_adc_ain3;
 
 extern const mxc_gpio_cfg_t gpio_cfg_adc_trig_p0_9;
 extern const mxc_gpio_cfg_t gpio_cfg_adc_trig_p0_0;
+extern const mxc_gpio_cfg_t gpio_cfg_adc_trig_p0_17;
 
 extern const mxc_gpio_cfg_t gpio_cfg_can;
 extern const mxc_gpio_cfg_t gpio_cfg_canb;

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me12.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me12.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2025 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,9 @@ static void initGPIOForTrigSrc(mxc_adc_trig_sel_t hwTrig)
         break;
     case MXC_ADC_TRIG_SEL_P0_0:
         MXC_GPIO_Config(&gpio_cfg_adc_trig_p0_0);
+        break;
+    case MXC_ADC_TRIG_SEL_P0_17:
+        MXC_GPIO_Config(&gpio_cfg_adc_trig_p0_17);
         break;
     }
 }

--- a/Libraries/PeriphDrivers/Source/SYS/pins_me12.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_me12.c
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,6 +120,8 @@ const mxc_gpio_cfg_t gpio_cfg_adc_ain3 = { MXC_GPIO0, MXC_GPIO_PIN_10, MXC_GPIO_
 const mxc_gpio_cfg_t gpio_cfg_adc_trig_p0_9 = { MXC_GPIO0, MXC_GPIO_PIN_9, MXC_GPIO_FUNC_ALT4,
                                                 MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_adc_trig_p0_0 = { MXC_GPIO0, MXC_GPIO_PIN_0, MXC_GPIO_FUNC_ALT5,
+                                                MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_adc_trig_p0_17 = { MXC_GPIO0, MXC_GPIO_PIN_17, MXC_GPIO_FUNC_ALT3,
                                                 MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
 const mxc_gpio_cfg_t gpio_cfg_can = { MXC_GPIO0, (MXC_GPIO_PIN_6 | MXC_GPIO_PIN_9), MXC_GPIO_FUNC_ALT2,


### PR DESCRIPTION
Adding trigger event AIN_TRIG_C for ADC in MAX32662. P0.17, only for TQFN package.