### PR TITLE
feat(PeriphDrivers): Allow skipping GPIO config for RTC in all parts

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32570/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/rtc.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,6 +112,8 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec);
 
 /**
  * @brief     Allow generation of Square Wave on the SQW pin (Blocking function)
+ * @note      If you wish to manage GPIO configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     fq     Frequency output selection
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes
  */

--- a/Libraries/PeriphDrivers/Include/MAX32572/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/rtc.h
@@ -8,7 +8,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,6 +115,8 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec);
 
 /**
  * @brief     Allow generation of Square Wave on the SQW pin (Blocking function)
+ * @note      If you wish to manage GPIO configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     fq     Frequency output selection
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes
  */

--- a/Libraries/PeriphDrivers/Include/MAX32650/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/rtc.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,6 +111,8 @@ int MXC_RTC_Init(uint32_t sec, uint8_t ssec);
 
 /**
  * @brief     Allow generation of Square Wave on the SQW pin (Blocking function)
+ * @note      If you wish to manage GPIO configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     fq     Frequency output selection
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes
  */

--- a/Libraries/PeriphDrivers/Include/MAX32655/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/rtc.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,6 +113,8 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec);
 
 /**
  * @brief     Allow generation of Square Wave on the SQW pin (Blocking function)
+ * @note      If you wish to manage GPIO configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     fq     Frequency output selection
  * @retval    returns Success or Fail, see \ref MXC_ERROR_CODES
  */

--- a/Libraries/PeriphDrivers/Include/MAX32657/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/rtc.h
@@ -5,7 +5,7 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2024-2025 Analog Devices, Inc.
+ * Copyright (C) 2024-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,6 +112,8 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec);
 
 /**
  * @brief     Allow generation of Square Wave on the SQW pin (Blocking function)
+ * @note      If you wish to manage GPIO configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     fq     Frequency output selection
  * @retval    returns Success or Fail, see \ref MXC_ERROR_CODES
  */

--- a/Libraries/PeriphDrivers/Include/MAX32660/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/rtc.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,6 +111,8 @@ int MXC_RTC_Init(uint32_t sec, uint8_t ssec);
 
 /**
  * @brief     Allow generation of Square Wave on the SQW pin (Blocking function)
+ * @note      If you wish to manage GPIO configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     fq     Frequency output selection
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes
  */

--- a/Libraries/PeriphDrivers/Include/MAX32662/mxc_pins.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/mxc_pins.h
@@ -102,4 +102,7 @@ extern const mxc_gpio_cfg_t gpio_cfg_spi0_ts0;
 extern const mxc_gpio_cfg_t gpio_cfg_spi1a_ts0;
 extern const mxc_gpio_cfg_t gpio_cfg_spi1b_ts0;
 
+// RTC Square Wave Pin Definitions
+extern const mxc_gpio_cfg_t gpio_cfg_32kcal;
+
 #endif // LIBRARIES_PERIPHDRIVERS_INCLUDE_MAX32662_MXC_PINS_H_

--- a/Libraries/PeriphDrivers/Include/MAX32662/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/rtc.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,6 +113,8 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec);
 
 /**
  * @brief     Allow generation of Square Wave on the SQW pin
+ * @note      If you wish to manage GPIO configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     fq     Frequency output selection
  * @retval    returns Success or Fail, see \ref MXC_ERROR_CODES
  */

--- a/Libraries/PeriphDrivers/Include/MAX32665/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/rtc.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,6 +112,8 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec);
 
 /**
  * @brief     Allow generation of Square Wave on the SQW pin (Blocking function)
+ * @note      If you wish to manage GPIO configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     fq     Frequency output selection
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes
  */

--- a/Libraries/PeriphDrivers/Include/MAX32670/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/rtc.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,6 +113,8 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec);
 
 /**
  * @brief     Allow generation of Square Wave on the SQW pin (Blocking function)
+ * @note      If you wish to manage GPIO configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     fq     Frequency output selection
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes
  */

--- a/Libraries/PeriphDrivers/Include/MAX32672/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/rtc.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,6 +113,8 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec);
 
 /**
  * @brief     Allow generation of Square Wave on the SQW pin (Blocking function)
+ * @note      If you wish to manage GPIO configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     fq     Frequency output selection
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes
  */

--- a/Libraries/PeriphDrivers/Include/MAX32680/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/rtc.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,6 +113,8 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec);
 
 /**
  * @brief     Allow generation of Square Wave on the SQW pin (Blocking function)
+ * @note      If you wish to manage GPIO configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     fq     Frequency output selection
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes
  */

--- a/Libraries/PeriphDrivers/Include/MAX32690/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/rtc.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,6 +114,8 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec);
 
 /**
  * @brief     Allow generation of Square Wave on the SQW pin (Blocking function)
+ * @note      If you wish to manage GPIO configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     fq     Frequency output selection
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes
  */

--- a/Libraries/PeriphDrivers/Include/MAX78000/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/rtc.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,6 +113,8 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec);
 
 /**
  * @brief     Allow generation of Square Wave on the SQW pin (Blocking function)
+ * @note      If you wish to manage GPIO configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     fq     Frequency output selection
  * @retval    returns Success or Fail, see \ref MXC_ERROR_CODES
  */

--- a/Libraries/PeriphDrivers/Include/MAX78002/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/rtc.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,6 +113,8 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec);
 
 /**
  * @brief     Allow generation of Square Wave on the SQW pin (Blocking function)
+ * @note      If you wish to manage GPIO configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     fq     Frequency output selection
  * @retval    returns Success or Fail, see \ref MXC_ERROR_CODES
  */

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_ai87.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_ai87.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,14 +71,18 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 
 int MXC_RTC_SquareWave(mxc_rtc_reva_sqwave_en_t sqe, mxc_rtc_freq_sel_t ft)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GPIO_Config(&gpio_cfg_rtcsqw);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_SquareWave((mxc_rtc_reva_regs_t *)MXC_RTC, sqe, ft);
 }
 
 int MXC_RTC_SquareWaveStart(mxc_rtc_freq_sel_t fq)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GPIO_Config(&gpio_cfg_rtcsqw);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_SquareWave((mxc_rtc_reva_regs_t *)MXC_RTC, MXC_RTC_REVA_SQUARE_WAVE_ENABLED,
                                    fq);

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me10.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me10.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,9 @@ int MXC_RTC_Init(uint32_t sec, uint8_t ssec)
 // *****************************************************************************
 int MXC_RTC_SquareWaveStart(mxc_rtc_freq_sel_t fq)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GPIO_Config(&gpio_cfg_rtcsqw);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
     return MXC_RTC_RevA_SquareWave((mxc_rtc_reva_regs_t *)MXC_RTC, MXC_RTC_REVA_SQUARE_WAVE_ENABLED,
                                    fq);
 }

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me11.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me11.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,14 +70,18 @@ int MXC_RTC_Init(uint32_t sec, uint8_t ssec)
 
 int MXC_RTC_SquareWave(mxc_rtc_reva_sqwave_en_t sqe, mxc_rtc_freq_sel_t ft)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GPIO_Config(&gpio_cfg_32kcal);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_SquareWave((mxc_rtc_reva_regs_t *)MXC_RTC, sqe, ft);
 }
 
 int MXC_RTC_SquareWaveStart(mxc_rtc_freq_sel_t fq)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GPIO_Config(&gpio_cfg_32kcal);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_SquareWave((mxc_rtc_reva_regs_t *)MXC_RTC, MXC_RTC_REVA_SQUARE_WAVE_ENABLED,
                                    fq);

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me12.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me12.c
@@ -72,9 +72,27 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 
 int MXC_RTC_SquareWave(mxc_rtc_reva_sqwave_en_t sqe, mxc_rtc_freq_sel_t ft)
 {
-    // MXC_GPIO_Config(&gpio_cfg_rtcsqw); //FIXME: uncomment once added
+#ifndef MSDK_NO_GPIO_CLK_INIT
+    MXC_GPIO_Config(&gpio_cfg_32kcal);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_SquareWave((mxc_rtc_reva_regs_t *)MXC_RTC, sqe, ft);
+}
+
+int MXC_RTC_SquareWaveStart(mxc_rtc_freq_sel_t fq)
+{
+#ifndef MSDK_NO_GPIO_CLK_INIT
+    MXC_GPIO_Config(&gpio_cfg_32kcal);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
+
+    return MXC_RTC_RevA_SquareWave((mxc_rtc_reva_regs_t *)MXC_RTC, MXC_RTC_REVA_SQUARE_WAVE_ENABLED,
+                                   fq);
+}
+
+int MXC_RTC_SquareWaveStop(void)
+{
+    return MXC_RTC_RevA_SquareWave((mxc_rtc_reva_regs_t *)MXC_RTC,
+                                   MXC_RTC_REVA_SQUARE_WAVE_DISABLED, 0);
 }
 
 int MXC_RTC_Trim(int8_t trm)

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me13.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me13.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,14 +70,18 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 
 int MXC_RTC_SquareWave(mxc_rtc_reva_sqwave_en_t sqe, mxc_rtc_freq_sel_t ft)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GPIO_Config(&gpio_cfg_rtcsqw);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_SquareWave((mxc_rtc_reva_regs_t *)MXC_RTC, sqe, ft);
 }
 
 int MXC_RTC_SquareWaveStart(mxc_rtc_freq_sel_t fq)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GPIO_Config(&gpio_cfg_rtcsqw);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_SquareWave((mxc_rtc_reva_regs_t *)MXC_RTC, MXC_RTC_REVA_SQUARE_WAVE_ENABLED,
                                    fq);

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me14.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me14.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,9 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 
 int MXC_RTC_SquareWaveStart(mxc_rtc_freq_sel_t ft)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GPIO_Config(&gpio_cfg_rtcsqw);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     MXC_MCR->outen |= (MXC_F_MCR_OUTEN_SQWOUT0EN | MXC_F_MCR_OUTEN_SQWOUT1EN);
 

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me15.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me15.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,9 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 int MXC_RTC_SquareWave(mxc_rtc_reva_sqwave_en_t sqe, mxc_rtc_freq_sel_t ft)
 {
 #if TARGET_NUM != 32675
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GPIO_Config(&gpio_cfg_rtcsqw);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_SquareWave((mxc_rtc_reva_regs_t *)MXC_RTC, sqe, ft);
 #else
@@ -83,7 +85,9 @@ int MXC_RTC_SquareWave(mxc_rtc_reva_sqwave_en_t sqe, mxc_rtc_freq_sel_t ft)
 int MXC_RTC_SquareWaveStart(mxc_rtc_freq_sel_t fq)
 {
 #if TARGET_NUM != 32675
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GPIO_Config(&gpio_cfg_rtcsqw);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
     return MXC_RTC_RevA_SquareWave((mxc_rtc_reva_regs_t *)MXC_RTC, MXC_RTC_REVA_SQUARE_WAVE_ENABLED,
                                    fq);
 #else

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me16.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me16.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,9 @@ int MXC_RTC_Init(uint32_t sec, uint8_t ssec)
 
 int MXC_RTC_SquareWave(mxc_rtc_sqwave_en_t sqe, mxc_rtc_freq_sel_t ft)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GPIO_Config(&gpio_cfg_rtcsqw);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_SquareWave(MXC_RTC, sqe, ft);
 }

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me17.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me17.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,9 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 
 int MXC_RTC_SquareWaveStart(mxc_rtc_freq_sel_t ft)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GPIO_Config(&gpio_cfg_rtcsqw);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
     MXC_MCR->outen |= MXC_F_MCR_OUTEN_SQWOUT_EN;
 
     return MXC_RTC_RevA_SquareWave((mxc_rtc_reva_regs_t *)MXC_RTC, MXC_RTC_REVA_SQUARE_WAVE_ENABLED,

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me18.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me18.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,9 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 
 int MXC_RTC_SquareWaveStart(mxc_rtc_freq_sel_t ft)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GPIO_Config(&gpio_cfg_rtcsqw);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
     MXC_MCR->outen |= MXC_F_MCR_OUTEN_SQWOUT_EN;
     return MXC_RTC_RevA_SquareWave((mxc_rtc_reva_regs_t *)MXC_RTC, MXC_RTC_REVA_SQUARE_WAVE_ENABLED,
                                    ft);

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me21.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me21.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,14 +70,18 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 
 int MXC_RTC_SquareWave(mxc_rtc_reva_sqwave_en_t sqe, mxc_rtc_freq_sel_t ft)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GPIO_Config(&gpio_cfg_rtcsqw);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_SquareWave((mxc_rtc_reva_regs_t *)MXC_RTC, sqe, ft);
 }
 
 int MXC_RTC_SquareWaveStart(mxc_rtc_freq_sel_t fq)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GPIO_Config(&gpio_cfg_rtcsqw);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_SquareWave((mxc_rtc_reva_regs_t *)MXC_RTC, MXC_RTC_REVA_SQUARE_WAVE_ENABLED,
                                    fq);

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me30.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me30.c
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2024-2025 Analog Devices, Inc.
+ * Copyright (C) 2024-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,9 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 
 int MXC_RTC_SquareWaveStart(mxc_rtc_freq_sel_t ft)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GPIO_Config(&gpio_cfg_rtcsqw);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     MXC_MCR->outen |= MXC_F_MCR_OUTEN_SQWOUT_EN;
 

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me55.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me55.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc. All Rights Reserved. This software
+ * Copyright (C) 2023-2026 Analog Devices, Inc. All Rights Reserved. This software
  * is proprietary to Analog Devices, Inc. and its licensors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -71,7 +71,9 @@ int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 
 int MXC_RTC_SquareWaveStart(mxc_rtc_freq_sel_t ft)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GPIO_Config(&gpio_cfg_rtcsqw);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_SquareWave((mxc_rtc_reva_regs_t *)MXC_RTC, MXC_RTC_REVA_SQUARE_WAVE_ENABLED,
                                    ft);

--- a/Libraries/PeriphDrivers/Source/SYS/pins_me12.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_me12.c
@@ -153,3 +153,6 @@ const mxc_gpio_cfg_t gpio_cfg_spi1a_ts0 = { MXC_GPIO0, MXC_GPIO_PIN_18, MXC_GPIO
                                             MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_spi1b_ts0 = { MXC_GPIO0, MXC_GPIO_PIN_10, MXC_GPIO_FUNC_ALT2,
                                             MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+
+const mxc_gpio_cfg_t gpio_cfg_32kcal = { MXC_GPIO0, MXC_GPIO_PIN_11, MXC_GPIO_FUNC_ALT3,
+                                         MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };


### PR DESCRIPTION
### Description

Wrap `MXC_GPIO_Config` calls in `MXC_RTC_SquareWaveStart` (and the legacy `MXC_RTC_SquareWave` where present) with `MSDK_NO_GPIO_CLK_INIT` guard so that GPIO configuration can be done externally.

Also adds missing square wave pin and functions for MAX32662.
