### PR TITLE
feat(PeriphDrivers): Allow skipping RTC clock config for all parts

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32570/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/rtc.h
@@ -104,6 +104,8 @@ int MXC_RTC_Stop(void);
 
 /**
  * @brief     Initialize the sec and ssec registers and enable RTC (Blocking function)
+ * @note      If you wish to manage clock configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     sec    set the RTC Sec counter (32-bit)
  * @param     ssec   set the RTC Sub-second counter (12-bit)
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes

--- a/Libraries/PeriphDrivers/Include/MAX32572/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/rtc.h
@@ -107,6 +107,8 @@ int MXC_RTC_Stop(void);
 
 /**
  * @brief     Initialize the sec and ssec registers and enable RTC (Blocking function)
+ * @note      If you wish to manage clock configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     sec    set the RTC Sec counter (32-bit)
  * @param     ssec   set the RTC Sub-second counter (12-bit)
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes

--- a/Libraries/PeriphDrivers/Include/MAX32650/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/rtc.h
@@ -103,6 +103,8 @@ int MXC_RTC_Stop(void);
 
 /**
  * @brief     Initialize the sec and ssec registers and enable RTC (Blocking function)
+ * @note      If you wish to manage clock configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     sec set the RTC Sec counter (32-bit)
  * @param     ssec set the RTC Sub-second counter (8-bit)
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes

--- a/Libraries/PeriphDrivers/Include/MAX32655/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/rtc.h
@@ -105,6 +105,8 @@ int MXC_RTC_Stop(void);
 
 /**
  * @brief     Initialize the sec and ssec registers and enable RTC (Blocking function)
+ * @note      If you wish to manage clock configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     sec    set the RTC Sec counter (32-bit)
  * @param     ssec   set the RTC Sub-second counter (12-bit)
  * @retval    returns Success or Fail, see \ref MXC_ERROR_CODES

--- a/Libraries/PeriphDrivers/Include/MAX32660/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/rtc.h
@@ -103,6 +103,8 @@ int MXC_RTC_Stop(void);
 
 /**
  * @brief     Initialize the sec and ssec registers and enable RTC (Blocking function)
+ * @note      If you wish to manage clock configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     sec    set the RTC Sec counter (32-bit)
  * @param     ssec   set the RTC Sub-second counter (8-bit)
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes

--- a/Libraries/PeriphDrivers/Include/MAX32662/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/rtc.h
@@ -105,6 +105,8 @@ int MXC_RTC_Stop(void);
 
 /**
  * @brief     Initialize the sec and ssec registers and enable RTC
+ * @note      If you wish to manage clock configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     sec    set the RTC Sec counter (32-bit)
  * @param     ssec   set the RTC Sub-second counter (12-bit)
  * @retval    returns Success or Fail, see \ref MXC_ERROR_CODES

--- a/Libraries/PeriphDrivers/Include/MAX32665/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/rtc.h
@@ -104,6 +104,8 @@ int MXC_RTC_Stop(void);
 
 /**
  * @brief     Initialize the sec and ssec registers and enable RTC (Blocking function)
+ * @note      If you wish to manage clock configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     sec    set the RTC Sec counter (32-bit)
  * @param     ssec   set the RTC Sub-second counter (12-bit)
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes

--- a/Libraries/PeriphDrivers/Include/MAX32670/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/rtc.h
@@ -105,6 +105,8 @@ int MXC_RTC_Stop(void);
 
 /**
  * @brief     Initialize the sec and ssec registers and enable RTC (Blocking function)
+ * @note      If you wish to manage clock configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     sec    set the RTC Sec counter (32-bit)
  * @param     ssec   set the RTC Sub-second counter (12-bit)
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes

--- a/Libraries/PeriphDrivers/Include/MAX32672/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/rtc.h
@@ -105,6 +105,8 @@ int MXC_RTC_Stop(void);
 
 /**
  * @brief     Initialize the sec and ssec registers and enable RTC (Blocking function)
+ * @note      If you wish to manage clock configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     sec    set the RTC Sec counter (32-bit)
  * @param     ssec   set the RTC Sub-second counter (12-bit)
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes

--- a/Libraries/PeriphDrivers/Include/MAX32680/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/rtc.h
@@ -105,6 +105,8 @@ int MXC_RTC_Stop(void);
 
 /**
  * @brief     Initialize the sec and ssec registers and enable RTC (Blocking function)
+ * @note      If you wish to manage clock configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     sec    set the RTC Sec counter (32-bit)
  * @param     ssec   set the RTC Sub-second counter (12-bit)
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes

--- a/Libraries/PeriphDrivers/Include/MAX32690/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/rtc.h
@@ -106,6 +106,8 @@ int MXC_RTC_Stop(void);
 
 /**
  * @brief     Initialize the sec and ssec registers and enable RTC (Blocking function)
+ * @note      If you wish to manage clock configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     sec    set the RTC Sec counter (32-bit)
  * @param     ssec   set the RTC Sub-second counter (12-bit)
  * @retval    returns Success or Fail, see \ref MXC_Error_Codes

--- a/Libraries/PeriphDrivers/Include/MAX78000/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/rtc.h
@@ -105,6 +105,8 @@ int MXC_RTC_Stop(void);
 
 /**
  * @brief     Initialize the sec and ssec registers and enable RTC (Blocking function)
+ * @note      If you wish to manage clock configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     sec    set the RTC Sec counter (32-bit)
  * @param     ssec   set the RTC Sub-second counter (12-bit)
  * @retval    returns Success or Fail, see \ref MXC_ERROR_CODES

--- a/Libraries/PeriphDrivers/Include/MAX78002/rtc.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/rtc.h
@@ -105,6 +105,8 @@ int MXC_RTC_Stop(void);
 
 /**
  * @brief     Initialize the sec and ssec registers and enable RTC (Blocking function)
+ * @note      If you wish to manage clock configuration externally, define the flag
+ *            MSDK_NO_GPIO_CLK_INIT.
  * @param     sec    set the RTC Sec counter (32-bit)
  * @param     ssec   set the RTC Sub-second counter (12-bit)
  * @retval    returns Success or Fail, see \ref MXC_ERROR_CODES

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_ai87.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_ai87.c
@@ -64,7 +64,9 @@ int MXC_RTC_Stop(void)
 
 int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GCR->clkctrl |= MXC_F_GCR_CLKCTRL_ERTCO_EN;
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_Init((mxc_rtc_reva_regs_t *)MXC_RTC, sec, (ssec & MXC_F_RTC_SSEC_SSEC));
 }

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me10.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me10.c
@@ -52,8 +52,10 @@ int MXC_RTC_Stop(void)
 // *****************************************************************************
 int MXC_RTC_Init(uint32_t sec, uint8_t ssec)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_RTCClockEnable();
     MXC_SYS_Reset_Periph(MXC_SYS_RESET_RTC);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_Init((mxc_rtc_reva_regs_t *)MXC_RTC, sec, (ssec & MXC_F_RTC_SSEC_SSEC));
 }

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me11.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me11.c
@@ -62,8 +62,10 @@ int MXC_RTC_Stop(void)
 
 int MXC_RTC_Init(uint32_t sec, uint8_t ssec)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     // Enable clock
     MXC_GCR->clk_ctrl |= MXC_F_GCR_CLK_CTRL_X32K_EN;
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_Init((mxc_rtc_reva_regs_t *)MXC_RTC, sec, (ssec & MXC_F_RTC_SSEC_RTSS));
 }

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me12.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me12.c
@@ -64,8 +64,10 @@ int MXC_RTC_Stop(void)
 
 int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_MCR->clkctrl &= ~MXC_F_MCR_CLKCTRL_ERTCO_PD;
     MXC_MCR->clkctrl |= MXC_F_MCR_CLKCTRL_ERTCO_EN;
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_Init((mxc_rtc_reva_regs_t *)MXC_RTC, sec, (ssec & MXC_F_RTC_SSEC_SSEC));
 }

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me13.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me13.c
@@ -62,8 +62,10 @@ int MXC_RTC_Stop(void)
 
 int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     // Enable clock
     MXC_GCR->clkctrl |= MXC_F_GCR_CLKCTRL_ERTCO_EN;
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_Init((mxc_rtc_reva_regs_t *)MXC_RTC, sec, (ssec & MXC_F_RTC_SSEC_SSEC));
 }

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me14.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me14.c
@@ -63,8 +63,10 @@ int MXC_RTC_Stop(void)
 
 int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     // Enable clock
     MXC_GCR->clkcn |= MXC_F_GCR_CLKCN_X32K_EN;
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_Init((mxc_rtc_reva_regs_t *)MXC_RTC, sec, (ssec & MXC_F_RTC_SSEC_SSEC));
 }

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me15.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me15.c
@@ -63,8 +63,10 @@ int MXC_RTC_Stop(void)
 
 int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     // Enable clock
     MXC_SYS_RTCClockEnable();
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_Init((mxc_rtc_reva_regs_t *)MXC_RTC, sec, (ssec & MXC_F_RTC_SSEC_SSEC));
 }

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me16.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me16.c
@@ -62,8 +62,10 @@ int MXC_RTC_Stop(void)
 
 int MXC_RTC_Init(uint32_t sec, uint8_t ssec)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     // Enable clock
     MXC_GCR->clkctrl |= MXC_F_GCR_CLKCTRL_ERTCO_EN;
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_Init(MXC_RTC, sec, ssec);
 }

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me17.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me17.c
@@ -79,7 +79,9 @@ int MXC_RTC_Stop(void)
 
 int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GCR->clkctrl |= MXC_F_GCR_CLKCTRL_ERTCO_EN;
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_Init((mxc_rtc_reva_regs_t *)MXC_RTC, sec, (ssec & MXC_F_RTC_SSEC_SSEC));
 }

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me18.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me18.c
@@ -64,7 +64,9 @@ int MXC_RTC_Stop(void)
 
 int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GCR->clkctrl |= MXC_F_GCR_CLKCTRL_ERTCO_EN;
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_Init((mxc_rtc_reva_regs_t *)MXC_RTC, sec, (ssec & MXC_F_RTC_SSEC_SSEC));
 }

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me21.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me21.c
@@ -62,8 +62,10 @@ int MXC_RTC_Stop(void)
 
 int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     // Enable clock
     MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_Init((mxc_rtc_reva_regs_t *)MXC_RTC, sec, (ssec & MXC_F_RTC_SSEC_SSEC));
 }

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me55.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me55.c
@@ -63,8 +63,10 @@ int MXC_RTC_Stop(void)
 
 int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_MCR->ctrl |= MXC_F_MCR_CLKCTRL_ERTCO_EN;
     MXC_MCR->clkctrl &= ~(MXC_F_MCR_CLKCTRL_ERTCO_PD);
+#endif /* MSDK_NO_GPIO_CLK_INIT */
 
     return MXC_RTC_RevA_Init((mxc_rtc_reva_regs_t *)MXC_RTC, sec, (ssec & MXC_F_RTC_SSEC_SSEC));
 }

--- a/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
+++ b/Libraries/zephyr/MAX/Include/wrap_max32_sys.h
@@ -120,6 +120,9 @@ static inline mxc_sys_32k_clock_t wrap_get_32k_clock_source_instance(uint8_t clo
     mxc_sys_32k_clock_t clk_src;
 
     switch (clock_source) {
+    case 1: // ADI_MAX32_PRPH_CLK_SRC_EXTCLK
+        clk_src = MXC_SYS_32K_CLOCK_RTC_IN;
+        break;
     case 4: // ADI_MAX32_PRPH_CLK_SRC_ERTCO
         clk_src = MXC_SYS_32K_CLOCK_ERTCO;
         break;


### PR DESCRIPTION
### Description

Continuation of https://github.com/analogdevicesinc/msdk/pull/1601

Wrap clock configuration code in `MXC_RTC_Init` with `MSDK_NO_GPIO_CLK_INIT` guard so that clock configuration can be done externally.

In Zephyr side, clock source selection for RTC will be done outside the RTC driver, so remove the obsolete wrapper code. Also add external clock source option to `wrap_get_32k_clock_source_instance`.

With https://github.com/zephyrproject-rtos/zephyr/pull/116541, we can support `RTC_CLK_IN` as 32kHz clock source.