### PR TITLE
feat(PeriphDrivers): Add MXC_TMR_SetClockSourceFreq API for timers

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32650/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/tmr.h
@@ -150,6 +150,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 void MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg);
 
 /**
+ * @brief      Set the timer input clock frequency.
+ * @param      tmr  Pointer to timer instance.
+ * @param      clksrc_freq Timer input clock frequency in Hz.
+ * @note       Call this after selecting MXC_TMR_EXT_CLK on RevB timers. This API has no
+ *             effect on timer revisions without selectable clock sources.
+ */
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq);
+
+/**
  * @brief      Shutdown timer module clock.
  * @param      tmr  Pointer to timer module to shutdown.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32655/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/tmr.h
@@ -192,6 +192,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins);
 
 /**
+ * @brief   Set the timer input clock frequency.
+ * @param   tmr  Pointer to timer instance.
+ * @param   clksrc_freq Timer input clock frequency in Hz.
+ * @note    Call this after selecting MXC_TMR_EXT_CLK on RevB timers. This API has no effect
+ *          on timer revisions without selectable clock sources.
+ */
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq);
+
+/**
  * @brief   Shutdown timer module clock.
  * @param   tmr  Pointer to timer module to initialize.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32657/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/tmr.h
@@ -190,6 +190,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins);
 
 /**
+ * @brief   Set the timer input clock frequency.
+ * @param   tmr  Pointer to timer instance.
+ * @param   clksrc_freq Timer input clock frequency in Hz.
+ * @note    Call this after selecting MXC_TMR_EXT_CLK on RevB timers. This API has no effect
+ *          on timer revisions without selectable clock sources.
+ */
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq);
+
+/**
  * @brief   Shutdown timer module clock.
  * @param   tmr  Pointer to timer module to initialize.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32660/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/tmr.h
@@ -170,6 +170,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg);
 
 /**
+ * @brief   Set the timer input clock frequency.
+ * @param   tmr  Pointer to timer instance.
+ * @param   clksrc_freq Timer input clock frequency in Hz.
+ * @note    Call this after selecting MXC_TMR_EXT_CLK on RevB timers. This API has no effect
+ *          on timer revisions without selectable clock sources.
+ */
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq);
+
+/**
  * @brief   Shutdown timer module clock.
  * @param   tmr  Pointer to timer module to initialize.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32662/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/tmr.h
@@ -195,6 +195,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins, sys_map_t pin_sel);
 
 /**
+ * @brief   Set the timer input clock frequency.
+ * @param   tmr  Pointer to timer instance.
+ * @param   clksrc_freq Timer input clock frequency in Hz.
+ * @note    Call this after selecting MXC_TMR_EXT_CLK on RevB timers. This API has no effect
+ *          on timer revisions without selectable clock sources.
+ */
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq);
+
+/**
  * @brief   Shutdown timer module clock.
  * @param   tmr  Pointer to timer module to initialize.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32665/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/tmr.h
@@ -148,6 +148,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 void MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg);
 
 /**
+ * @brief      Set the timer input clock frequency.
+ * @param      tmr  Pointer to timer instance.
+ * @param      clksrc_freq Timer input clock frequency in Hz.
+ * @note       Call this after selecting MXC_TMR_EXT_CLK on RevB timers. This API has no
+ *             effect on timer revisions without selectable clock sources.
+ */
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq);
+
+/**
  * @brief      Shutdown timer module clock.
  * @param      tmr  Pointer to timer module to initialize.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32670/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/tmr.h
@@ -191,6 +191,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins);
 
 /**
+ * @brief   Set the timer input clock frequency.
+ * @param   tmr  Pointer to timer instance.
+ * @param   clksrc_freq Timer input clock frequency in Hz.
+ * @note    Call this after selecting MXC_TMR_EXT_CLK on RevB timers. This API has no effect
+ *          on timer revisions without selectable clock sources.
+ */
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq);
+
+/**
  * @brief   Shutdown timer module clock.
  * @param   tmr  Pointer to timer module to initialize.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32672/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/tmr.h
@@ -191,6 +191,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins);
 
 /**
+ * @brief   Set the timer input clock frequency.
+ * @param   tmr  Pointer to timer instance.
+ * @param   clksrc_freq Timer input clock frequency in Hz.
+ * @note    Call this after selecting MXC_TMR_EXT_CLK on RevB timers. This API has no effect
+ *          on timer revisions without selectable clock sources.
+ */
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq);
+
+/**
  * @brief   Shutdown timer module clock.
  * @param   tmr  Pointer to timer module to initialize.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32675/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/tmr.h
@@ -190,6 +190,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins);
 
 /**
+ * @brief   Set the timer input clock frequency.
+ * @param   tmr  Pointer to timer instance.
+ * @param   clksrc_freq Timer input clock frequency in Hz.
+ * @note    Call this after selecting MXC_TMR_EXT_CLK on RevB timers. This API has no effect
+ *          on timer revisions without selectable clock sources.
+ */
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq);
+
+/**
  * @brief   Shutdown timer module clock.
  * @param   tmr  Pointer to timer module to initialize.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32680/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/tmr.h
@@ -192,6 +192,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins);
 
 /**
+ * @brief   Set the timer input clock frequency.
+ * @param   tmr  Pointer to timer instance.
+ * @param   clksrc_freq Timer input clock frequency in Hz.
+ * @note    Call this after selecting MXC_TMR_EXT_CLK on RevB timers. This API has no effect
+ *          on timer revisions without selectable clock sources.
+ */
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq);
+
+/**
  * @brief   Shutdown timer module clock.
  * @param   tmr  Pointer to timer module to initialize.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32690/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/tmr.h
@@ -222,6 +222,15 @@ void MXC_TMR_SetPrescalar(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
                           mxc_tmr_pres_t prescalar);
 
 /**
+ * @brief   Set the timer input clock frequency.
+ * @param   tmr  Pointer to timer instance.
+ * @param   clksrc_freq Timer input clock frequency in Hz.
+ * @note    Call this after selecting MXC_TMR_EXT_CLK on RevB timers. This API has no effect
+ *          on timer revisions without selectable clock sources.
+ */
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq);
+
+/**
  * @brief   Shutdown timer module clock.
  * @param   tmr  Pointer to timer module to initialize.
  */

--- a/Libraries/PeriphDrivers/Include/MAX78000/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/tmr.h
@@ -194,6 +194,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins);
 
 /**
+ * @brief   Set the timer input clock frequency.
+ * @param   tmr  Pointer to timer instance.
+ * @param   clksrc_freq Timer input clock frequency in Hz.
+ * @note    Call this after selecting MXC_TMR_EXT_CLK on RevB timers. This API has no effect
+ *          on timer revisions without selectable clock sources.
+ */
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq);
+
+/**
  * @brief   Shutdown timer module clock.
  * @param   tmr  Pointer to timer module to initialize.
  */

--- a/Libraries/PeriphDrivers/Include/MAX78002/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/tmr.h
@@ -220,6 +220,15 @@ void MXC_TMR_SetPrescalar(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
                           mxc_tmr_pres_t prescalar);
 
 /**
+ * @brief   Set the timer input clock frequency.
+ * @param   tmr  Pointer to timer instance.
+ * @param   clksrc_freq Timer input clock frequency in Hz.
+ * @note    Call this after selecting MXC_TMR_EXT_CLK on RevB timers. This API has no effect
+ *          on timer revisions without selectable clock sources.
+ */
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq);
+
+/**
  * @brief   Shutdown timer module clock.
  * @param   tmr  Pointer to timer module to initialize.
  */

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_ai85.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_ai85.c
@@ -182,6 +182,11 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }
 
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq)
+{
+    MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, clksrc_freq);
+}
+
 void MXC_TMR_Shutdown(mxc_tmr_regs_t *tmr)
 {
     MXC_ASSERT(MXC_TMR_GET_IDX(tmr) >= 0);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
@@ -134,6 +134,11 @@ void MXC_TMR_LockClockSource(mxc_tmr_regs_t *tmr, bool lock)
     MXC_TMR_RevB_LockClockSource((mxc_tmr_revb_regs_t *)tmr, lock);
 }
 
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq)
+{
+    MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, clksrc_freq);
+}
+
 uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
                                mxc_tmr_clock_t clk_src)
 {

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_es17.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_es17.c
@@ -59,6 +59,12 @@ void MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
     MXC_TMR_RevA_Init((mxc_tmr_reva_regs_t *)tmr, cfg);
 }
 
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq)
+{
+    (void)tmr;
+    (void)clksrc_freq;
+}
+
 void MXC_TMR_Shutdown(mxc_tmr_regs_t *tmr)
 {
     int tmr_id = MXC_TMR_GET_IDX(tmr);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me10.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me10.c
@@ -79,6 +79,12 @@ void MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
 }
 
 /* ************************************************************************** */
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq)
+{
+    (void)tmr;
+    (void)clksrc_freq;
+}
+
 void MXC_TMR_Shutdown(mxc_tmr_regs_t *tmr)
 {
     int tmr_id = MXC_TMR_GET_IDX(tmr);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me11.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me11.c
@@ -54,6 +54,12 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
     return E_NO_ERROR;
 }
 
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq)
+{
+    (void)tmr;
+    (void)clksrc_freq;
+}
+
 void MXC_TMR_Shutdown(mxc_tmr_regs_t *tmr)
 {
     int tmr_id = MXC_TMR_GET_IDX(tmr);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me12.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me12.c
@@ -177,6 +177,11 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins, sys_ma
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }
 
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq)
+{
+    MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, clksrc_freq);
+}
+
 void MXC_TMR_Shutdown(mxc_tmr_regs_t *tmr)
 {
     MXC_ASSERT(MXC_TMR_GET_IDX(tmr) >= 0);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me13.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me13.c
@@ -106,6 +106,12 @@ void MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
     MXC_TMR_RevA_Init((mxc_tmr_reva_regs_t *)tmr, cfg);
 }
 
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq)
+{
+    (void)tmr;
+    (void)clksrc_freq;
+}
+
 void MXC_TMR_Shutdown(mxc_tmr_regs_t *tmr)
 {
     int tmr_id = MXC_TMR_GET_IDX(tmr);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me14.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me14.c
@@ -77,6 +77,12 @@ void MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
     MXC_TMR_RevA_Init((mxc_tmr_reva_regs_t *)tmr, cfg);
 }
 
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq)
+{
+    (void)tmr;
+    (void)clksrc_freq;
+}
+
 void MXC_TMR_Shutdown(mxc_tmr_regs_t *tmr)
 {
     int tmr_id = MXC_TMR_GET_IDX(tmr);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me15.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me15.c
@@ -182,6 +182,11 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }
 
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq)
+{
+    MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, clksrc_freq);
+}
+
 void MXC_TMR_Shutdown(mxc_tmr_regs_t *tmr)
 {
     int tmr_id = MXC_TMR_GET_IDX(tmr);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me16.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me16.c
@@ -153,6 +153,11 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }
 
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq)
+{
+    MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, clksrc_freq);
+}
+
 void MXC_TMR_Shutdown(mxc_tmr_regs_t *tmr)
 {
     int tmr_id = MXC_TMR_GET_IDX(tmr);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me17.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me17.c
@@ -181,6 +181,11 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }
 
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq)
+{
+    MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, clksrc_freq);
+}
+
 void MXC_TMR_Shutdown(mxc_tmr_regs_t *tmr)
 {
     MXC_ASSERT(MXC_TMR_GET_IDX(tmr) >= 0);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
@@ -146,6 +146,11 @@ void MXC_TMR_LockClockSource(mxc_tmr_regs_t *tmr, bool lock)
     MXC_TMR_RevB_LockClockSource((mxc_tmr_revb_regs_t *)tmr, lock);
 }
 
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq)
+{
+    MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, clksrc_freq);
+}
+
 uint8_t MXC_TMR_SetClockSource(mxc_tmr_regs_t *tmr, mxc_tmr_bit_mode_t bit_mode,
                                mxc_tmr_clock_t clk_src)
 {

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me21.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me21.c
@@ -176,6 +176,11 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }
 
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq)
+{
+    MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, clksrc_freq);
+}
+
 void MXC_TMR_Shutdown(mxc_tmr_regs_t *tmr)
 {
     uint8_t tmr_id = MXC_TMR_GET_IDX(tmr);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me30.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me30.c
@@ -125,6 +125,11 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }
 
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq)
+{
+    MXC_TMR_RevB_SetClockSourceFreq((mxc_tmr_revb_regs_t *)tmr, clksrc_freq);
+}
+
 void MXC_TMR_Shutdown(mxc_tmr_regs_t *tmr)
 {
     MXC_ASSERT(MXC_TMR_GET_IDX(tmr) >= 0);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me55.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me55.c
@@ -71,6 +71,12 @@ void MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
     MXC_TMR_RevA_Init((mxc_tmr_reva_regs_t *)tmr, cfg);
 }
 
+void MXC_TMR_SetClockSourceFreq(mxc_tmr_regs_t *tmr, int clksrc_freq)
+{
+    (void)tmr;
+    (void)clksrc_freq;
+}
+
 void MXC_TMR_Shutdown(mxc_tmr_regs_t *tmr)
 {
     int tmr_id = MXC_TMR_GET_IDX(tmr);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
@@ -551,11 +551,15 @@ int MXC_TMR_RevB_GetTicks(mxc_tmr_revb_regs_t *tmr, uint32_t time, mxc_tmr_unit_
                           uint32_t *ticks)
 {
     uint32_t unit_div0, unit_div1;
-    uint32_t timerClock;
+    int timerClock;
     uint32_t prescale;
     uint64_t temp_ticks;
 
-    timerClock = PeripheralClock;
+    timerClock = MXC_TMR_RevB_GetClockSourceFreq(tmr);
+
+    if (timerClock < 0) {
+        return timerClock;
+    }
 
     prescale = ((tmr->ctrl0 & MXC_F_TMR_CTRL0_CLKDIV_A) >> MXC_F_TMR_CTRL0_CLKDIV_A_POS);
 


### PR DESCRIPTION
### Description

Add a new `MXC_TMR_SetClockSourceFreq` API so that the timer frequency can be manually set when using external clock as timer clock source.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
