### PR TITLE
feat(PeriphDrivers): Allow GPIO pins to be disabled

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32520/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32520/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,6 +227,15 @@ int MXC_GPIO_Reset(uint32_t portMask);
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */
 int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg);
+
+/**
+ * @brief      Fully disable pin(s), clearing the input buffer, output driver,
+ *             and pull configuration set by MXC_GPIO_Config().
+ * @param      port  Pointer to GPIO port.
+ * @param      mask  Mask of the pin to disable
+ * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
+ */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask);
 
 /**
  * @brief      Gets the pin(s) input state.

--- a/Libraries/PeriphDrivers/Include/MAX32570/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,6 +227,15 @@ int MXC_GPIO_Reset(uint32_t portMask);
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */
 int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg);
+
+/**
+ * @brief      Fully disable pin(s), clearing the input buffer, output driver,
+ *             and pull configuration set by MXC_GPIO_Config().
+ * @param      port  Pointer to GPIO port.
+ * @param      mask  Mask of the pin to disable
+ * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
+ */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask);
 
 /**
  * @brief      Gets the pin(s) input state.

--- a/Libraries/PeriphDrivers/Include/MAX32572/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -228,6 +228,15 @@ int MXC_GPIO_Reset(uint32_t portMask);
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */
 int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg);
+
+/**
+ * @brief      Fully disable pin(s), clearing the input buffer, output driver,
+ *             and pull configuration set by MXC_GPIO_Config().
+ * @param      port  Pointer to GPIO port.
+ * @param      mask  Mask of the pin to disable
+ * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
+ */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask);
 
 /**
  * @brief      Gets the pin(s) input state.

--- a/Libraries/PeriphDrivers/Include/MAX32650/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2025 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -216,6 +216,15 @@ int MXC_GPIO_Reset(uint32_t port);
  * @return     #E_NO_ERROR if everything is successful.
  */
 int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg);
+
+/**
+ * @brief      Fully disable pin(s), clearing the input buffer, output driver,
+ *             and pull configuration set by MXC_GPIO_Config().
+ * @param      port  Pointer to GPIO port.
+ * @param      mask  Mask of the pin to disable
+ * @return     #E_NO_ERROR if everything is successful.
+ */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask);
 
 /**
  * @brief      Gets the pin(s) input state.

--- a/Libraries/PeriphDrivers/Include/MAX32655/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,6 +227,15 @@ int MXC_GPIO_Reset(uint32_t portMask);
  * @return     #E_NO_ERROR if everything is successful.
  */
 int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg);
+
+/**
+ * @brief      Fully disable pin(s), clearing the input buffer, output driver,
+ *             and pull configuration set by MXC_GPIO_Config().
+ * @param      port  Pointer to the GPIO port registers
+ * @param      mask  Mask of the pin(s) to disable
+ * @return     #E_NO_ERROR if everything is successful.
+ */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask);
 
 /**
  * @brief      Gets the pin(s) input state.

--- a/Libraries/PeriphDrivers/Include/MAX32657/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/gpio.h
@@ -5,7 +5,7 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2024-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -225,6 +225,15 @@ int MXC_GPIO_Reset(uint32_t portMask);
  * @return     #E_NO_ERROR if everything is successful.
  */
 int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg);
+
+/**
+ * @brief      Fully disable pin(s), clearing the input buffer, output driver,
+ *             and pull configuration set by MXC_GPIO_Config().
+ * @param      port  Pointer to the GPIO port registers
+ * @param      mask  Mask of the pin(s) to disable
+ * @return     #E_NO_ERROR if everything is successful.
+ */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask);
 
 /**
  * @brief      Gets the pin(s) input state.

--- a/Libraries/PeriphDrivers/Include/MAX32660/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,6 +206,15 @@ int MXC_GPIO_Reset(uint32_t portMask);
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */
 int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg);
+
+/**
+ * @brief      Fully disable pin(s), clearing the input buffer, output driver,
+ *             and pull configuration set by MXC_GPIO_Config().
+ * @param      port  Pointer to the GPIO port registers
+ * @param      mask  Mask of the pin(s) to disable
+ * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
+ */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask);
 
 /**
  * @brief      Gets the pin(s) input state.

--- a/Libraries/PeriphDrivers/Include/MAX32662/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -226,6 +226,15 @@ int MXC_GPIO_Reset(uint32_t portMask);
  * @return     #E_NO_ERROR if everything is successful.
  */
 int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg);
+
+/**
+ * @brief      Fully disable pin(s), clearing the input buffer, output driver,
+ *             and pull configuration set by MXC_GPIO_Config().
+ * @param      port  Pointer to the GPIO port registers
+ * @param      mask  Mask of the pin(s) to disable
+ * @return     #E_NO_ERROR if everything is successful.
+ */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask);
 
 /**
  * @brief      Gets the pin(s) input state.

--- a/Libraries/PeriphDrivers/Include/MAX32665/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -226,6 +226,15 @@ int MXC_GPIO_Reset(uint32_t portMask);
  * @return     #E_NO_ERROR if everything is successful.
  */
 int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg);
+
+/**
+ * @brief      Fully disable pin(s), clearing the input buffer, output driver,
+ *             and pull configuration set by MXC_GPIO_Config().
+ * @param      port  Pointer to GPIO port.
+ * @param      mask  Mask of the pin to disable
+ * @return     #E_NO_ERROR if everything is successful.
+ */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask);
 
 /**
  * @brief      Gets the pin(s) input state.

--- a/Libraries/PeriphDrivers/Include/MAX32670/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,6 +227,15 @@ int MXC_GPIO_Reset(uint32_t portMask);
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */
 int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg);
+
+/**
+ * @brief      Fully disable pin(s), clearing the input buffer, output driver,
+ *             and pull configuration set by MXC_GPIO_Config().
+ * @param      port  Pointer to GPIO port.
+ * @param      mask  Mask of the pin to disable
+ * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
+ */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask);
 
 /**
  * @brief      Gets the pin(s) input state.

--- a/Libraries/PeriphDrivers/Include/MAX32672/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,6 +227,15 @@ int MXC_GPIO_Reset(uint32_t portMask);
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */
 int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg);
+
+/**
+ * @brief      Fully disable pin(s), clearing the input buffer, output driver,
+ *             and pull configuration set by MXC_GPIO_Config().
+ * @param      port  Pointer to GPIO port.
+ * @param      mask  Mask of the pin to disable
+ * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
+ */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask);
 
 /**
  * @brief      Gets the pin(s) input state.

--- a/Libraries/PeriphDrivers/Include/MAX32675/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,6 +227,15 @@ int MXC_GPIO_Reset(uint32_t portMask);
  * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
  */
 int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg);
+
+/**
+ * @brief      Fully disable pin(s), clearing the input buffer, output driver,
+ *             and pull configuration set by MXC_GPIO_Config().
+ * @param      port  Pointer to GPIO port.
+ * @param      mask  Mask of the pin to disable
+ * @return     #E_NO_ERROR if everything is successful. See \ref MXC_Error_Codes for the list of error codes.
+ */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask);
 
 /**
  * @brief      Gets the pin(s) input state.

--- a/Libraries/PeriphDrivers/Include/MAX32680/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,6 +227,15 @@ int MXC_GPIO_Reset(uint32_t portMask);
  * @return     #E_NO_ERROR if everything is successful.
  */
 int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg);
+
+/**
+ * @brief      Fully disable pin(s), clearing the input buffer, output driver,
+ *             and pull configuration set by MXC_GPIO_Config().
+ * @param      port  Pointer to the GPIO port registers
+ * @param      mask  Mask of the pin(s) to disable
+ * @return     #E_NO_ERROR if everything is successful.
+ */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask);
 
 /**
  * @brief      Gets the pin(s) input state.

--- a/Libraries/PeriphDrivers/Include/MAX32690/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -228,6 +228,15 @@ int MXC_GPIO_Reset(uint32_t portMask);
  * @return     #E_NO_ERROR if everything is successful.
  */
 int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg);
+
+/**
+ * @brief      Fully disable pin(s), clearing the input buffer, output driver,
+ *             and pull configuration set by MXC_GPIO_Config().
+ * @param      port  Pointer to the GPIO port registers
+ * @param      mask  Mask of the pin(s) to disable
+ * @return     #E_NO_ERROR if everything is successful.
+ */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask);
 
 /**
  * @brief      Gets the pin(s) input state.

--- a/Libraries/PeriphDrivers/Include/MAX78000/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,6 +227,15 @@ int MXC_GPIO_Reset(uint32_t portMask);
  * @return     #E_NO_ERROR if everything is successful.
  */
 int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg);
+
+/**
+ * @brief      Fully disable pin(s), clearing the input buffer, output driver,
+ *             and pull configuration set by MXC_GPIO_Config().
+ * @param      port  Pointer to the GPIO port
+ * @param      mask  Mask of the pin(s) to disable
+ * @return     #E_NO_ERROR if everything is successful.
+ */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask);
 
 /**
  * @brief      Gets the pin(s) input state.

--- a/Libraries/PeriphDrivers/Include/MAX78002/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/gpio.h
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,6 +227,15 @@ int MXC_GPIO_Reset(uint32_t portMask);
  * @return     #E_NO_ERROR if everything is successful.
  */
 int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg);
+
+/**
+ * @brief      Fully disable pin(s), clearing the input buffer, output driver,
+ *             and pull configuration set by MXC_GPIO_Config().
+ * @param      port  Pointer to the selected GPIO port instance.
+ * @param      mask  Mask of the pin to disable.
+ * @return     #E_NO_ERROR if everything is successful.
+ */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask);
 
 /**
  * @brief      Gets the pin(s) input state.

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_ai85.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_ai85.c
@@ -306,6 +306,19 @@ void MXC_GPIO_OutToggle(mxc_gpio_regs_t *port, uint32_t mask)
 }
 
 /* ************************************************************************** */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask)
+{
+    if (port == MXC_GPIO3) {
+        MXC_MCR->gpio3_ctrl &= ~(P30_OUT_EN(mask) | P31_OUT_EN(mask));
+        MXC_MCR->gpio3_ctrl |= P30_PULL_DIS(mask) | P31_PULL_DIS(mask);
+        MXC_MCR->outen &= ~(SQWAVE_OUT_EN(mask) | PDOWN_OUT_EN(mask));
+        return E_NO_ERROR;
+    }
+
+    return MXC_GPIO_RevA_Disable((mxc_gpio_reva_regs_t *)port, mask);
+}
+
+/* ************************************************************************** */
 int MXC_GPIO_IntConfig(const mxc_gpio_cfg_t *cfg, mxc_gpio_int_pol_t pol)
 {
     if (cfg->port == MXC_GPIO3) {

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_ai87.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_ai87.c
@@ -306,6 +306,19 @@ void MXC_GPIO_OutToggle(mxc_gpio_regs_t *port, uint32_t mask)
 }
 
 /* ************************************************************************** */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask)
+{
+    if (port == MXC_GPIO3) {
+        MXC_MCR->gpio3_ctrl &= ~(P30_OUT_EN(mask) | P31_OUT_EN(mask));
+        MXC_MCR->gpio3_ctrl |= P30_PULL_DIS(mask) | P31_PULL_DIS(mask);
+        MXC_MCR->outen &= ~(SQWAVE_OUT_EN(mask) | PDOWN_OUT_EN(mask));
+        return E_NO_ERROR;
+    }
+
+    return MXC_GPIO_RevA_Disable((mxc_gpio_reva_regs_t *)port, mask);
+}
+
+/* ************************************************************************** */
 int MXC_GPIO_IntConfig(const mxc_gpio_cfg_t *cfg, mxc_gpio_int_pol_t pol)
 {
     if (cfg->port == MXC_GPIO3) {

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_es17.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_es17.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,6 +165,11 @@ void MXC_GPIO_OutPut(mxc_gpio_regs_t *port, uint32_t mask, uint32_t val)
 void MXC_GPIO_OutToggle(mxc_gpio_regs_t *port, uint32_t mask)
 {
     MXC_GPIO_RevA_OutToggle((mxc_gpio_reva_regs_t *)port, mask);
+}
+
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask)
+{
+    return MXC_GPIO_RevA_Disable((mxc_gpio_reva_regs_t *)port, mask);
 }
 
 int MXC_GPIO_IntConfig(const mxc_gpio_cfg_t *cfg, mxc_gpio_int_pol_t pol)

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me10.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me10.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2025 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -191,6 +191,11 @@ void MXC_GPIO_OutPut(mxc_gpio_regs_t *port, uint32_t mask, uint32_t val)
 void MXC_GPIO_OutToggle(mxc_gpio_regs_t *port, uint32_t mask)
 {
     MXC_GPIO_RevA_OutToggle((mxc_gpio_reva_regs_t *)port, mask);
+}
+
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask)
+{
+    return MXC_GPIO_RevA_Disable((mxc_gpio_reva_regs_t *)port, mask);
 }
 
 /* ************************************************************************** */

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me11.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me11.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,6 +167,11 @@ void MXC_GPIO_OutPut(mxc_gpio_regs_t *port, uint32_t mask, uint32_t val)
 void MXC_GPIO_OutToggle(mxc_gpio_regs_t *port, uint32_t mask)
 {
     MXC_GPIO_RevA_OutToggle((mxc_gpio_reva_regs_t *)port, mask);
+}
+
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask)
+{
+    return MXC_GPIO_RevA_Disable((mxc_gpio_reva_regs_t *)port, mask);
 }
 
 int MXC_GPIO_IntConfig(const mxc_gpio_cfg_t *cfg, mxc_gpio_int_pol_t pol)

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me12.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me12.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,6 +149,11 @@ void MXC_GPIO_OutPut(mxc_gpio_regs_t *port, uint32_t mask, uint32_t val)
 void MXC_GPIO_OutToggle(mxc_gpio_regs_t *port, uint32_t mask)
 {
     MXC_GPIO_RevA_OutToggle((mxc_gpio_reva_regs_t *)port, mask);
+}
+
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask)
+{
+    return MXC_GPIO_RevA_Disable((mxc_gpio_reva_regs_t *)port, mask);
 }
 
 /* ************************************************************************** */

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me13.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me13.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -189,6 +189,11 @@ void MXC_GPIO_OutPut(mxc_gpio_regs_t *port, uint32_t mask, uint32_t val)
 void MXC_GPIO_OutToggle(mxc_gpio_regs_t *port, uint32_t mask)
 {
     MXC_GPIO_RevA_OutToggle((mxc_gpio_reva_regs_t *)port, mask);
+}
+
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask)
+{
+    return MXC_GPIO_RevA_Disable((mxc_gpio_reva_regs_t *)port, mask);
 }
 
 int MXC_GPIO_IntConfig(const mxc_gpio_cfg_t *cfg, mxc_gpio_int_pol_t pol)

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me14.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me14.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -175,6 +175,11 @@ void MXC_GPIO_OutPut(mxc_gpio_regs_t *port, uint32_t mask, uint32_t val)
 void MXC_GPIO_OutToggle(mxc_gpio_regs_t *port, uint32_t mask)
 {
     MXC_GPIO_RevA_OutToggle((mxc_gpio_reva_regs_t *)port, mask);
+}
+
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask)
+{
+    return MXC_GPIO_RevA_Disable((mxc_gpio_reva_regs_t *)port, mask);
 }
 
 /* ************************************************************************** */

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me15.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me15.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,6 +141,11 @@ void MXC_GPIO_OutPut(mxc_gpio_regs_t *port, uint32_t mask, uint32_t val)
 void MXC_GPIO_OutToggle(mxc_gpio_regs_t *port, uint32_t mask)
 {
     MXC_GPIO_RevA_OutToggle((mxc_gpio_reva_regs_t *)port, mask);
+}
+
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask)
+{
+    return MXC_GPIO_RevA_Disable((mxc_gpio_reva_regs_t *)port, mask);
 }
 
 int MXC_GPIO_IntConfig(const mxc_gpio_cfg_t *cfg, mxc_gpio_int_pol_t pol)

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me16.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me16.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,6 +142,11 @@ void MXC_GPIO_OutPut(mxc_gpio_regs_t *port, uint32_t mask, uint32_t val)
 void MXC_GPIO_OutToggle(mxc_gpio_regs_t *port, uint32_t mask)
 {
     MXC_GPIO_RevA_OutToggle((mxc_gpio_reva_regs_t *)port, mask);
+}
+
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask)
+{
+    return MXC_GPIO_RevA_Disable((mxc_gpio_reva_regs_t *)port, mask);
 }
 
 int MXC_GPIO_IntConfig(const mxc_gpio_cfg_t *cfg, mxc_gpio_int_pol_t pol)

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me17.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me17.c
@@ -306,6 +306,19 @@ void MXC_GPIO_OutToggle(mxc_gpio_regs_t *port, uint32_t mask)
 }
 
 /* ************************************************************************** */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask)
+{
+    if (port == MXC_GPIO3) {
+        MXC_MCR->gpio3_ctrl &= ~(P30_OUT_EN(mask) | P31_OUT_EN(mask));
+        MXC_MCR->gpio3_ctrl |= P30_PULL_DIS(mask) | P31_PULL_DIS(mask);
+        MXC_MCR->outen &= ~(SQWAVE_OUT_EN(mask) | PDOWN_OUT_EN(mask));
+        return E_NO_ERROR;
+    }
+
+    return MXC_GPIO_RevA_Disable((mxc_gpio_reva_regs_t *)port, mask);
+}
+
+/* ************************************************************************** */
 int MXC_GPIO_IntConfig(const mxc_gpio_cfg_t *cfg, mxc_gpio_int_pol_t pol)
 {
     if (cfg->port == MXC_GPIO3) {

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2025 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -335,6 +335,19 @@ void MXC_GPIO_OutToggle(mxc_gpio_regs_t *port, uint32_t mask)
     }
 
     MXC_GPIO_RevA_OutToggle((mxc_gpio_reva_regs_t *)port, mask);
+}
+
+/* ************************************************************************** */
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask)
+{
+    if (port == MXC_GPIO4) {
+        MXC_MCR->gpio4_ctrl &= ~GPIO4_OUTEN_MASK(mask);
+        MXC_MCR->gpio4_ctrl |= GPIO4_PULLDIS_MASK(mask);
+        MXC_MCR->outen &= ~GPIO4_AFEN_MASK(mask);
+        return E_NO_ERROR;
+    }
+
+    return MXC_GPIO_RevA_Disable((mxc_gpio_reva_regs_t *)port, mask);
 }
 
 /* ************************************************************************** */

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me21.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me21.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,6 +143,11 @@ void MXC_GPIO_OutPut(mxc_gpio_regs_t *port, uint32_t mask, uint32_t val)
 void MXC_GPIO_OutToggle(mxc_gpio_regs_t *port, uint32_t mask)
 {
     MXC_GPIO_RevA_OutToggle((mxc_gpio_reva_regs_t *)port, mask);
+}
+
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask)
+{
+    return MXC_GPIO_RevA_Disable((mxc_gpio_reva_regs_t *)port, mask);
 }
 
 int MXC_GPIO_IntConfig(const mxc_gpio_cfg_t *cfg, mxc_gpio_int_pol_t pol)

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me30.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me30.c
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2024 Analog Devices, Inc.
+ * Copyright (C) 2024-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,6 +155,11 @@ void MXC_GPIO_OutPut(mxc_gpio_regs_t *port, uint32_t mask, uint32_t val)
 void MXC_GPIO_OutToggle(mxc_gpio_regs_t *port, uint32_t mask)
 {
     MXC_GPIO_RevA_OutToggle((mxc_gpio_reva_regs_t *)port, mask);
+}
+
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask)
+{
+    return MXC_GPIO_RevA_Disable((mxc_gpio_reva_regs_t *)port, mask);
 }
 
 /* ************************************************************************** */

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me55.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me55.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,6 +167,11 @@ void MXC_GPIO_OutPut(mxc_gpio_regs_t *port, uint32_t mask, uint32_t val)
 void MXC_GPIO_OutToggle(mxc_gpio_regs_t *port, uint32_t mask)
 {
     MXC_GPIO_RevA_OutToggle((mxc_gpio_reva_regs_t *)port, mask);
+}
+
+int MXC_GPIO_Disable(mxc_gpio_regs_t *port, uint32_t mask)
+{
+    return MXC_GPIO_RevA_Disable((mxc_gpio_reva_regs_t *)port, mask);
 }
 
 int MXC_GPIO_IntConfig(const mxc_gpio_cfg_t *cfg, mxc_gpio_int_pol_t pol)

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_reva.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_reva.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -214,6 +214,24 @@ int MXC_GPIO_RevA_SetAF(mxc_gpio_reva_regs_t *port, mxc_gpio_func_t func, uint32
     default:
         return E_BAD_PARAM;
     }
+
+    return E_NO_ERROR;
+}
+
+int MXC_GPIO_RevA_Disable(mxc_gpio_reva_regs_t *port, uint32_t mask)
+{
+    if (MXC_GPIO_GetConfigLock() == MXC_GPIO_CONFIG_LOCKED) {
+        // Configuration is locked.  Ignore any attempts to change it.
+        return E_NO_ERROR;
+    }
+
+    // Disable the input and output.
+    port->inen &= ~mask;
+    port->outen_clr = mask;
+
+    // Remove any pull resistor so the pin is left floating.
+    port->padctrl0 &= ~mask;
+    port->padctrl1 &= ~mask;
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_reva.h
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_reva.h
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ void MXC_GPIO_RevA_ClearFlags(mxc_gpio_reva_regs_t *port, uint32_t flags);
 uint32_t MXC_GPIO_RevA_GetFlags(mxc_gpio_reva_regs_t *port);
 int MXC_GPIO_RevA_SetVSSEL(mxc_gpio_reva_regs_t *port, mxc_gpio_vssel_t vssel, uint32_t mask);
 int MXC_GPIO_RevA_SetAF(mxc_gpio_reva_regs_t *port, mxc_gpio_func_t func, uint32_t mask);
+int MXC_GPIO_RevA_Disable(mxc_gpio_reva_regs_t *port, uint32_t mask);
 void MXC_GPIO_RevA_SetWakeEn(mxc_gpio_reva_regs_t *port, uint32_t mask);
 void MXC_GPIO_RevA_ClearWakeEn(mxc_gpio_reva_regs_t *port, uint32_t mask);
 uint32_t MXC_GPIO_RevA_GetWakeEn(mxc_gpio_reva_regs_t *port);


### PR DESCRIPTION
### Description

This PR adds the ability to disable GPIO pins by providing a MXC_GPIO_Disable function.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.