### PR TITLE
fix(PeriphDrivers): Name of ADC channel for MAX32690

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32690/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/adc.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,8 @@ typedef enum {
     MXC_ADC_CH_VCOREA = 14, ///< Select Channel 14
     MXC_ADC_CH_VSS = 15, ///< Select Channel 15
     MXC_ADC_CH_VDBB3A_DIV4 = 18, ///< Select Channel 18
-    MXC_ADC_CH_VDBB_DIV4 = 19, ///< Select Channel 19
+    MXC_ADC_CH_VDDB_DIV4 = 19, ///< Select Channel 19
+    MXC_ADC_CH_VDBB_DIV4 = MXC_ADC_CH_VDDB_DIV4, ///< Typo in previous version
     MXC_ADC_CH_VSSA = 20, ///< Select Channel 20
 } mxc_adc_chsel_t;
 

--- a/Libraries/PeriphDrivers/Include/MAX32690/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/adc.h
@@ -71,9 +71,8 @@ typedef enum {
     MXC_ADC_CH_TEMP_SENS = 13, ///< Select Channel 13
     MXC_ADC_CH_VCOREA = 14, ///< Select Channel 14
     MXC_ADC_CH_VSS = 15, ///< Select Channel 15
-    MXC_ADC_CH_VDBB3A_DIV4 = 18, ///< Select Channel 18
+    MXC_ADC_CH_VDD3A_DIV4 = 18, ///< Select Channel 18
     MXC_ADC_CH_VDDB_DIV4 = 19, ///< Select Channel 19
-    MXC_ADC_CH_VDBB_DIV4 = MXC_ADC_CH_VDDB_DIV4, ///< Typo in previous version
     MXC_ADC_CH_VSSA = 20, ///< Select Channel 20
 } mxc_adc_chsel_t;
 


### PR DESCRIPTION
MXC_ADC_CH_VDDB_DIV4 instead of MXC_ADC_CH_VDBB_DIV4

Please see the user guide. Please see the same file for MAX78002.