### PR TITLE
fix(CMSIS,PeriphDrivers): MSDK-1343: Add missing BTLE clock enable support for MAX32655, MAX32657, and MAX32680

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/gcr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/gcr_regs.h
@@ -7,7 +7,7 @@
 
 /******************************************************************************
  *
- * Copyright (C) 2024-2025 Analog Devices, Inc.
+ * Copyright (C) 2024-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -446,6 +446,9 @@ typedef struct {
  * @brief    Peripheral Clock Disable.
  * @{
  */
+#define MXC_F_GCR_PCLKDIS1_BTLE_POS                    0 /**< PCLKDIS1_BTLE Position */
+#define MXC_F_GCR_PCLKDIS1_BTLE                        ((uint32_t)(0x1UL << MXC_F_GCR_PCLKDIS1_BTLE_POS)) /**< PCLKDIS1_BTLE Mask */
+
 #define MXC_F_GCR_PCLKDIS1_TRNG_POS                    2 /**< PCLKDIS1_TRNG Position */
 #define MXC_F_GCR_PCLKDIS1_TRNG                        ((uint32_t)(0x1UL << MXC_F_GCR_PCLKDIS1_TRNG_POS)) /**< PCLKDIS1_TRNG Mask */
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.svd
@@ -2585,9 +2585,9 @@
      <addressOffset>0x48</addressOffset>
      <fields>
       <field>
-       <name>TRNG</name>
-       <description>TRNG Clock Disable.</description>
-       <bitOffset>2</bitOffset>
+       <name>BTLE</name>
+       <description>BTLE Clock Disable.</description>
+       <bitOffset>0</bitOffset>
        <bitWidth>1</bitWidth>
        <enumeratedValues>
         <enumeratedValue>
@@ -2602,25 +2602,31 @@
         </enumeratedValue>
        </enumeratedValues>
       </field>
-      <field derivedFrom="TRNG">
+      <field derivedFrom="BTLE">
+       <name>TRNG</name>
+       <description>TRNG Clock Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BTLE">
        <name>CRC</name>
        <description>CRC Disable.</description>
        <bitOffset>14</bitOffset>
        <bitWidth>1</bitWidth>
       </field>
-      <field derivedFrom="TRNG">
+      <field derivedFrom="BTLE">
        <name>AES</name>
        <description>AES Clock Disable</description>
        <bitOffset>15</bitOffset>
        <bitWidth>1</bitWidth>
       </field>
-      <field derivedFrom="TRNG">
+      <field derivedFrom="BTLE">
        <name>DMA1</name>
        <description>DMA1 Clock Disable</description>
        <bitOffset>21</bitOffset>
        <bitWidth>1</bitWidth>
       </field>
-      <field derivedFrom="TRNG">
+      <field derivedFrom="BTLE">
        <name>WDT</name>
        <description>WDT Clock Disable</description>
        <bitOffset>27</bitOffset>

--- a/Libraries/PeriphDrivers/Include/MAX32655/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/mxc_sys.h
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,6 +119,8 @@ typedef enum {
         MXC_F_GCR_PCLKDIS0_I2C1_POS, /**< Disable MXC_F_GCR_PCLKDIS0_I2C1 clock */
     MXC_SYS_PERIPH_CLOCK_PT = MXC_F_GCR_PCLKDIS0_PT_POS, /**< Disable MXC_F_GCR_PCLKDIS0_PT clock */
     /* PCLKDIS1 Below this line we add 32 to separate PCLKDIS0 and PCLKDIS1 */
+    MXC_SYS_PERIPH_CLOCK_BTLE =
+        (MXC_F_GCR_PCLKDIS1_BTLE_POS + 32), /**< Disable MXC_F_GCR_PCLKDIS1_BTLE clock */
     MXC_SYS_PERIPH_CLOCK_UART2 =
         (MXC_F_GCR_PCLKDIS1_UART2_POS + 32), /**< Disable MXC_F_GCR_PCLKDIS1_UART2 clock */
     MXC_SYS_PERIPH_CLOCK_TRNG =

--- a/Libraries/PeriphDrivers/Include/MAX32657/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32657/mxc_sys.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2024-2025 Analog Devices, Inc.
+ * Copyright (C) 2024-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,6 +80,7 @@ typedef enum {
     MXC_SYS_PERIPH_CLOCK_TMR4 = MXC_F_GCR_PCLKDIS0_TMR4_POS, /**< Disable TMR4 clock */
     MXC_SYS_PERIPH_CLOCK_TMR5 = MXC_F_GCR_PCLKDIS0_TMR5_POS, /**< Disable TMR4 clock */
     /* PCLKDIS1 Below this line we add 32 to separate PCLKDIS0 and PCLKDIS1 */
+    MXC_SYS_PERIPH_CLOCK_BTLE = (MXC_F_GCR_PCLKDIS1_BTLE_POS + 32), /**< Disable BTLE clock */
     MXC_SYS_PERIPH_CLOCK_TRNG = (MXC_F_GCR_PCLKDIS1_TRNG_POS + 32), /**< Disable TRNG clock */
     MXC_SYS_PERIPH_CLOCK_CRC = (MXC_F_GCR_PCLKDIS1_CRC_POS + 32), /**< Disable CRC clock */
     MXC_SYS_PERIPH_CLOCK_AES = (MXC_F_GCR_PCLKDIS1_AES_POS + 32), /**< Disable AES clock */

--- a/Libraries/PeriphDrivers/Include/MAX32680/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/mxc_sys.h
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022-2023 Maxim Integrated Products, Inc. (now owned by 
  * Analog Devices, Inc.),
- * Copyright (C) 2023-2024 Analog Devices, Inc.
+ * Copyright (C) 2023-2026 Analog Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,6 +119,8 @@ typedef enum {
         MXC_F_GCR_PCLKDIS0_I2C1_POS, /**< Disable MXC_F_GCR_PCLKDIS0_I2C1 clock */
     MXC_SYS_PERIPH_CLOCK_PT = MXC_F_GCR_PCLKDIS0_PT_POS, /**< Disable MXC_F_GCR_PCLKDIS0_PT clock */
     /* PCLKDIS1 Below this line we add 32 to separate PCLKDIS0 and PCLKDIS1 */
+    MXC_SYS_PERIPH_CLOCK_BTLE =
+        (MXC_F_GCR_PCLKDIS1_BTLE_POS + 32), /**< Disable MXC_F_GCR_PCLKDIS1_BTLE clock */
     MXC_SYS_PERIPH_CLOCK_UART2 =
         (MXC_F_GCR_PCLKDIS1_UART2_POS + 32), /**< Disable MXC_F_GCR_PCLKDIS1_UART2 clock */
     MXC_SYS_PERIPH_CLOCK_TRNG =

--- a/Libraries/PeriphDrivers/Source/SYS/SVD/gcr_me30.svd
+++ b/Libraries/PeriphDrivers/Source/SYS/SVD/gcr_me30.svd
@@ -685,9 +685,9 @@
         <addressOffset>0x48</addressOffset>
         <fields>
           <field>
-            <name>TRNG</name>
-            <description>TRNG Clock Disable.</description>
-            <bitOffset>2</bitOffset>
+            <name>BTLE</name>
+            <description>BTLE Clock Disable.</description>
+            <bitOffset>0</bitOffset>
             <bitWidth>1</bitWidth>
             <enumeratedValues>
               <enumeratedValue>
@@ -702,25 +702,31 @@
               </enumeratedValue>
             </enumeratedValues>
           </field>
-          <field derivedFrom="TRNG">
+          <field derivedFrom="BTLE">
+            <name>TRNG</name>
+            <description>TRNG Clock Disable.</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+          </field>
+          <field derivedFrom="BTLE">
             <name>CRC</name>
             <description>CRC Disable.</description>
             <bitOffset>14</bitOffset>
             <bitWidth>1</bitWidth>
           </field>
-          <field derivedFrom="TRNG">
+          <field derivedFrom="BTLE">
             <name>AES</name>
             <description>AES Clock Disable</description>
             <bitOffset>15</bitOffset>
             <bitWidth>1</bitWidth>
           </field>
-          <field derivedFrom="TRNG">
+          <field derivedFrom="BTLE">
             <name>DMA1</name>
             <description>DMA1 Clock Disable</description>
             <bitOffset>21</bitOffset>
             <bitWidth>1</bitWidth>
           </field>
-          <field derivedFrom="TRNG">
+          <field derivedFrom="BTLE">
             <name>WDT</name>
             <description>WDT Clock Disable</description>
             <bitOffset>27</bitOffset>


### PR DESCRIPTION
### Description

Add the missing `MXC_SYS_PERIPH_CLOCK_BTLE` enumeration value to `mxc_sys_periph_clock_t` for MAX32655, MAX32657, and MAX32680, allowing callers to use `MXC_SYS_ClockEnable`/`MXC_SYS_ClockDisable` to control the Bluetooth clock on these parts.

The `MXC_F_GCR_PCLKDIS1_BTLE_POS` (bit 0 of `PCLKDIS1`) hardware register bit was already present in the `gcr_regs.h` for MAX32655 and MAX32680, but was missing entirely for MAX32657. The corresponding `MXC_SYS_PERIPH_CLOCK_BTLE` enum value was absent from all three parts' `mxc_sys.h` files. The BTLE bitfield at bit 0 of `PCLKDIS1` was also missing from `max32657.svd` and `gcr_me30.svd`.

This fix is consistent with the existing implementation for MAX32665 and MAX32690, and is documented in the MAX32655, MAX32665/MAX32666, and MAX32680 user guides (GCR_PERCKCN1/GCR_PCLKDIS1 bit 0).

**Files changed:**
- `Libraries/CMSIS/Device/Maxim/MAX32657/Include/gcr_regs.h` – add `MXC_F_GCR_PCLKDIS1_BTLE_POS` and mask
- `Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.svd` – add BTLE field at bit 0 of PCLKDIS1
- `Libraries/PeriphDrivers/Include/MAX32655/mxc_sys.h` – add `MXC_SYS_PERIPH_CLOCK_BTLE`
- `Libraries/PeriphDrivers/Include/MAX32657/mxc_sys.h` – add `MXC_SYS_PERIPH_CLOCK_BTLE`
- `Libraries/PeriphDrivers/Include/MAX32680/mxc_sys.h` – add `MXC_SYS_PERIPH_CLOCK_BTLE`
- `Libraries/PeriphDrivers/Source/SYS/SVD/gcr_me30.svd` – add BTLE field at bit 0 of PCLKDIS1

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] Link to Jira ticket: https://jira.analog.com/browse/MSDK-1343