### PR TITLE
fix(CMSIS): Define ADC_REVB_SAMPCLKCTRL_TRACK_CNT for MAX32662, MAX32672, MAX32690

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32662/Include/adc_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32662/Include/adc_regs.h
@@ -9,7 +9,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -240,7 +240,7 @@ typedef struct {
  * @{
  */
 #define MXC_F_ADC_SAMPCLKCTRL_TRACK_CNT_POS            0 /**< SAMPCLKCTRL_TRACK_CNT Position */
-#define MXC_F_ADC_SAMPCLKCTRL_TRACK_CNT                ((uint32_t)(0xFFFFUL << MXC_F_ADC_SAMPCLKCTRL_TRACK_CNT_POS)) /**< SAMPCLKCTRL_TRACK_CNT Mask */
+#define MXC_F_ADC_SAMPCLKCTRL_TRACK_CNT                ((uint32_t)(0x3FFUL << MXC_F_ADC_SAMPCLKCTRL_TRACK_CNT_POS)) /**< SAMPCLKCTRL_TRACK_CNT Mask */
 
 #define MXC_F_ADC_SAMPCLKCTRL_IDLE_CNT_POS             16 /**< SAMPCLKCTRL_IDLE_CNT Position */
 #define MXC_F_ADC_SAMPCLKCTRL_IDLE_CNT                 ((uint32_t)(0xFFFFUL << MXC_F_ADC_SAMPCLKCTRL_IDLE_CNT_POS)) /**< SAMPCLKCTRL_IDLE_CNT Mask */

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Include/adc_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Include/adc_regs.h
@@ -9,7 +9,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -240,7 +240,7 @@ typedef struct {
  * @{
  */
 #define MXC_F_ADC_SAMPCLKCTRL_TRACK_CNT_POS            0 /**< SAMPCLKCTRL_TRACK_CNT Position */
-#define MXC_F_ADC_SAMPCLKCTRL_TRACK_CNT                ((uint32_t)(0xFFUL << MXC_F_ADC_SAMPCLKCTRL_TRACK_CNT_POS)) /**< SAMPCLKCTRL_TRACK_CNT Mask */
+#define MXC_F_ADC_SAMPCLKCTRL_TRACK_CNT                ((uint32_t)(0xFFFFUL << MXC_F_ADC_SAMPCLKCTRL_TRACK_CNT_POS)) /**< SAMPCLKCTRL_TRACK_CNT Mask */
 
 #define MXC_F_ADC_SAMPCLKCTRL_IDLE_CNT_POS             16 /**< SAMPCLKCTRL_IDLE_CNT Position */
 #define MXC_F_ADC_SAMPCLKCTRL_IDLE_CNT                 ((uint32_t)(0xFFFFUL << MXC_F_ADC_SAMPCLKCTRL_IDLE_CNT_POS)) /**< SAMPCLKCTRL_IDLE_CNT Mask */

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/adc_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/adc_regs.h
@@ -9,7 +9,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -240,7 +240,7 @@ typedef struct {
  * @{
  */
 #define MXC_F_ADC_SAMPCLKCTRL_TRACK_CNT_POS            0 /**< SAMPCLKCTRL_TRACK_CNT Position */
-#define MXC_F_ADC_SAMPCLKCTRL_TRACK_CNT                ((uint32_t)(0xFFUL << MXC_F_ADC_SAMPCLKCTRL_TRACK_CNT_POS)) /**< SAMPCLKCTRL_TRACK_CNT Mask */
+#define MXC_F_ADC_SAMPCLKCTRL_TRACK_CNT                ((uint32_t)(0x3FFUL << MXC_F_ADC_SAMPCLKCTRL_TRACK_CNT_POS)) /**< SAMPCLKCTRL_TRACK_CNT Mask */
 
 #define MXC_F_ADC_SAMPCLKCTRL_IDLE_CNT_POS             16 /**< SAMPCLKCTRL_IDLE_CNT Position */
 #define MXC_F_ADC_SAMPCLKCTRL_IDLE_CNT                 ((uint32_t)(0xFFFFUL << MXC_F_ADC_SAMPCLKCTRL_IDLE_CNT_POS)) /**< SAMPCLKCTRL_IDLE_CNT Mask */

--- a/Libraries/PeriphDrivers/Source/ADC/adc_revb_regs.h
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_revb_regs.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -241,7 +241,13 @@ typedef struct {
  * @{
  */
  #define MXC_F_ADC_REVB_SAMPCLKCTRL_TRACK_CNT_POS            0 /**< SAMPCLKCTRL_TRACK_CNT Position */
+ #if defined(MAX32672)
+ #define MXC_F_ADC_REVB_SAMPCLKCTRL_TRACK_CNT                ((uint32_t)(0xFFFFUL << MXC_F_ADC_REVB_SAMPCLKCTRL_TRACK_CNT_POS)) /**< SAMPCLKCTRL_TRACK_CNT Mask */
+ #elif defined(MAX32690) || defined(MAX32662)
+ #define MXC_F_ADC_REVB_SAMPCLKCTRL_TRACK_CNT                ((uint32_t)(0x3FFUL << MXC_F_ADC_REVB_SAMPCLKCTRL_TRACK_CNT_POS)) /**< SAMPCLKCTRL_TRACK_CNT Mask */
+ #else
  #define MXC_F_ADC_REVB_SAMPCLKCTRL_TRACK_CNT                ((uint32_t)(0xFFUL << MXC_F_ADC_REVB_SAMPCLKCTRL_TRACK_CNT_POS)) /**< SAMPCLKCTRL_TRACK_CNT Mask */
+ #endif
 
  #define MXC_F_ADC_REVB_SAMPCLKCTRL_IDLE_CNT_POS             16 /**< SAMPCLKCTRL_IDLE_CNT Position */
  #define MXC_F_ADC_REVB_SAMPCLKCTRL_IDLE_CNT                 ((uint32_t)(0xFFFFUL << MXC_F_ADC_REVB_SAMPCLKCTRL_IDLE_CNT_POS)) /**< SAMPCLKCTRL_IDLE_CNT Mask */


### PR DESCRIPTION
Currently it is defined 0xFF for all boards, but it's just applied for MAX78002 only.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

