### PR TITLE
feat(CMSIS, Other): Add MAX32672 SBT support in Zephyr

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Source/sla_header_MAX32672.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Source/sla_header_MAX32672.c
@@ -54,7 +54,11 @@ typedef struct {
     unsigned int AppVersionNumber; //> Version of this application
 } flash_app_header_t;
 
+#ifdef USE_ZEPHYR_SECTIONS
+__attribute__((section(".rom_start"))) __attribute__((__used__))
+#else
 __attribute__((section(".sb_sla_header"))) __attribute__((__used__))
+#endif
 const flash_app_header_t sb_header = {
     .Magic =
         {

--- a/Libraries/zephyr/MAX/Source/MAX32672/CMakeLists.txt
+++ b/Libraries/zephyr/MAX/Source/MAX32672/CMakeLists.txt
@@ -67,6 +67,10 @@ zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/QDEC/qdec_reva.c
 )
 
+if (CONFIG_SOC_FAMILY_MAX32_SECURE_SOC_SIGNING)
+zephyr_library_sources(${MSDK_CMSIS_DIR}/Source/sla_header_MAX32672.c)
+endif()
+
 if (CONFIG_ADC_MAX32)
 zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/ADC/adc_me21.c


### PR DESCRIPTION
### Description
This PR adds sla_header_MAX32672.c to Zephyr build system so the header necessary for using the SBT is placed in rom_start when linking zephyr applications. This implementation is in-line with MAX32651 implementation which was initially merged in #1391, and was later updated in #1560. This is to be accompanied with another PR which I will upstream into Zephyr.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [X] Description of changes and all other relevant information.
- [x] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.