### PR TITLE
fix(CMSIS): Remove WUT1 from MAX32655 source files

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Include/max32655.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Include/max32655.h
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,7 +177,6 @@ typedef enum {
     RSV122_IRQn, /* 0x7A  0x01E8 122: Reserved */
     RSV123_IRQn, /* 0x7B  0x01EC 123: Reserved */
     RSV124_IRQn, /* 0x7C  0x01F0 124: Reserved */
-    WUT1_IRQn, /* 0x7D  0x01F4 125: ERFO Ready/WUT 1 */
 #else // __riscv
     PF_IRQn = 4, /* 0x04,4 PFW | SYSFAULT | CM4 */
     WDT0_IRQn, /* 0x05,5 Watchdog 0 */
@@ -227,7 +226,7 @@ typedef enum {
     WDT1_IRQn, /* 0x30,48 Watchdog 1 (LP) */
     DVS_IRQn, /* 0x31,49 DVS Controller */
     SIMO_IRQn, /* 0x32,50 SIMO Controller */
-    WUT1_IRQn, /* 0x33,51 ERFO Ready/WUT1  */
+    RSV51_IRQn, /* 0x33,51 Reserved */
     PT_IRQn, /* 0x34,52 Pulse train */
     ADC_IRQn, /* 0x35,53 ADC */
     OWM_IRQn, /* 0x36,54 One Wire Master */
@@ -334,13 +333,11 @@ typedef enum {
 
 /******************************************************************************/
 /*                                                        Wake-Up Timer (WUT) */
-#define MXC_CFG_WUT_INSTANCES (2)
+#define MXC_CFG_WUT_INSTANCES (1)
 
 #define MXC_BASE_WUT0 ((uint32_t)0x40006400UL)
 #define MXC_WUT0 ((mxc_wut_regs_t *)MXC_BASE_WUT0)
 #define MXC_WUT MXC_WUT0
-#define MXC_BASE_WUT1 ((uint32_t)0x40006600UL)
-#define MXC_WUT1 ((mxc_wut_regs_t *)MXC_BASE_WUT1)
 
 // Included for legacy compatability after changing WUT_IRQn -> WUT0_IRQn
 // in system startup files.

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Source/GCC/startup_max32655.S
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Source/GCC/startup_max32655.S
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -237,8 +237,7 @@ __isr_vector:
     .long RSV121_IRQHandler            /* 0x79  0x01E4  121: Reserved */
     .long RSV122_IRQHandler            /* 0x7A  0x01E8  122: Reserved */
     .long RSV123_IRQHandler            /* 0x7B  0x01EC  123: Reserved */
-    .long RSV124_IRQHandler            /* 0x7C  0x01F0  124: Reserved */
-    .long WUT1_IRQHandler              /* 0x7D  0x01F4  125: Wakeup Timer 1 */    
+    .long RSV124_IRQHandler            /* 0x7C  0x01F0  124: Reserved */    
     .text   
     .thumb
     .thumb_func
@@ -457,6 +456,5 @@ Reset_Handler:
     def_irq_handler RSV121_IRQHandler            /* 0x79  0x01E4  121: Reserved */
     def_irq_handler RSV122_IRQHandler            /* 0x7A  0x01E8  122: Reserved */
     def_irq_handler RSV123_IRQHandler            /* 0x7B  0x01EC  123: Reserved */
-    def_irq_handler RSV124_IRQHandler            /* 0x7C  0x01F0  124: Reserved */
-    def_irq_handler WUT1_IRQHandler              /* 0x7D  0x01F4  125: Wakeup Timer 1 */  
+    def_irq_handler RSV124_IRQHandler            /* 0x7C  0x01F0  124: Reserved */  
     .end

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Source/GCC/startup_riscv_max32655.S
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Source/GCC/startup_riscv_max32655.S
@@ -147,7 +147,7 @@ __isr_vector:
   jal x0, WDT1_IRQHandlerWrap
   jal x0, DVS_IRQHandlerWrap
   jal x0, SIMO_IRQHandlerWrap
-  jal x0, WUT1_IRQHandlerWrap
+  jal x0, RSV51_IRQHandlerWrap
   jal x0, PT_IRQHandlerWrap
   jal x0, ADC_IRQHandlerWrap
   jal x0, OWM_IRQHandlerWrap
@@ -326,7 +326,7 @@ main_entry:
   def_irq_handler WDT1_IRQHandlerWrap
   def_irq_handler DVS_IRQHandlerWrap
   def_irq_handler SIMO_IRQHandlerWrap
-  def_irq_handler WUT1_IRQHandlerWrap
+  def_irq_handler RSV51_IRQHandlerWrap
   def_irq_handler PT_IRQHandlerWrap
   def_irq_handler ADC_IRQHandlerWrap
   def_irq_handler OWM_IRQHandlerWrap

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_riscv_max32655.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_riscv_max32655.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2025 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ void __attribute__((weak)) TRNG_IRQHandler(void) {}
 void __attribute__((weak)) WDT1_IRQHandler(void) {}
 void __attribute__((weak)) DVS_IRQHandler(void) {}
 void __attribute__((weak)) SIMO_IRQHandler(void) {}
-void __attribute__((weak)) WUT1_IRQHandler(void) {}
+void __attribute__((weak)) RSV51_IRQHandler(void) {}
 void __attribute__((weak)) PT_IRQHandler(void) {}
 void __attribute__((weak)) ADC_IRQHandler(void) {}
 void __attribute__((weak)) OWM_IRQHandler(void) {}
@@ -577,14 +577,14 @@ void __attribute__((interrupt("machine"))) SIMO_IRQHandlerWrap(void)
     NVIC_EnableIRQ(SIMO_IRQn);
     intContext = 0;
 }
-void __attribute__((interrupt("machine"))) WUT1_IRQHandlerWrap(void)
+void __attribute__((interrupt("machine"))) RSV51_IRQHandlerWrap(void)
 {
     intContext = 1;
 
-    NVIC_DisableIRQ(WUT1_IRQn);
-    NVIC_ClearPendingIRQ(WUT1_IRQn);
-    WUT1_IRQHandler();
-    NVIC_EnableIRQ(WUT1_IRQn);
+    NVIC_DisableIRQ(RSV51_IRQn);
+    NVIC_ClearPendingIRQ(RSV51_IRQn);
+    RSV51_IRQHandler();
+    NVIC_EnableIRQ(RSV51_IRQn);
     intContext = 0;
 }
 void __attribute__((interrupt("machine"))) PT_IRQHandlerWrap(void)


### PR DESCRIPTION
The WUT1 instance needs to be removed from MAX32655 source files to consistent with User guide.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

